### PR TITLE
Reset attributes nested under toggle fields

### DIFF
--- a/app/models/forms/base.rb
+++ b/app/models/forms/base.rb
@@ -25,7 +25,10 @@ module Forms
         end
 
         def validate(*)
-          super.tap { |*| reset_attributes_if_disabled_by_toggle }
+          result = super
+          reset_attributes_if_disabled_by_toggle if result
+
+          result
         end
 
         private

--- a/app/models/forms/base.rb
+++ b/app/models/forms/base.rb
@@ -25,12 +25,12 @@ module Forms
         end
 
         def validate(*)
-          super.tap { |*| reset_attributes_if_disbaled_by_toggle }
+          super.tap { |*| reset_attributes_if_disabled_by_toggle }
         end
 
         private
 
-        def reset_attributes_if_disbaled_by_toggle
+        def reset_attributes_if_disabled_by_toggle
           self.class.resetters.each do |(attributes_to_reset, toggle_attribute)|
             if public_send(toggle_attribute) != TOGGLE_YES
               attributes_to_reset.each { |method| public_send("#{method}=", nil) }

--- a/app/models/forms/base.rb
+++ b/app/models/forms/base.rb
@@ -33,9 +33,7 @@ module Forms
         def reset_attributes_if_disbaled_by_toggle
           self.class.resetters.each do |(attributes_to_reset, toggle_attribute)|
             if public_send(toggle_attribute) != TOGGLE_YES
-              attributes_to_reset.each do |method_name|
-                public_send("#{method_name}=", nil)
-              end
+              attributes_to_reset.each { |method| public_send("#{method}=", nil) }
             end
           end
         end
@@ -117,8 +115,6 @@ module Forms
         define_method "handle_nested_params_for_#{field_name}" do |collection:, fragment:, **|
           item = collection.find { |d| ( d.id.present? && d.id == fragment['id']) }
           marked_to_be_deleted = fragment['_delete'] == '1'
-
-          # TODO this should be able to be removed with the addition of reset
           all_to_be_deleted = %w[ yes ].exclude?(
             public_send("has_#{field_name}")
           )

--- a/app/models/forms/base.rb
+++ b/app/models/forms/base.rb
@@ -76,6 +76,7 @@ module Forms
           presence: true,
           if:
             -> { public_send(field_name) && public_send(toggle) == TOGGLE_YES }
+        reset attributes: ["#{field_name}_details"], if_falsey: field_name, enabled_value: true
       end
 
       def singularize(field_name)

--- a/app/models/forms/base.rb
+++ b/app/models/forms/base.rb
@@ -15,8 +15,8 @@ module Forms
     concerning :ResetAttributes do
       included do
         class << self
-          def reset(attributes:, if_falsey:)
-            resetters << [attributes, if_falsey]
+          def reset(attributes:, if_falsey:, enabled_value: TOGGLE_YES)
+            resetters << [attributes, if_falsey, enabled_value]
           end
 
           def resetters
@@ -34,8 +34,8 @@ module Forms
         private
 
         def reset_attributes_if_disabled_by_toggle
-          self.class.resetters.each do |(attributes_to_reset, toggle_attribute)|
-            if public_send(toggle_attribute) != TOGGLE_YES
+          self.class.resetters.each do |(attributes_to_reset, toggle_attribute, enabled_value)|
+            if public_send(toggle_attribute) != enabled_value
               attributes_to_reset.each { |method| public_send("#{method}=", nil) }
             end
           end

--- a/app/models/forms/base.rb
+++ b/app/models/forms/base.rb
@@ -65,6 +65,7 @@ module Forms
         validates "#{field_name}_details",
           presence: true,
           if: -> { public_send(field_name) == TOGGLE_YES }
+        reset attributes: ["#{field_name}_details"], if_falsey: field_name
       end
 
       def optional_checkbox(field_name, toggle = nil)

