### PR TITLE
Remove open acct details

### DIFF
--- a/app/form_builders/mps_form_builder.rb
+++ b/app/form_builders/mps_form_builder.rb
@@ -10,7 +10,7 @@ class MpsFormBuilder < GovukElementsFormBuilder::FormBuilder
           radio_button_fieldset attribute,
             choices: choices, inline: true
         end,
-        content_tag(:div, class: style) { yield }
+        (content_tag(:div, class: style) { yield } if block_given?)
       ])
     end
   end

--- a/app/models/forms/risk/risk_to_self.rb
+++ b/app/models/forms/risk/risk_to_self.rb
@@ -1,7 +1,7 @@
 module Forms
   module Risk
     class RiskToSelf < Forms::Base
-      optional_details_field :open_acct
+      optional_field :open_acct
       optional_details_field :suicide
     end
   end

--- a/app/views/profiles/_header.html.slim
+++ b/app/views/profiles/_header.html.slim
@@ -12,7 +12,6 @@ header#header
 
     .tile
       div = image_tag "open_acct_#{risk.open_acct}.png"
-      = risk.open_acct_details
 
   .info-tiles
     .tile

--- a/app/views/risks/_risk_to_self.html.slim
+++ b/app/views/risks/_risk_to_self.html.slim
@@ -1,2 +1,2 @@
-= f.radio_toggle_with_textarea :open_acct
+= f.radio_toggle :open_acct
 = f.radio_toggle_with_textarea :suicide

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,7 +31,7 @@ en:
         verbal_abuse: Is the detainee at risk of verbal abuse from others?
         physical_abuse: Is the detainee at risk of physical abuse from others?
       risk_to_self:
-        open_acct: Open or recent ACCT?
+        open_acct: Open ACCT?
         suicide: Risk of suicide or self-harm?
       security:
         category_a: Category A?
@@ -207,6 +207,12 @@ en:
         verbal_abuse_details: Give details
         physical_abuse_details: Give details
       risk_to_self:
+        open_acct: |
+          If an ACCT is open, the ACCT plan should be present and there
+          should be a relevant alert on NOMIS
+        suicide: |
+          Give details of recent suicide or self-harm attempts and
+          previous ACCTS
         suicide_details: Give details
       security:
         category_a_details: Give details

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,7 +125,6 @@ en:
       risk_to_self:
         open_acct:
           unknown: Clear selection
-        open_acct_details: Open ACCT details
         suicide:
           unknown: Clear selection
         suicide_details: Risk of suicide or self-harm details
@@ -208,7 +207,6 @@ en:
         verbal_abuse_details: Give details
         physical_abuse_details: Give details
       risk_to_self:
-        open_acct_details: Give details and dates of open or recent ACCTs
         suicide_details: Give details
       security:
         category_a_details: Give details

--- a/db/migrate/20160804111953_remove_open_acct_details_from_risk.rb
+++ b/db/migrate/20160804111953_remove_open_acct_details_from_risk.rb
@@ -1,0 +1,5 @@
+class RemoveOpenAcctDetailsFromRisk < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :risks, :open_acct_details
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160803163221) do
+ActiveRecord::Schema.define(version: 20160804111953) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -114,7 +114,6 @@ ActiveRecord::Schema.define(version: 20160803163221) do
 
   create_table "risks", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string   "open_acct",                       default: "unknown"
-    t.text     "open_acct_details"
     t.string   "suicide",                         default: "unknown"
     t.text     "suicide_details"
     t.string   "rule_45",                         default: "unknown"

--- a/spec/features/pages/profile.rb
+++ b/spec/features/pages/profile.rb
@@ -6,7 +6,6 @@ module Page
           expect(page).to have_content(result)
           expect(page).to have_content('Serving Sentence')
           expect(page).to have_content('High CSRA')
-          expect(page).to have_content('Needs ACCT')
           expect(page).to have_content('Details for Rule 45')
           expect(page).to have_content('Category A information')
         end

--- a/spec/features/pages/risk.rb
+++ b/spec/features/pages/risk.rb
@@ -22,7 +22,6 @@ module Page
 
     def fill_in_risk_to_self
       choose 'risk_to_self_open_acct_yes'
-      fill_in 'risk_to_self[open_acct_details]', with: 'Needs ACCT'
       choose 'risk_to_self_suicide_yes'
       fill_in 'risk_to_self[suicide_details]', with: 'Tried twice'
       save_and_continue

--- a/spec/forms/risk/risk_to_self_spec.rb
+++ b/spec/forms/risk/risk_to_self_spec.rb
@@ -7,14 +7,13 @@ RSpec.describe Forms::Risk::RiskToSelf, type: :form do
   let(:params) {
     {
       open_acct: 'yes',
-      open_acct_details: 'There is an open ACCT',
       suicide: 'yes',
       suicide_details: 'Risk of suicide',
     }.with_indifferent_access
   }
 
   describe '#validate' do
-    it { is_expected.to validate_optional_details_field(:open_acct) }
+    it { is_expected.to validate_optional_field(:open_acct) }
     it { is_expected.to validate_optional_details_field(:suicide) }
   end
 


### PR DESCRIPTION
Based on feedback from the users open_acct_details is no longer required. 🙌

![screen shot 2016-08-04 at 12 44 11](https://cloud.githubusercontent.com/assets/1006365/17400693/2bf129cc-5a41-11e6-823b-26482d7df91c.png)
