### PR TITLE
Change the toggle field type to String

### DIFF
--- a/app/models/forms/base.rb
+++ b/app/models/forms/base.rb
@@ -23,7 +23,7 @@ module Forms
       end
 
       def optional_field(field_name)
-        property(field_name, type: StrictString, default: DEFAULT_CHOICE)
+        property(field_name, type: String, default: DEFAULT_CHOICE)
         validates field_name,
           inclusion: { in: TOGGLE_CHOICES },
           allow_blank: true

--- a/spec/forms/healthcare/physical_spec.rb
+++ b/spec/forms/healthcare/physical_spec.rb
@@ -16,12 +16,6 @@ RSpec.describe Forms::Healthcare::Physical, type: :form do
   end
 
   describe '#validate' do
-    describe 'nilifies empty strings' do
-      %w[ physical_issues ].each do |attribute|
-        it { is_expected.to nilify_empty_strings_for(attribute) }
-      end
-    end
-
     it do
       is_expected.
         to validate_inclusion_of(:physical_issues).

--- a/spec/forms/risk/harassments_spec.rb
+++ b/spec/forms/risk/harassments_spec.rb
@@ -17,12 +17,6 @@ RSpec.describe Forms::Risk::Harassments, type: :form do
   end
 
   describe '#validate' do
-    describe 'nilifies empty strings' do
-      %w[ stalker_harasser_bully ].each do |attribute|
-        it { is_expected.to nilify_empty_strings_for(attribute) }
-      end
-    end
-
     it do
       is_expected.
         to validate_inclusion_of(:stalker_harasser_bully).

--- a/spec/forms/risk/risk_from_others_spec.rb
+++ b/spec/forms/risk/risk_from_others_spec.rb
@@ -25,12 +25,6 @@ RSpec.describe Forms::Risk::RiskFromOthers, type: :form do
   end
 
   describe '#validate' do
-    describe 'nilifies empty strings' do
-      %w[ rule_45 csra verbal_abuse physical_abuse ].each do |attribute|
-        it { is_expected.to nilify_empty_strings_for(attribute) }
-      end
-    end
-
     it do
       is_expected.
         to validate_inclusion_of(:rule_45).

--- a/spec/forms/risk/risk_to_self_spec.rb
+++ b/spec/forms/risk/risk_to_self_spec.rb
@@ -19,12 +19,6 @@ RSpec.describe Forms::Risk::RiskToSelf, type: :form do
   end
 
   describe '#validate' do
-    describe 'nilifies empty strings' do
-      %w[ open_acct suicide ].each do |attribute|
-        it { is_expected.to nilify_empty_strings_for(attribute) }
-      end
-    end
-
     it do
       is_expected.
         to validate_inclusion_of(:open_acct).

--- a/spec/forms/risk/violence_spec.rb
+++ b/spec/forms/risk/violence_spec.rb
@@ -17,12 +17,6 @@ RSpec.describe Forms::Risk::Violence, type: :form do
   end
 
   describe '#validate' do
-    describe 'nilifies empty strings' do
-      %w[ violent ].each do |attribute|
-        it { is_expected.to nilify_empty_strings_for(attribute) }
-      end
-    end
-
     it do
       is_expected.
         to validate_inclusion_of(:violent).


### PR DESCRIPTION
We don't need to alter the coercion strategy on empty strings
for the toggle fields because the value can be only one of three
available flags: yes, no & unknown.

This is a precursor to improving the form macros in all specs.