--- a/app/models/forms/risk/communication.rb
+++ b/app/models/forms/risk/communication.rb
@@ -7,6 +7,8 @@ module Forms
         presence: true,
         if: -> { interpreter_required == TOGGLE_YES }
 
+      reset attributes: %i[ language ], if_falsey: :interpreter_required
+
       optional_details_field :hearing_speach_sight
       optional_details_field :can_read_and_write
     end

--- a/app/models/forms/risk/harassments.rb
+++ b/app/models/forms/risk/harassments.rb
@@ -2,6 +2,11 @@ module Forms
   module Risk
     class Harassments < Forms::Base
       optional_field :stalker_harasser_bully
+      reset attributes: %i[
+        hostage_taker hostage_taker_details stalker stalker_details harasser
+        harasser_details intimidator intimidator_details bully bully_details
+      ], if_falsey: :stalker_harasser_bully
+
       optional_checkbox :hostage_taker, :stalker_harasser_bully
       optional_checkbox :stalker, :stalker_harasser_bully
       optional_checkbox :harasser, :stalker_harasser_bully

--- a/app/models/forms/risk/risk_from_others.rb
+++ b/app/models/forms/risk/risk_from_others.rb
@@ -20,6 +20,9 @@ module Forms
           validates :csra_details,
             presence: true,
             if: -> { csra == CSRA_HIGH }
+
+          reset attributes: %i[ csra_details ],
+            if_falsey: :csra, enabled_value: CSRA_HIGH
         end
 
         def csra_toggle_choices

--- a/app/models/forms/risk/risk_from_others.rb
+++ b/app/models/forms/risk/risk_from_others.rb
@@ -22,7 +22,7 @@ module Forms
             if: -> { csra == CSRA_HIGH }
 
           reset attributes: %i[ csra_details ],
-            if_falsey: :csra, enabled_value: CSRA_HIGH
+                if_falsey: :csra, enabled_value: CSRA_HIGH
         end
 
         def csra_toggle_choices

--- a/app/models/forms/risk/sex_offences.rb
+++ b/app/models/forms/risk/sex_offences.rb
@@ -20,7 +20,7 @@ module Forms
         if: -> { sex_offence == 'yes' && sex_offence_victim == UNDER_18 }
 
       reset attributes: %i[ sex_offence_details ],
-        if_falsey: :sex_offence_victim, enabled_value: UNDER_18
+            if_falsey: :sex_offence_victim, enabled_value: UNDER_18
 
       def victim_values
         VICTIM_VALUES

--- a/app/models/forms/risk/sex_offences.rb
+++ b/app/models/forms/risk/sex_offences.rb
@@ -6,7 +6,7 @@ module Forms
 
       optional_field :sex_offence
       reset attributes: %i[sex_offence_victim sex_offence_details],
-        if_falsey: :sex_offence
+            if_falsey: :sex_offence
 
       property :sex_offence_victim, type: StrictString
       property :sex_offence_details, type: StrictString

--- a/app/models/forms/risk/sex_offences.rb
+++ b/app/models/forms/risk/sex_offences.rb
@@ -19,6 +19,9 @@ module Forms
         presence: true,
         if: -> { sex_offence == 'yes' && sex_offence_victim == UNDER_18 }
 
+      reset attributes: %i[ sex_offence_details ],
+        if_falsey: :sex_offence_victim, enabled_value: UNDER_18
+
       def victim_values
         VICTIM_VALUES
       end

--- a/app/models/forms/risk/sex_offences.rb
+++ b/app/models/forms/risk/sex_offences.rb
@@ -5,6 +5,9 @@ module Forms
       VICTIM_VALUES = ['adult_male', 'adult_female', UNDER_18]
 
       optional_field :sex_offence
+      reset attributes: %i[sex_offence_victim sex_offence_details],
+        if_falsey: :sex_offence
+
       property :sex_offence_victim, type: StrictString
       property :sex_offence_details, type: StrictString
 

--- a/app/models/forms/risk/violence.rb
+++ b/app/models/forms/risk/violence.rb
@@ -2,6 +2,14 @@ module Forms
   module Risk
     class Violence < Forms::Base
       optional_field :violent
