### PR TITLE
Provide a custom sex offences summary presenter

### DIFF
--- a/app/presenters/summary/sex_offences_presenter.rb
+++ b/app/presenters/summary/sex_offences_presenter.rb
@@ -1,0 +1,21 @@
+module Summary
+  class SexOffencesPresenter < SummaryPresenter
+    def details_for(*)
+      "#{victim_type}. #{details}" if sex_offence_checked?
+    end
+
+    private
+
+    def sex_offence_checked?
+      public_send(:sex_offence) == 'yes'
+    end
+
+    def victim_type
+      public_send(:sex_offence_victim).humanize
+    end
+
+    def details
+      public_send(:sex_offence_details)
+    end
+  end
+end

--- a/app/views/summary/risk.html.slim
+++ b/app/views/summary/risk.html.slim
@@ -14,7 +14,7 @@
     locals: { presenter: SummaryPresenter.new(risk), section: 'harassments', questions: %w[ hostage_taker stalker harasser intimidator bully ], path: risk_path(detainee, 'harassments') }
 
   = render partial: 'summary/section',
-    locals: { presenter: SummaryPresenter.new(risk), section: 'sex_offences', questions: %w[ sex_offence ], path: risk_path(detainee, 'sex_offences') }
+    locals: { presenter: Summary::SexOffencesPresenter.new(risk), section: 'sex_offences', questions: %w[ sex_offence ], path: risk_path(detainee, 'sex_offences') }
 
   = render partial: 'summary/section',
     locals: { presenter: SummaryPresenter.new(risk), section: 'non_association_markers', questions: %w[ non_association_markers ], path: risk_path(detainee, 'non_association_markers') }

--- a/spec/presenters/summary/sex_offences_presenter_spec.rb
+++ b/spec/presenters/summary/sex_offences_presenter_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Summary::SexOffencesPresenter, type: :presenter do
+  let(:model) { instance_double(Risk, sex_offence: 'unknown') }
+  subject { described_class.new(model) }
+
+  # it already implements the answer_for method etc
+  it { is_expected.to be_a SummaryPresenter }
+
+  describe '#details_for' do
+    describe 'accepts an argument in order to appear like a regular summary presenter' do
+      it 'ignores the arg as the presenter is specific to sex offence' do
+        expect(subject.details_for('ignored')).to be_nil
+        expect(subject.details_for).to be_nil
+      end
+    end
+
+    context 'when the sex offence attribute is no' do
+      let(:model) { instance_double(Risk, sex_offence: 'no') }
+      its(:details_for) { is_expected.to be_nil }
+    end
+
+    context 'when the sex offence attribute is unknown' do
+      let(:model) { instance_double(Risk, sex_offence: 'unknown') }
+      its(:details_for) { is_expected.to be_nil }
+    end
+
+    context 'when the sex offence attribute is yes' do
+      let(:model) do
+        instance_double(
+          Risk,
+          sex_offence: 'yes',
+          sex_offence_victim: 'under_18',
+          sex_offence_details: 'Details of the crime.'
+        )
+      end
+
+      it 'returns the sex offence victim type & details' do
+        expect(subject.details_for).to eq "Under 18. Details of the crime."
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sex offences doesn't behave like there questions in the
sense that most are a toggle with a text field. Instead it
has a category and a details field(depending on the type of
category) its output on the summary needs to reflect this.
