### PR TITLE
Updated rspec gem to latest stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ group :test do
   gem 'codeclimate-test-reporter', require: nil
   gem 'launchy'
   gem 'rspec-its'
-  gem 'rspec-rails', '~> 3.5.0.beta3'
+  gem 'rspec-rails'
   gem 'rspec-cells'
   gem 'shoulda-matchers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,7 +330,7 @@ DEPENDENCIES
   reform-rails
   rspec-cells
   rspec-its
-  rspec-rails (~> 3.5.0.beta3)
+  rspec-rails
   rubocop (~> 0.35.1)
   sass-rails (~> 5.0)
   shoulda-matchers


### PR DESCRIPTION
Following the release of Rails 5.0.0, RSpec 3.5.0 is out of beta. This brings our project up to date with the mainline releases.