+      reset attributes: %i[
+        prison_staff prison_staff_details risk_to_females risk_to_females_details
+        escort_or_court_staff escort_or_court_staff_details healthcare_staff
+        healthcare_staff_details other_detainees other_detainees_details homophobic
+        homophobic_details racist racist_details public_offence_related
+        public_offence_related_details police police_details
+      ], if_falsey: :violent
+
       optional_checkbox :prison_staff, :violent
       optional_checkbox :risk_to_females, :violent
       optional_checkbox :escort_or_court_staff, :violent

--- a/spec/forms/risk/communication_spec.rb
+++ b/spec/forms/risk/communication_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe Forms::Risk::Communication, type: :form do
         before { subject.interpreter_required = 'yes' }
         it { is_expected.to validate_presence_of(:language) }
       end
+
+      it {
+        is_expected.to validate_attributes_are_reset(:language).
+          when_attribute_is_disabled(:interpreter_required)
+      }
     end
 
     it { is_expected.to validate_optional_details_field(:hearing_speach_sight) }

--- a/spec/forms/risk/harassments_spec.rb
+++ b/spec/forms/risk/harassments_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe Forms::Risk::Harassments, type: :form do
     context "for the 'stalker_harasser_bully' attribute" do
       it { is_expected.to validate_optional_field(:stalker_harasser_bully) }
 
-      it {
-        is_expected.
-          to validate_attributes_are_reset(
-            :hostage_taker, :hostage_taker_details, :stalker, :stalker_details, :harasser,
-            :harasser_details, :intimidator, :intimidator_details, :bully, :bully_details).
-          when_attribute_is_disabled(:stalker_harasser_bully)
-      }
+      # FIXME this is super hard to grok.. the validator is just complicating the spec
+      it "resets all attributes unless the 'stalker_harasser_bully' toggle is enabled" do
+        is_expected.to validate_attributes_are_reset(
+          :hostage_taker, :hostage_taker_details, :stalker, :stalker_details, :harasser,
+          :harasser_details, :intimidator, :intimidator_details, :bully, :bully_details).
+          when_attribute_is_disabled(:stalker_harasser_bully).with_attribute_value_set_as(true)
+      end
 
       context 'when stalker_harasser_bully is set to yes' do
         before { subject.stalker_harasser_bully = 'yes' }

--- a/spec/forms/risk/harassments_spec.rb
+++ b/spec/forms/risk/harassments_spec.rb
@@ -16,9 +16,18 @@ RSpec.describe Forms::Risk::Harassments, type: :form do
     context "for the 'stalker_harasser_bully' attribute" do
       it { is_expected.to validate_optional_field(:stalker_harasser_bully) }
 
+      it {
+        is_expected.
+          to validate_attributes_are_reset(
+            :hostage_taker, :hostage_taker_details, :stalker, :stalker_details, :harasser,
+            :harasser_details, :intimidator, :intimidator_details, :bully, :bully_details).
+          when_attribute_is_disabled(:stalker_harasser_bully)
+      }
+
       context 'when stalker_harasser_bully is set to yes' do
         before { subject.stalker_harasser_bully = 'yes' }
 
+        # TODO this smells of needing a checkbox validator
         %w[ hostage_taker stalker harasser intimidator bully ].each do |field|
           context "when #{field} is set to true" do
             before { subject.public_send("#{field}=", true) }

--- a/spec/forms/risk/sex_offences_spec.rb
+++ b/spec/forms/risk/sex_offences_spec.rb
@@ -18,9 +18,13 @@ RSpec.describe Forms::Risk::SexOffences, type: :form do
     end
 
     it {
-      is_expected.
-        to validate_attributes_are_reset(:sex_offence_victim, :sex_offence_details).
+      is_expected.to validate_attributes_are_reset(:sex_offence_details).
         when_attribute_is_disabled(:sex_offence)
+    }
+
+    it {
+      is_expected.to validate_attributes_are_reset(:sex_offence_victim).
+        when_attribute_is_disabled(:sex_offence).with_attribute_value_set_as('adult_male')
     }
 
     describe "sex_offence_details" do

