### PR TITLE
Spec optional fields

### DIFF
--- a/app/models/forms/base.rb
+++ b/app/models/forms/base.rb
@@ -23,7 +23,7 @@ module Forms
       end
 
       def optional_field(field_name)
-        property(field_name, type: String, default: DEFAULT_CHOICE)
+        property(field_name, type: String)
         validates field_name,
           inclusion: { in: TOGGLE_CHOICES },
           allow_blank: true

--- a/spec/forms/healthcare/needs_spec.rb
+++ b/spec/forms/healthcare/needs_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe Forms::Healthcare::Needs, type: :form do
 
   describe 'defaults' do
     its(:dependencies) { is_expected.to eq 'unknown' }
-    its(:has_medications)   { is_expected.to eq 'unknown' }
   end
 
   describe '#validate' do
@@ -50,11 +49,7 @@ RSpec.describe Forms::Healthcare::Needs, type: :form do
       it { is_expected.to validate_presence_of(:dependencies_details) }
     end
 
-    it do
-      is_expected.
-        to validate_inclusion_of(:has_medications).
-        in_array(%w[ yes no unknown ])
-    end
+    it { is_expected.to validate_optional_field(:has_medications) }
   end
 
   describe '#save' do

--- a/spec/forms/healthcare/needs_spec.rb
+++ b/spec/forms/healthcare/needs_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Forms::Healthcare::Needs, type: :form do
 
   describe '#validate' do
     it { is_expected.to validate_prepopulated_collection :medications }
+    it { is_expected.to validate_optional_field(:has_medications) }
 
     describe 'nilifies empty strings' do
       %w[ dependencies_details ].each do |attribute|
@@ -48,8 +49,6 @@ RSpec.describe Forms::Healthcare::Needs, type: :form do
       before { subject.dependencies = 'yes' }
       it { is_expected.to validate_presence_of(:dependencies_details) }
     end
-
-    it { is_expected.to validate_optional_field(:has_medications) }
   end
 
   describe '#save' do

--- a/spec/forms/moves/information_spec.rb
+++ b/spec/forms/moves/information_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Forms::Moves::Information, type: :form do
 
   describe '#validate' do
     it { is_expected.to validate_prepopulated_collection :destinations }
+    it { is_expected.to validate_optional_field(:has_destinations) }
 
     describe 'nilifies empty strings' do
       %w[ from to reason ].each do |attribute|
@@ -70,12 +71,6 @@ RSpec.describe Forms::Moves::Information, type: :form do
       is_expected.
         to validate_inclusion_of(:reason).
         in_array(subject.reasons)
-    end
-
-    it do
-      is_expected.
-        to validate_inclusion_of(:has_destinations).
-        in_array(%w[ yes no unknown ])
     end
 
     context 'when reason is other' do

--- a/spec/forms/offences_spec.rb
+++ b/spec/forms/offences_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Forms::Offences, type: :form do
     it { is_expected.to validate_string_as_date(:release_date) }
     it { is_expected.to validate_prepopulated_collection :current_offences }
     it { is_expected.to validate_prepopulated_collection :past_offences }
+    it { is_expected.to validate_optional_field(:has_past_offences) }
   end
 
   describe '#save' do

--- a/spec/forms/risk/communication_spec.rb
+++ b/spec/forms/risk/communication_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Forms::Risk::Communication, type: :form do
   }
 
   describe 'defaults' do
-    its(:interpreter_required) { is_expected.to eq 'unknown' }
     its(:hearing_speach_sight) { is_expected.to eq 'unknown' }
     its(:can_read_and_write) { is_expected.to eq 'unknown' }
   end
@@ -28,15 +27,13 @@ RSpec.describe Forms::Risk::Communication, type: :form do
       end
     end
 
-    it do
-      is_expected.
-        to validate_inclusion_of(:interpreter_required).
-        in_array(%w[ yes no unknown ])
-    end
+    context "for the 'interpreter_required' attribute" do
+      it { is_expected.to validate_optional_field(:interpreter_required) }
 
-    context 'when interpreter_required is set to yes' do
-      before { subject.interpreter_required = 'yes' }
-      it { is_expected.to validate_presence_of(:language) }
+      context 'when interpreter_required is set to yes' do
+        before { subject.interpreter_required = 'yes' }
+        it { is_expected.to validate_presence_of(:language) }
+      end
     end
 
     it do

