### PR TITLE
Genericize JavaScript for optional sections

### DIFF
--- a/app/assets/javascripts/multiples.js
+++ b/app/assets/javascripts/multiples.js
@@ -1,0 +1,26 @@
+'use strict';
+
+$(function () {
+
+  /**
+   * Hides selected elements when an element with id ending in one or
+   * more digits followed by '_delete' triggers a 'change' event
+   */
+
+  $.fn.multiples = function () {
+
+    return this.each(function () {
+      var $this = $(this);
+
+      $this.on('change', function (e) {
+        var changed_element_id = $(e.target).attr('id');
+        if (/move_information_destinations_attributes_\d+__delete/.test(changed_element_id)) {
+          $this.hide();
+        }
+      })
+    })
+  };
+
+  $('.optional-section').multiples();
+
+});

--- a/app/assets/javascripts/multiples.js
+++ b/app/assets/javascripts/multiples.js
@@ -14,7 +14,7 @@ $(function () {
 
       $this.on('change', function (e) {
         var changed_element_id = $(e.target).attr('id');
-        if (/move_information_destinations_attributes_\d+__delete/.test(changed_element_id)) {
+        if (/_attributes_\d+__delete/.test(changed_element_id)) {
           $this.hide();
         }
       })

--- a/app/assets/javascripts/optional_sections.js
+++ b/app/assets/javascripts/optional_sections.js
@@ -7,20 +7,24 @@ $(function () {
    * @param {jQuery wrapped input} $input - A radio button.
    */
 
-  var manageStateOfOptionalSection = function ($input, $optional_section_wrapper) {
+  var manageStateOfOptionalSection = function ($input, $optional_section_wrapper, $clear_selection_control) {
     var id = $input.attr('id');
     switch (true) {
       case /_yes$/.test(id):
         $optional_section_wrapper.show();
+        $clear_selection_control.show();
         break;
       case /_no$/.test(id):
         $optional_section_wrapper.hide();
+        $clear_selection_control.show();
         break;
-      case /_clear_selection$/.test(id):
+      case /_unknown$/.test(id):
         $optional_section_wrapper.hide();
+        $clear_selection_control.hide();
         break;
       default:
         $optional_section_wrapper.hide();
+        $clear_selection_control.hide();
     }
   };
 
@@ -32,15 +36,16 @@ $(function () {
       var $this = $(this),
         $controls = $(settings.controls_for_optional_section, $this),
         $checked_item_at_load = $controls.find(':checked'),
-        $optional_section_wrapper = $(settings.optional_section_wrapper, $this);
+        $optional_section_wrapper = $(settings.optional_section_wrapper, $this),
+        $clear_selection_control = $controls.find('label[for$="_unknown"]');
 
       // Initialization
-      manageStateOfOptionalSection($checked_item_at_load, $optional_section_wrapper);
+      manageStateOfOptionalSection($checked_item_at_load, $optional_section_wrapper, $clear_selection_control);
 
       // Event management
       $controls.on('change', function (e) {
         var $input = $(e.target);
-        manageStateOfOptionalSection($input, $optional_section_wrapper);
+        manageStateOfOptionalSection($input, $optional_section_wrapper, $clear_selection_control);
       });
 
     })

--- a/app/assets/javascripts/optional_sections.js
+++ b/app/assets/javascripts/optional_sections.js
@@ -3,20 +3,20 @@
 $(function () {
 
   /**
-   * Links visibility of an optional section to the
+   * Links visibility of an optional section to the selection within a specified set of controls
    * @param {jQuery wrapped input} $input - A radio button.
-   * @param {jQuery wrapped div} $optional_section - The optional section that is to be shown/hidden.
    */
 
   var manageStateOfOptionalSection = function ($input, $optional_section_wrapper) {
-    switch ($input.attr('id')) {
-      case 'move_information_has_destinations_yes':
+    var id = $input.attr('id');
+    switch (true) {
+      case /_yes$/.test(id):
         $optional_section_wrapper.show();
         break;
-      case 'move_information_has_destinations_no':
+      case /_no$/.test(id):
         $optional_section_wrapper.hide();
         break;
-      case 'move_information_has_destinations_clear_selection':
+      case /_clear_selection$/.test(id):
         $optional_section_wrapper.hide();
         break;
       default:
@@ -24,15 +24,14 @@ $(function () {
     }
   };
 
-  $.fn.destinations = function (options) {
+  $.fn.optional_section = function (options) {
 
-    var settings = $.extend({}, $.fn.destinations.defaults, options);
+    var settings = $.extend({}, $.fn.optional_section.defaults, options);
 
     return this.each(function () {
       var $this = $(this),
         $controls = $(settings.controls_for_optional_section, $this),
         $checked_item_at_load = $controls.find(':checked'),
-        $optional_section = $(settings.optional_section, $this),
         $optional_section_wrapper = $(settings.optional_section_wrapper, $this);
 
       // Initialization
@@ -44,24 +43,13 @@ $(function () {
         manageStateOfOptionalSection($input, $optional_section_wrapper);
       });
 
-      $optional_section.on('change', function (e) {
-        var $this = $(this),
-          $changed_element = $(e.target);
-        if(/move_information_destinations_attributes_\d+__delete/.test($changed_element.attr('id'))) {
-          $this.hide();
-        } else {
-          $this.show();
-        }
-      });
-
     })
   };
 
-  $.fn.destinations.defaults = {
+  $.fn.optional_section.defaults = {
     controls_for_optional_section: '.controls-optional-section',
-    optional_section_wrapper: '.optional-section-wrapper',
-    optional_section: '.optional-section'
+    optional_section_wrapper: '.optional-section-wrapper'
   };
 
-  $('.js_destinations').destinations();
+  $('.js_destinations').optional_section();
 });

--- a/app/assets/stylesheets/_helper_classes.scss
+++ b/app/assets/stylesheets/_helper_classes.scss
@@ -1,3 +1,11 @@
 .padded {
   padding: $padding-large $padding-unit;
 }
+
+.styled-as-link {
+  text-decoration: underline;
+  &:hover {
+    cursor: pointer;
+    text-decoration: none;
+  }
+}

--- a/app/cells/move_information/show.slim
+++ b/app/cells/move_information/show.slim
@@ -26,9 +26,10 @@
           .form-group.optional-section
             = df.hidden_field :id
             = df.text_field :establishment
-            = df.radio_button_fieldset :must_return,
-              choices: df.object.must_return_values,
-              inline: true
+            .form-group
+              = df.radio_button_fieldset :must_return,
+                choices: df.object.must_return_values,
+                inline: true
             = df.text_area :reasons
             = df.label :_delete, class: 'styled-as-link'
             = df.check_box :_delete


### PR DESCRIPTION
Separates the JavaScript functionality for:
- Showing/hiding optional sections
- Removing optional sections

Into two jQuery plugins that can be used in isolation or in tandem
depending on specific needs.