--- a/spec/forms/risk/sex_offences_spec.rb
+++ b/spec/forms/risk/sex_offences_spec.rb
@@ -17,10 +17,16 @@ RSpec.describe Forms::Risk::SexOffences, type: :form do
       it { is_expected.to validate_optional_field(:sex_offence) }
     end
 
+    it {
+      is_expected.
+        to validate_attributes_are_reset(:sex_offence_victim, :sex_offence_details).
+        when_attribute_is_disabled(:sex_offence)
+    }
+
     describe "sex_offence_details" do
       it { is_expected.to validate_strict_string(:sex_offence_details) }
 
-      context "when sex_offence is set to yes" do
+      context 'when sex_offence is set to yes' do
         before { subject.sex_offence = 'yes' }
 
         context "when the victim is set to under 18" do

--- a/spec/forms/risk/sex_offences_spec.rb
+++ b/spec/forms/risk/sex_offences_spec.rb
@@ -15,17 +15,22 @@ RSpec.describe Forms::Risk::SexOffences, type: :form do
   describe '#validate' do
     describe "sex_offence" do
       it { is_expected.to validate_optional_field(:sex_offence) }
+
+      context "when the sex offence victim is set to 'under_18'" do
+        it "resets the sex offence details attribute" do
+          subject.sex_offence_victim = "under_18"
+
+          is_expected.to validate_attributes_are_reset(:sex_offence_details).
+            when_attribute_is_disabled(:sex_offence)
+        end
+      end
+
+      # FIXME this is super hard to grok.. the validator is just complicating the spec
+      it "resets the sex offence victim" do
+        is_expected.to validate_attributes_are_reset(:sex_offence_victim).
+          when_attribute_is_disabled(:sex_offence).with_attribute_value_set_as('adult_male')
+      end
     end
-
-    it {
-      is_expected.to validate_attributes_are_reset(:sex_offence_details).
-        when_attribute_is_disabled(:sex_offence)
-    }
-
-    it {
-      is_expected.to validate_attributes_are_reset(:sex_offence_victim).
-        when_attribute_is_disabled(:sex_offence).with_attribute_value_set_as('adult_male')
-    }
 
     describe "sex_offence_details" do
       it { is_expected.to validate_strict_string(:sex_offence_details) }

--- a/spec/forms/risk/violence_spec.rb
+++ b/spec/forms/risk/violence_spec.rb
@@ -16,6 +16,16 @@ RSpec.describe Forms::Risk::Violence, type: :form do
     context "for the 'violent' attribute" do
       it { is_expected.to validate_optional_field(:violent) }
 
+      it {
+        is_expected.to validate_attributes_are_reset(
+          :prison_staff, :prison_staff_details, :risk_to_females, :risk_to_females_details,
+          :escort_or_court_staff, :escort_or_court_staff_details, :healthcare_staff,
+          :healthcare_staff_details, :other_detainees, :other_detainees_details, :homophobic,
+          :homophobic_details, :racist, :racist_details, :public_offence_related,
+          :public_offence_related_details, :police, :police_details
+        ).when_attribute_is_disabled(:violent)
+      }
+
       context 'when violent is set to yes' do
         before { subject.violent = 'yes' }
 

--- a/spec/forms/risk/violence_spec.rb
+++ b/spec/forms/risk/violence_spec.rb
@@ -16,15 +16,16 @@ RSpec.describe Forms::Risk::Violence, type: :form do
     context "for the 'violent' attribute" do
       it { is_expected.to validate_optional_field(:violent) }
 
