### PR TITLE
Remove old specs that are now handled by a matcher

### DIFF
--- a/spec/forms/healthcare/needs_spec.rb
+++ b/spec/forms/healthcare/needs_spec.rb
@@ -120,23 +120,6 @@ RSpec.describe Forms::Healthcare::Needs, type: :form do
     end
   end
 
-  describe '#prepopulate!' do
-    context 'when medications are empty' do
-      it 'adds a new medication to the collection' do
-        expect { subject.prepopulate! }.
-          to change { subject.medications.size }.from(0).to(1)
-      end
-    end
-
-    context 'when at least one medication exists' do
-      it 'it doesnt alter the collection' do
-        subject.medications << Medication.new
-        expect { subject.prepopulate! }.
-          not_to change { subject.medications.size }
-      end
-    end
-  end
-
   describe '#add_medication' do
     it 'adds a new medication to the collection' do
       expect { subject.add_medication }.

--- a/spec/forms/moves/information_spec.rb
+++ b/spec/forms/moves/information_spec.rb
@@ -171,23 +171,6 @@ RSpec.describe Forms::Moves::Information, type: :form do
     end
   end
 
-  describe '#prepopulate!' do
-    context 'when destinations are empty' do
-      it 'adds a new destination to the collection' do
-        expect { subject.prepopulate! }.
-          to change { subject.destinations.size }.from(0).to(1)
-      end
-    end
-
-    context 'when at least one destination exists' do
-      it 'it doesnt alter the collection' do
-        subject.destinations << Destination.new
-        expect { subject.prepopulate! }.
-          not_to change { subject.destinations.size }
-      end
-    end
-  end
-
   describe '#add_destination' do
     it 'adds a new destination to the collection' do
       expect { subject.add_destination }.


### PR DESCRIPTION
Redundant code, the handy `validate_prepopulated_collection` now handles this part of the spec.