--- a/spec/forms/risk/harassments_spec.rb
+++ b/spec/forms/risk/harassments_spec.rb
@@ -12,24 +12,18 @@ RSpec.describe Forms::Risk::Harassments, type: :form do
     }
   }
 
-  describe 'defaults' do
-    its(:stalker_harasser_bully) { is_expected.to eq 'unknown' }
-  end
-
   describe '#validate' do
-    it do
-      is_expected.
-        to validate_inclusion_of(:stalker_harasser_bully).
-        in_array(%w[ yes no unknown ])
-    end
+    context "for the 'stalker_harasser_bully' attribute" do
+      it { is_expected.to validate_optional_field(:stalker_harasser_bully) }
 
-    context 'when stalker_harasser_bully is set to yes' do
-      before { subject.stalker_harasser_bully = 'yes' }
+      context 'when stalker_harasser_bully is set to yes' do
+        before { subject.stalker_harasser_bully = 'yes' }
 
-      %w[ hostage_taker stalker harasser intimidator bully ].each do |field|
-        context "when #{field} is set to true" do
-          before { subject.public_send("#{field}=", true) }
-          it { is_expected.to validate_presence_of("#{field}_details") }
+        %w[ hostage_taker stalker harasser intimidator bully ].each do |field|
+          context "when #{field} is set to true" do
+            before { subject.public_send("#{field}=", true) }
+            it { is_expected.to validate_presence_of("#{field}_details") }
+          end
         end
       end
     end

--- a/spec/forms/risk/sex_offences_spec.rb
+++ b/spec/forms/risk/sex_offences_spec.rb
@@ -12,10 +12,6 @@ RSpec.describe Forms::Risk::SexOffences, type: :form do
     }
   }
 
-  describe 'defaults' do
-    its(:sex_offence) { is_expected.to eq 'unknown' }
-  end
-
   describe '#validate' do
     describe 'nilifies empty strings' do
       %w[ sex_offence_details ].each do |attribute|
@@ -23,21 +19,19 @@ RSpec.describe Forms::Risk::SexOffences, type: :form do
       end
     end
 
-    it do
-      is_expected.
-        to validate_inclusion_of(:sex_offence).
-        in_array(%w[ yes no unknown ])
+    context "for the 'sex_offence' attribute" do
+      it { is_expected.to validate_optional_field(:sex_offence) }
+
+      context 'when sex_offence is set to yes' do
+        before { subject.sex_offence = 'yes' }
+        it { is_expected.to validate_presence_of(:sex_offence_details) }
+      end
     end
 
     it do
       is_expected.
         to validate_inclusion_of(:sex_offence_victim).
         in_array(%w[ adult_male adult_female under_18 ])
-    end
-
-    context 'when sex_offence is set to yes' do
-      before { subject.sex_offence = 'yes' }
-      it { is_expected.to validate_presence_of(:sex_offence_details) }
     end
   end
 

--- a/spec/forms/risk/violence_spec.rb
+++ b/spec/forms/risk/violence_spec.rb
@@ -12,32 +12,26 @@ RSpec.describe Forms::Risk::Violence, type: :form do
     }
   }
 
-  describe 'defaults' do
-    its(:violent) { is_expected.to eq 'unknown' }
-  end
-
   describe '#validate' do
-    it do
-      is_expected.
-        to validate_inclusion_of(:violent).
-        in_array(%w[ yes no unknown ])
-    end
+    context "for the 'violent' attribute" do
+      it { is_expected.to validate_optional_field(:violent) }
 
-    context 'when violent is set to yes' do
-      before { subject.violent = 'yes' }
+      context 'when violent is set to yes' do
+        before { subject.violent = 'yes' }
 