-      it {
+      # FIXME this is super hard to grok.. the validator is just complicating the spec
+      it "resets all attributes unless the 'violent' toggle is enabled" do
         is_expected.to validate_attributes_are_reset(
           :prison_staff, :prison_staff_details, :risk_to_females, :risk_to_females_details,
           :escort_or_court_staff, :escort_or_court_staff_details, :healthcare_staff,
           :healthcare_staff_details, :other_detainees, :other_detainees_details, :homophobic,
           :homophobic_details, :racist, :racist_details, :public_offence_related,
           :public_offence_related_details, :police, :police_details
-        ).when_attribute_is_disabled(:violent)
-      }
+        ).when_attribute_is_disabled(:violent).with_attribute_value_set_as(true)
+      end
 
       context 'when violent is set to yes' do
         before { subject.violent = 'yes' }

--- a/spec/support/matchers/validate_attributes_are_reset.rb
+++ b/spec/support/matchers/validate_attributes_are_reset.rb
@@ -1,8 +1,10 @@
 class ValidateAttributesAreReset
-  attr_reader :attributes, :toggle_attribute, :subject, :error
+  attr_reader :attributes, :toggle_attribute, :subject,
+    :error, :attribute_value
 
   def initialize(*attributes)
     @attributes = attributes
+    @attribute_value = "some user input"
   end
 
   def matches?(subject)
@@ -18,6 +20,11 @@ class ValidateAttributesAreReset
     self
   end
 
+  def with_attribute_value_set_as(value)
+    @attribute_value = value
+    self
+  end
+
   def description
     "validate that #{attributes.to_sentence} are reset when #{toggle_attribute} is disabled."
   end
@@ -28,15 +35,13 @@ class ValidateAttributesAreReset
 
   private
 
-  MOCK_USER_INPUT = "some user input"
-
   def validate_attributes_retained_when_toggle_attribute_is_yes
     populate_attributes_under_test
     set_toggle_attribute_to "yes"
     simulate_form_being_validated
 
     attributes.all? do |attr|
-      result = subject.public_send(attr) == MOCK_USER_INPUT
+      result = subject.public_send(attr) == attribute_value
 
       unless result
         set_error "Expected #{attr} to be retained when #{toggle_attribute} set to yes"
@@ -63,7 +68,7 @@ class ValidateAttributesAreReset
   end
 
   def populate_attributes_under_test
-    attributes.each { |attr| subject.public_send("#{attr}=", MOCK_USER_INPUT) }
+    attributes.each { |attr| subject.public_send("#{attr}=", attribute_value) }
   end
 
   def set_toggle_attribute_to(value)

--- a/spec/support/matchers/validate_attributes_are_reset.rb
+++ b/spec/support/matchers/validate_attributes_are_reset.rb
@@ -1,4 +1,4 @@
-class ValidateAttributesReset
+class ValidateAttributesAreReset
   attr_reader :attributes, :toggle_attribute, :subject, :error
 
   def initialize(*attributes)

--- a/spec/support/matchers/validate_attributes_reset.rb
+++ b/spec/support/matchers/validate_attributes_reset.rb
@@ -1,0 +1,81 @@
+class ValidateAttributesReset
+  attr_reader :attributes, :toggle_attribute, :subject, :error
+
+  def initialize(*attributes)
+    @attributes = attributes
+  end
+
+  def matches?(subject)
+    @subject = subject
+
+    validate_attributes_retained_when_toggle_attribute_is_yes &&
+      validate_attributes_reset_when_toggle_attribute_is("no") &&
+      validate_attributes_reset_when_toggle_attribute_is("unknown")
+  end
+
+  def when_attribute_is_disabled(attribute)
+    @toggle_attribute = attribute
+    self
+  end
+
+  def description
+    "validate that #{attributes.to_sentence} are reset when #{toggle_attribute} is disabled."
+  end
+
+  def failure_message
+    "Expected #{attributes.to_sentence} to be reset when #{toggle_attribute} is disabled.\n#{error}"
+  end
+
+  private
+
+  MOCK_USER_INPUT = "some user input"
+
+  def validate_attributes_retained_when_toggle_attribute_is_yes
+    populate_attributes_under_test
+    set_toggle_attribute_to "yes"
+    simulate_form_being_validated
+
+    attributes.all? do |attr|
+      result = subject.public_send(attr) == MOCK_USER_INPUT
+
+      unless result
+        set_error "Expected #{attr} to be retained when #{toggle_attribute} set to yes"
+      end
+
+      result
+    end
+  end
+
+  def validate_attributes_reset_when_toggle_attribute_is(value)
+    populate_attributes_under_test
+    set_toggle_attribute_to value
+    simulate_form_being_validated
+
+    attributes.all? do |attr|
+      result = subject.public_send(attr).nil?
+
+      unless result
+        set_error "Expected #{attr} to be reset when #{toggle_attribute} set to #{value}"
+      end
+
+      result
+    end
+  end
+
+  def populate_attributes_under_test
+    attributes.each { |attr| subject.public_send("#{attr}=", MOCK_USER_INPUT) }
+  end
+
+  def set_toggle_attribute_to(value)
+    subject.public_send("#{toggle_attribute}=", value)
+  end
+
+  def simulate_form_being_validated
+    fake_web_params = {}
+    subject.validate(fake_web_params)
+  end
+
+  def set_error(msg)
+    @error = msg
+  end
+end

