### PR TITLE
Implement reset functionality

### DIFF
--- a/app/models/forms/attribute_reset_collection.rb
+++ b/app/models/forms/attribute_reset_collection.rb
@@ -7,16 +7,18 @@ module Forms
       @collection = []
     end
 
+    attr_reader :collection
+
     def add(*args)
-      @collection << ResetData.new(*args)
+      collection << ResetData.new(*args)
     end
 
     def any?
-      @collection.any?
+      collection.any?
     end
 
-      @collection.each do |reset_obj|
     def reset_all(form, defaults)
+      collection.each do |reset_obj|
         next if form.public_send(reset_obj.master_attribute) == reset_obj.enabled_value
 
         reset_obj.attributes_to_reset.each do |attribute|

--- a/app/models/forms/attribute_reset_collection.rb
+++ b/app/models/forms/attribute_reset_collection.rb
@@ -1,5 +1,6 @@
 module Forms
   class AttributeResetCollection
+    # ([Symbol::Attribute], Symbol::Attribute, String) => Struct::ResetData
     ResetData = Struct.new(:attributes_to_reset, :master_attribute, :enabled_value)
 
     def initialize
@@ -10,12 +11,16 @@ module Forms
       @collection << ResetData.new(*args)
     end
 
-    def perform(form)
+    def any?
+      @collection.any?
+    end
+
+    def perform(form, defaults)
       @collection.each do |reset_obj|
         next if form.public_send(reset_obj.master_attribute) == reset_obj.enabled_value
 
         reset_obj.attributes_to_reset.each do |attribute|
-          form.public_send("#{attribute}=", nil)
+          form.public_send("#{attribute}=", defaults[attribute])
         end
       end
     end

--- a/app/models/forms/attribute_reset_collection.rb
+++ b/app/models/forms/attribute_reset_collection.rb
@@ -1,0 +1,23 @@
+module Forms
+  class AttributeResetCollection
+    ResetData = Struct.new(:attributes_to_reset, :master_attribute, :enabled_value)
+
+    def initialize
+      @collection = []
+    end
+
+    def add(*args)
+      @collection << ResetData.new(*args)
+    end
+
+    def perform(form)
+      @collection.each do |reset_obj|
+        if form.public_send(reset_obj.master_attribute) != reset_obj.enabled_value
+          reset_obj.attributes_to_reset.each do |attribute|
+            form.public_send("#{attribute}=", nil)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/forms/attribute_reset_collection.rb
+++ b/app/models/forms/attribute_reset_collection.rb
@@ -15,8 +15,8 @@ module Forms
       @collection.any?
     end
 
-    def perform(form, defaults)
       @collection.each do |reset_obj|
+    def reset_all(form, defaults)
         next if form.public_send(reset_obj.master_attribute) == reset_obj.enabled_value
 
         reset_obj.attributes_to_reset.each do |attribute|

--- a/app/models/forms/attribute_reset_collection.rb
+++ b/app/models/forms/attribute_reset_collection.rb
@@ -12,10 +12,10 @@ module Forms
 
     def perform(form)
       @collection.each do |reset_obj|
-        if form.public_send(reset_obj.master_attribute) != reset_obj.enabled_value
-          reset_obj.attributes_to_reset.each do |attribute|
-            form.public_send("#{attribute}=", nil)
-          end
+        next if form.public_send(reset_obj.master_attribute) == reset_obj.enabled_value
+
+        reset_obj.attributes_to_reset.each do |attribute|
+          form.public_send("#{attribute}=", nil)
         end
       end
     end

--- a/app/models/forms/base.rb
+++ b/app/models/forms/base.rb
@@ -27,7 +27,7 @@ module Forms
         def validate(*)
           super.tap do |valid|
             if valid && self.class.resettable_attributes.any?
-              self.class.resettable_attributes.perform(self, default_attribute_values)
+              self.class.resettable_attributes.reset_all(self, default_attribute_values)
             end
           end
         end

--- a/app/models/forms/base.rb
+++ b/app/models/forms/base.rb
@@ -53,7 +53,6 @@ module Forms
         validates "#{field_name}_details",
           presence: true,
           if: -> { public_send(field_name) == TOGGLE_YES }
-        reset attributes: ["#{field_name}_details"], if_falsey: field_name
       end
 
       def optional_checkbox(field_name, toggle = nil)