-      %w[ prison_staff
-        risk_to_females
-        escort_or_court_staff
-        healthcare_staff
-        other_detainees
-        homophobic
-        racist
-        public_offence_related
-        police ].each do |field|
-        context "when #{field} is set to true" do
-          before { subject.public_send("#{field}=", true) }
-          it { is_expected.to validate_presence_of("#{field}_details") }
+        %w[ prison_staff
+          risk_to_females
+          escort_or_court_staff
+          healthcare_staff
+          other_detainees
+          homophobic
+          racist
+          public_offence_related
+          police ].each do |field|
+          context "when #{field} is set to true" do
+            before { subject.public_send("#{field}=", true) }
+            it { is_expected.to validate_presence_of("#{field}_details") }
+          end
         end
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,7 +53,7 @@ RSpec.configure do |config|
   config.include(ActiveSupport::Testing::TimeHelpers)
   config.include(Devise::Test::IntegrationHelpers, type: :request)
   config.include(FactoryGirl::Syntax::Methods)
-  config.include(CollectionsHelper, type: :form)
+  config.include(FormsHelper, type: :form)
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/support/matchers/validate_optional_field.rb
+++ b/spec/support/matchers/validate_optional_field.rb
@@ -1,0 +1,54 @@
+class ValidateOptionalField
+  attr_reader :subject, :method_name, :error
+
+  def initialize(method_name)
+    @method_name = method_name
+  end
+
+  def matches?(subject)
+    @subject = subject
+    has_default_value && validates_inclusion
+  end
+
+  def description
+    "validate that :#{method_name} behaves like an optional field."
+  end
+
+  def failure_message
+    "Expected #{method_name} to behave like an optional field. \n#{error}"
+  end
+
+  private
+
+  EXPECTED_DEFAULT_VALUE = 'unknown'
+
+  def has_default_value
+    default_value = subject.schema[method_name.to_s][:default].instance_variable_get("@value")
+    result = default_value == EXPECTED_DEFAULT_VALUE
+
+    unless result
+      set_error "Attribute had a default value of #{default_value} instead of #{EXPECTED_DEFAULT_VALUE}."
+    end
+
+    result
+  end
+
+  FIELD_OPTIONS = %w[ yes no unknown ]
+
+  def validates_inclusion
+    result = Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher.
+      new(method_name).
+      in_array(FIELD_OPTIONS).
+      matches?(subject)
+
+    unless result
+      set_error "Attribute did not validate inclusion in #{FIELD_OPTIONS.to_sentence}."
+    end
+
+    result
+  end
+
+  def set_error(msg)
+    @error = msg
+  end
+end

--- a/spec/support/matchers/validate_optional_field.rb
+++ b/spec/support/matchers/validate_optional_field.rb
@@ -29,7 +29,7 @@ class ValidateOptionalField
       matches?(subject)
 
     unless result
-      set_error "Attribute did not validate inclusion in #{FIELD_OPTIONS.to_sentence}."
+      set_error "Attribute value was not included in: #{FIELD_OPTIONS.to_sentence}."
     end
 
     result

--- a/spec/support/matchers/validate_optional_field.rb
+++ b/spec/support/matchers/validate_optional_field.rb
@@ -7,7 +7,7 @@ class ValidateOptionalField
 
   def matches?(subject)
     @subject = subject
-    has_default_value && validates_inclusion
+    validates_inclusion
   end
 
   def description
@@ -19,19 +19,6 @@ class ValidateOptionalField
   end
 
   private
-
-  EXPECTED_DEFAULT_VALUE = 'unknown'
-
-  def has_default_value
-    default_value = subject.schema[method_name.to_s][:default].instance_variable_get("@value")
-    result = default_value == EXPECTED_DEFAULT_VALUE
-
-    unless result
-      set_error "Attribute had a default value of #{default_value} instead of #{EXPECTED_DEFAULT_VALUE}."
-    end
-
-    result
-  end
 
   FIELD_OPTIONS = %w[ yes no unknown ]
 

--- a/spec/support/spec_helpers/collections_helper.rb
+++ b/spec/support/spec_helpers/collections_helper.rb
@@ -1,5 +1,9 @@
-module CollectionsHelper
+module FormsHelper
   def validate_prepopulated_collection(field_name)
     ValidatePrepopulatedCollection.new(field_name)
+  end
+
+  def validate_optional_field(field_name)
+    ValidateOptionalField.new(field_name)
   end
 end


### PR DESCRIPTION
- [x] Optional field spec helper
- [x] Apply to all forms that use the optional_field helper(ignoring optional_details_field for now - will handle with its own matcher)