--- a/spec/support/matchers/validate_optional_details_field.rb
+++ b/spec/support/matchers/validate_optional_details_field.rb
@@ -87,7 +87,7 @@ class ValidateOptionalDetailsField
   end
 
   def validate_details_are_reset
-    validator = ValidateAttributesReset.new(details_field_method_name)
+    validator = ValidateAttributesAreReset.new(details_field_method_name)
     validator.when_attribute_is_disabled(method_name)
     result = validator.matches?(subject)
 

--- a/spec/support/matchers/validate_optional_details_field.rb
+++ b/spec/support/matchers/validate_optional_details_field.rb
@@ -13,6 +13,7 @@ class ValidateOptionalDetailsField
         validates_presence_of_details_field_when_option_field_positive
         doesnt_validate_presence_of_details_field_when_option_field_negative
         validates_details_field_as_strict_string
+        validate_details_are_reset
     ].map { |assertion_name| reset_subject && send(assertion_name) }.all?
   end
 
@@ -78,6 +79,16 @@ class ValidateOptionalDetailsField
 
   def validates_details_field_as_strict_string
     validator = ValidateStrictString.new(details_field_method_name)
+    result = validator.matches?(subject)
+
+    set_error validator.failure_message unless result
+
+    result
+  end
+
+  def validate_details_are_reset
+    validator = ValidateAttributesReset.new(details_field_method_name)
+    validator.when_attribute_is_disabled(method_name)
     result = validator.matches?(subject)
 
     set_error validator.failure_message unless result

--- a/spec/support/spec_helpers/forms_helper.rb
+++ b/spec/support/spec_helpers/forms_helper.rb
@@ -14,4 +14,8 @@ module FormsHelper
   def validate_strict_string(field_name)
     ValidateStrictString.new(field_name)
   end
+
+  def validate_attributes_are_reset(attributes)
+    ValidateAttributesAreReset.new(attributes)
+  end
 end

--- a/spec/support/spec_helpers/forms_helper.rb
+++ b/spec/support/spec_helpers/forms_helper.rb
@@ -15,7 +15,7 @@ module FormsHelper
     ValidateStrictString.new(field_name)
   end
 
-  def validate_attributes_are_reset(attributes)
-    ValidateAttributesAreReset.new(attributes)
+  def validate_attributes_are_reset(*attributes)
+    ValidateAttributesAreReset.new(*attributes)
   end
 end


### PR DESCRIPTION
- [x] implement reset macro
- [x] apply reset to optional details field
- [x] apply to misc risk toggle fields
- [ ] reset csra - this one is slightly different to normal toggle fields
- [ ] reset sex offence details - this one is slightly different to normal toggle fields
- [ ] reset Arson details
- [ ] specs needs sorting out
- [ ] checkboxes with details fields