--- a/app/models/forms/base.rb
+++ b/app/models/forms/base.rb
@@ -25,7 +25,15 @@ module Forms
         end
 
         def validate(*)
-          super.tap { |valid| self.class.resettable_attributes.perform(self) if valid }
+          super.tap do |valid|
+            if valid && self.class.resettable_attributes.any?
+              self.class.resettable_attributes.perform(self, default_attribute_values)
+            end
+          end
+        end
+
+        def default_attribute_values
+          model.class.column_defaults
         end
       end
     end

--- a/spec/forms/base/resetting_attributes_spec.rb
+++ b/spec/forms/base/resetting_attributes_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe Forms::Base, "resetting attributes" do
+  let(:form) do
+    Class.new(described_class) do
+      property :foo, type: String, validates: { presence: true }
+      property :bar, type: String
+
+      reset attributes: %i[ bar ], if_falsey: :foo, enabled_value: "yes"
+
+      def self.name; "LOL"; end # form base will keel over and die without it
+    end
+  end
+
+  let(:mock_model) { double("MockModel", foo: nil, bar: nil) }
+
+  subject { form.new(mock_model) }
+
+  let(:quote) { "i like cats" }
+
+  describe "#validate" do
+    context "when the form is valid" do
+      context "when the 'if_falsey' attribute is not the expected enabled value" do
+        let(:unexpected_enabled_value) { "no" }
+
+        it "resets the attributes when" do
+          params = { foo: unexpected_enabled_value, bar: quote }
+          subject.validate(params)
+
+          expect(subject).to be_valid
+          expect(subject.bar).to be_nil
+          expect(subject.foo).to eq unexpected_enabled_value
+        end
+      end
+
+      context "when the 'if_falsey' attribute is the expected enabled value" do
+        let(:expected_enabled_value) { "yes" }
+
+        it "retains the attributes even is marked for reset" do
+          params = { foo: expected_enabled_value, bar: quote }
+          subject.validate(params)
+
+          expect(subject).to be_valid
+          expect(subject.bar).to eq quote
+          expect(subject.foo).to eq expected_enabled_value
+        end
+      end
+    end
+
+    context "when the form is invalid" do
+      let(:must_be_present) { nil }
+
+      it "doesn't reset the attributes" do
+        params = { foo: must_be_present, bar: "i like cats" }
+        subject.validate(params)
+
+        expect(subject).not_to be_valid
+        expect(subject.bar).to eq quote
+        expect(subject.foo).to eq must_be_present
+      end
+    end
+  end
+end

--- a/spec/forms/base/resetting_attributes_spec.rb
+++ b/spec/forms/base/resetting_attributes_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Forms::Base, "resetting attributes" do
       def self.name; "LOL"; end # form base will keel over and die without it
 
       def default_attribute_values
-        { foo: nil, bar: nil }
+        { foo: nil, bar: "default" }
       end
     end
   end
@@ -32,8 +32,10 @@ RSpec.describe Forms::Base, "resetting attributes" do
           subject.validate(params)
 
           expect(subject).to be_valid
-          expect(subject.bar).to be_nil
           expect(subject.foo).to eq unexpected_enabled_value
+
+          default_field_value_on_reset = "default"
+          expect(subject.bar).to eq default_field_value_on_reset
         end
       end
 

--- a/spec/forms/base/resetting_attributes_spec.rb
+++ b/spec/forms/base/resetting_attributes_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Forms::Base, "resetting attributes" do
       reset attributes: %i[ bar ], if_falsey: :foo, enabled_value: "yes"
 
       def self.name; "LOL"; end # form base will keel over and die without it
+
+      def default_attribute_values
+        { foo: nil, bar: nil }
+      end
     end
   end
 

--- a/spec/forms/base/resetting_attributes_spec.rb
+++ b/spec/forms/base/resetting_attributes_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Forms::Base, "resetting attributes" do
       let(:must_be_present) { nil }
 
       it "doesn't reset the attributes" do
-        params = { foo: must_be_present, bar: "i like cats" }
+        params = { foo: must_be_present, bar: quote }
         subject.validate(params)
 
         expect(subject).not_to be_valid


### PR DESCRIPTION
First of a few PR's to introduce resetting attribute values. Breaking down #115.

This just introduces the reset macro & tests the abstract form.
