### PR TITLE
Adds a DB backed session store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 ruby '2.3.0'
 
+gem 'activerecord-session_store'
 gem 'rails', '5.0.0'
 gem 'pg', '~> 0.18'
 gem 'puma', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,12 @@ GEM
       activemodel (= 5.0.0)
       activesupport (= 5.0.0)
       arel (~> 7.0)
+    activerecord-session_store (1.0.0)
+      actionpack (>= 4.0, < 5.1)
+      activerecord (>= 4.0, < 5.1)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0, < 5.1)
     activesupport (5.0.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
@@ -157,6 +163,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
+    multi_json (1.12.1)
     multipart-post (2.0.0)
     nio4r (1.2.1)
     nokogiri (1.6.8)
@@ -326,6 +333,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-session_store
   better_errors
   binding_of_caller
   capybara

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_moving-people-safely_session'
+Rails.application.config.session_store :active_record_store, key: '_moving-people-safely_session'

--- a/db/migrate/20160818143833_add_sessions_table.rb
+++ b/db/migrate/20160818143833_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, :unique => true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160818134016) do
+ActiveRecord::Schema.define(version: 20160818143833) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -194,6 +194,15 @@ ActiveRecord::Schema.define(version: 20160818134016) do
     t.datetime "updated_at",                                          null: false
     t.uuid     "detainee_id"
     t.index ["detainee_id"], name: "index_risks_on_detainee_id", using: :btree
+  end
+
+  create_table "sessions", force: :cascade do |t|
+    t.string   "session_id", null: false
+    t.text     "data"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true, using: :btree
+    t.index ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
We don't render on POST/PUT requests, instead we redirect the user.
In order to get access to invalid form objects on redirects when
invalid we need to access the session. A cookie isn't big enough, we
can have more than 4KB of data in some instances which will raise
a cookie overflow error. DB sessions solve this.
