### PR TITLE
Considerations concern

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,3 +61,6 @@ Style/PredicateName:
 
 Style/MultilineOperationIndentation:
   EnforcedStyle: indented
+
+Style/TrivialAccessors:
+  Enabled: false

--- a/app/models/concerns/considerable.rb
+++ b/app/models/concerns/considerable.rb
@@ -1,0 +1,104 @@
+module Considerable
+  extend ActiveSupport::Concern
+
+  included do
+    def children_of(field, recursive: false)
+      unless recursive
+        public_send("#{field}_children")
+      else
+        if respond_to?("#{field}_children")
+          children = public_send("#{field}_children")
+          children.reduce(children.dup) do |acc, sub_child|
+            acc.concat children_of(sub_child, recursive: true)
+          end
+        else
+          []
+        end
+      end
+    end
+
+    def on_values_for(**fields)
+      fields.each_with_object({}) { |field, obj| obj[field] = public_send "#{field}_on_values" }
+    end
+  end
+
+  class_methods do
+    def considerations
+      @considerations
+    end
+
+    def consideration(field, options)
+      @considerations ||= []
+      @considerations << field
+
+      type_options = get_type_options options.fetch(:type), field
+
+      options.merge!(type_options)
+
+      branch field, **options.slice(:values, :on_values, :child_fields)
+    end
+
+    def branch(field, values:, on_values:, child_fields: [])
+      existance_query_method = "is_#{field}_a_branch?"
+      possible_values_method = "#{field}_possible_values"
+      on_values_method = "#{field}_on_values"
+      branch_enabled_method = "#{field}_on?"
+      child_fields_method = "#{field}_children"
+
+      define_method child_fields_method do
+        child_fields
+      end
+
+      define_method existance_query_method do
+        true
+      end
+
+      define_method possible_values_method do
+        values
+      end
+
+      define_method on_values_method do
+        on_values
+      end
+
+      define_method branch_enabled_method do
+        public_send(on_values_method).include? public_send(field)
+      end
+
+      field
+    end
+
+    def details_field(field, options = {})
+      field
+    end
+
+    # TODO: standard options business
+    def boolean_and_details_field(field)
+      options = get_type_options :boolean, field
+      options[:child_fields] = [ details_field(:"#{field}_details") ]
+      branch field, **options.slice(:values, :on_values, :child_fields)
+    end
+
+    def values_and_details_field(field, options = {})
+      type_options = get_type_options options.fetch(:type), field
+      options.merge! type_options
+      branch field, **options.slice(:values, :on_values, :child_fields)
+    end
+
+    def get_type_options(type, field)
+      send("#{type}_type_options", field)
+    end
+
+    def boolean_type_options(_field)
+      { values: [true, false], on_values: [true] }
+    end
+
+    def ternary_type_options(_field)
+      { values: %w[ yes no unknown ], on_values: %w[ yes ] }
+    end
+
+    def ternary_and_details_field_type_options(field)
+      ternary_type_options(field).merge(child_fields: [ details_field(:"#{field}_details") ])
+    end
+  end
+end

--- a/app/models/concerns/considerable.rb
+++ b/app/models/concerns/considerable.rb
@@ -19,12 +19,7 @@ module Considerable
     def consideration(field, options)
       @considerations ||= []
       @considerations << field
-
-      type_options = get_type_options options.fetch(:type), field
-
-      options.merge!(type_options)
-
-      branch field, **options.slice(:values, :on_values, :child_fields)
+      branch field, **type_options(field, options)
     end
 
     def branch(field, values:, on_values:, child_fields: [])
@@ -65,20 +60,25 @@ module Considerable
     end
 
     def boolean_and_details_field(field)
-      options = get_type_options :boolean, field
-      options[:child_fields] = [details_field(:"#{field}_details")]
-      branch field, **options.slice(:values, :on_values, :child_fields)
+      options = { type: :boolean, child_fields: [details_field(:"#{field}_details")] }
+      branch field, **type_options(field, options)
     end
 
     def values_and_details_field(field, options = {})
-      type_options = get_type_options options.fetch(:type), field
-      options.merge! type_options
-      branch field, **options.slice(:values, :on_values, :child_fields)
+      branch field, **type_options(field, options)
     end
 
     private
 
-    def get_type_options(type, field)
+    def type_options(field, options)
+      if options.fetch(:type, false)
+        type_options = get_type_option_defaults options.fetch(:type), field
+        options.merge!(type_options)
+      end
+      options.slice(:values, :on_values, :child_fields)
+    end
+
+    def get_type_option_defaults(type, field)
       send("#{type}_type_options", field)
     end
 

--- a/app/models/concerns/considerable.rb
+++ b/app/models/concerns/considerable.rb
@@ -39,8 +39,7 @@ module Considerable
     end
 
     def branch(field, values:, on_values:, child_fields: [])
-      existance_query_method = "is_#{field}_a_branch?"
-      possible_values_method = "#{field}_possible_values"
+      all_values_method = "#{field}_all_values"
       on_values_method = "#{field}_on_values"
       branch_enabled_method = "#{field}_on?"
       child_fields_method = "#{field}_children"
@@ -49,11 +48,7 @@ module Considerable
         child_fields
       end
 
-      define_method existance_query_method do
-        true
-      end
-
-      define_method possible_values_method do
+      define_method all_values_method do
         values
       end
 

--- a/app/models/concerns/considerable.rb
+++ b/app/models/concerns/considerable.rb
@@ -2,8 +2,6 @@ module Considerable
   extend ActiveSupport::Concern
 
   included do
-    attr_reader :considerations
-
     def on_values_for(fields)
       fields = *fields
       fields.each_with_object({}) { |field, obj| obj[field] = public_send "#{field}_on_values" }
@@ -11,6 +9,10 @@ module Considerable
   end
 
   class_methods do
+    def considerations
+      @considerations
+    end
+
     def consideration(field, options)
       @considerations ||= []
       @considerations << field

--- a/app/models/forms/attribute_reset_collection.rb
+++ b/app/models/forms/attribute_reset_collection.rb
@@ -9,8 +9,8 @@ module Forms
 
     attr_reader :collection
 
-    def add(attributes, master_attribute, enabled_value)
-      collection << ResetData.new(attributes, master_attribute, enabled_value)
+    def add(*args)
+      collection << ResetData.new(*args)
     end
 
     def any?

--- a/app/models/forms/attribute_reset_collection.rb
+++ b/app/models/forms/attribute_reset_collection.rb
@@ -9,8 +9,8 @@ module Forms
 
     attr_reader :collection
 
-    def add(*args)
-      collection << ResetData.new(*args)
+    def add(attributes, master_attribute, enabled_value)
+      collection << ResetData.new(attributes, master_attribute, enabled_value)
     end
 
     def any?

--- a/app/models/forms/risk/arson.rb
+++ b/app/models/forms/risk/arson.rb
@@ -1,7 +1,9 @@
+require 'risk'
+
 module Forms
   module Risk
     class Arson < Forms::Base
-      ARSON_VALUES = %w[ index_offence behavioural_issue small_risk ]
+      ARSON_VALUES = ::Risk.arson_value_all_values
 
       optional_details_field :arson
       property :arson_value, type: StrictString

--- a/app/models/forms/risk/communication.rb
+++ b/app/models/forms/risk/communication.rb
@@ -5,9 +5,9 @@ module Forms
       property :language, type: StrictString
       validates :language,
         presence: true,
-        if: -> { interpreter_required == TOGGLE_YES }
+        if: -> { interpreter_required == ::Risk.interpreter_required_on_values[0] }
 
-      reset attributes: %i[ language ], if_falsey: :interpreter_required
+      reset attributes: ::Risk.children_of(:interpreter_required), if_falsey: :interpreter_required
 
       optional_details_field :hearing_speach_sight
       optional_details_field :can_read_and_write

--- a/app/models/forms/risk/harassments.rb
+++ b/app/models/forms/risk/harassments.rb
@@ -1,12 +1,11 @@
+require 'risk'
+
 module Forms
   module Risk
     class Harassments < Forms::Base
       optional_field :stalker_harasser_bully
 
-      reset attributes: %i[
-        hostage_taker hostage_taker_details stalker stalker_details harasser
-        harasser_details intimidator intimidator_details bully bully_details
-      ], if_falsey: :stalker_harasser_bully
+      reset attributes: ::Risk.stalker_harasser_bully_all_values, if_falsey: :stalker_harasser_bully
 
       optional_checkbox :hostage_taker, :stalker_harasser_bully
       optional_checkbox :stalker, :stalker_harasser_bully

--- a/app/models/forms/risk/harassments.rb
+++ b/app/models/forms/risk/harassments.rb
@@ -5,8 +5,7 @@ module Forms
     class Harassments < Forms::Base
       optional_field :stalker_harasser_bully
 
-      reset attributes: ::Risk.children_of(:stalker_harasser_bully, recursive: true),
-        if_falsey: :stalker_harasser_bully
+      reset attributes: ::Risk.children_of(:stalker_harasser_bully, recursive: true), if_falsey: :stalker_harasser_bully
 
       optional_checkbox :hostage_taker, :stalker_harasser_bully
       optional_checkbox :stalker, :stalker_harasser_bully

--- a/app/models/forms/risk/harassments.rb
+++ b/app/models/forms/risk/harassments.rb
@@ -5,7 +5,8 @@ module Forms
     class Harassments < Forms::Base
       optional_field :stalker_harasser_bully
 
-      reset attributes: ::Risk.stalker_harasser_bully_all_values, if_falsey: :stalker_harasser_bully
+      reset attributes: ::Risk.children_of(:stalker_harasser_bully, recursive: true),
+        if_falsey: :stalker_harasser_bully
 
       optional_checkbox :hostage_taker, :stalker_harasser_bully
       optional_checkbox :stalker, :stalker_harasser_bully

--- a/app/models/forms/risk/risk_from_others.rb
+++ b/app/models/forms/risk/risk_from_others.rb
@@ -7,27 +7,23 @@ module Forms
 
       concerning :CsraSection do
         included do
-          CSRA_HIGH = 'high'
-          CSRA_STANDARD = 'standard'
-          CSRA_TOGGLE_CHOICES = [CSRA_HIGH, CSRA_STANDARD, DEFAULT_CHOICE]
-
           _define_attribute_is_on(:csra, 'high')
           property(:csra, type: StrictString, default: DEFAULT_CHOICE)
           validates :csra,
-            inclusion: { in: CSRA_TOGGLE_CHOICES },
+            inclusion: { in: ::Risk.csra_all_values },
             allow_blank: true
 
           property(:csra_details, type: StrictString)
           validates :csra_details,
             presence: true,
-            if: -> { csra == CSRA_HIGH }
+            if: -> { csra == ::Risk.csra_on_values[0] }
 
-          reset attributes: %i[ csra_details ],
-                if_falsey: :csra, enabled_value: CSRA_HIGH
+          reset attributes: ::Risk.children_of(:csra),
+                if_falsey: :csra, enabled_value: ::Risk.csra_on_values[0]
         end
 
         def csra_toggle_choices
-          CSRA_TOGGLE_CHOICES
+          ::Risk.csra_all_values
         end
       end
     end

--- a/app/models/forms/risk/security.rb
+++ b/app/models/forms/risk/security.rb
@@ -1,10 +1,9 @@
 module Forms
   module Risk
     class Security < Forms::Base
-      E_RISK_VALUES = %w[ e_list_standard e_list_escort e_list_heightened ]
       optional_details_field :current_e_risk
       validates :current_e_risk_details,
-        inclusion: { in: E_RISK_VALUES },
+        inclusion: { in: ::Risk.current_e_risk_details_all_values },
         allow_blank: true
       optional_details_field :category_a
       optional_details_field :restricted_status
@@ -16,7 +15,7 @@ module Forms
         type: Axiom::Types::Boolean, default: false
 
       def e_risk_values
-        E_RISK_VALUES
+        ::Risk.current_e_risk_details_all_values
       end
     end
   end

--- a/app/models/forms/risk/sex_offences.rb
+++ b/app/models/forms/risk/sex_offences.rb
@@ -1,31 +1,28 @@
 module Forms
   module Risk
     class SexOffences < Forms::Base
-      UNDER_18 = 'under_18'
-      VICTIM_VALUES = ['adult_male', 'adult_female', UNDER_18]
-
       optional_field :sex_offence
 
-      reset attributes: %i[sex_offence_victim sex_offence_details],
+      reset attributes: ::Risk.children_of(:sex_offence),
             if_falsey: :sex_offence
 
       property :sex_offence_victim, type: StrictString
 
-      reset attributes: %i[ sex_offence_details ],
-            if_falsey: :sex_offence_victim, enabled_value: UNDER_18
+      reset attributes: ::Risk.children_of(:sex_offence_victim),
+            if_falsey: :sex_offence_victim, enabled_value: ::Risk.sex_offence_victim_on_values[0]
 
       property :sex_offence_details, type: StrictString
 
       validates :sex_offence_victim,
-        inclusion: { in: VICTIM_VALUES },
+        inclusion: { in: ::Risk.sex_offence_victim_all_values },
         allow_blank: true
 
       validates :sex_offence_details,
         presence: true,
-        if: -> { sex_offence == 'yes' && sex_offence_victim == UNDER_18 }
+        if: -> { sex_offence == 'yes' && sex_offence_victim == ::Risk.sex_offence_victim_on_values[0] }
 
       def victim_values
-        VICTIM_VALUES
+        ::Risk.sex_offence_victim_all_values
       end
     end
   end

--- a/app/models/forms/risk/violence.rb
+++ b/app/models/forms/risk/violence.rb
@@ -3,13 +3,7 @@ module Forms
     class Violence < Forms::Base
       optional_field :violent
 
-      reset attributes: %i[
-        prison_staff prison_staff_details risk_to_females risk_to_females_details
-        escort_or_court_staff escort_or_court_staff_details healthcare_staff
-        healthcare_staff_details other_detainees other_detainees_details homophobic
-        homophobic_details racist racist_details public_offence_related
-        public_offence_related_details police police_details
-      ], if_falsey: :violent
+      reset attributes: ::Risk.children_of(:violent, recursive: true), if_falsey: :violent
 
       optional_checkbox :prison_staff, :violent
       optional_checkbox :risk_to_females, :violent

--- a/app/models/risk.rb
+++ b/app/models/risk.rb
@@ -7,22 +7,6 @@ class Risk < ApplicationRecord
     self.class.considerations
   end
 
-  def self.csra_and_details_type_options(_field)
-    {
-      values: %w[ high standard unknown ],
-      on_values: %w[ high ],
-      child_fields: [ details_field(:csra_details) ]
-    }
-  end
-
-  def self.sex_offence_victim_type_options(_field)
-    {
-      values: %w[adult_male adult_female under_18],
-      on_values: %w[ under_18 ],
-      child_fields: [ details_field(:sex_offence_details) ]
-    }
-  end
-
   consideration :damage_to_property, type: :ternary_and_details_field
   consideration :non_association_markers, type: :ternary_and_details_field
   consideration :open_acct, type: :ternary
@@ -74,18 +58,19 @@ class Risk < ApplicationRecord
   ]
 
 
-  # # RiskPrintPresenter
-  #   summarize_section(:violent, {
-  #     prison_staff: true,
-  #     risk_to_females: true,
-  #     escort_or_court_staff: true,
-  #     healthcare_staff: true,
-  #     other_detainees: true,
-  #     homophobic: true,
-  #     racist: true,
-  #     public_offence_related: true,
-  #     police: true
-  #   })
+  def self.csra_and_details_type_options(_field)
+    {
+      values: %w[ high standard unknown ],
+      on_values: %w[ high ],
+      child_fields: [ details_field(:csra_details) ]
+    }
+  end
 
-
+  def self.sex_offence_victim_type_options(_field)
+    {
+      values: %w[adult_male adult_female under_18],
+      on_values: %w[ under_18 ],
+      child_fields: [ details_field(:sex_offence_details) ]
+    }
+  end
 end

--- a/app/models/risk.rb
+++ b/app/models/risk.rb
@@ -7,6 +7,22 @@ class Risk < ApplicationRecord
     self.class.considerations
   end
 
+  def self.csra_and_details_type_options(_field)
+    {
+      values: %w[ high standard unknown ],
+      on_values: %w[ high ],
+      child_fields: [ details_field(:csra_details) ]
+    }
+  end
+
+  def self.sex_offence_victim_type_options(_field)
+    {
+      values: %w[adult_male adult_female under_18],
+      on_values: %w[ under_18 ],
+      child_fields: [ details_field(:sex_offence_details) ]
+    }
+  end
+
   consideration :damage_to_property, type: :ternary_and_details_field
   consideration :non_association_markers, type: :ternary_and_details_field
   consideration :open_acct, type: :ternary
@@ -56,21 +72,4 @@ class Risk < ApplicationRecord
     details_field(:arson_value, values: %w[ index_offence behavioural_issue small_risk ]),
     details_field(:arson_details)
   ]
-
-
-  def self.csra_and_details_type_options(_field)
-    {
-      values: %w[ high standard unknown ],
-      on_values: %w[ high ],
-      child_fields: [ details_field(:csra_details) ]
-    }
-  end
-
-  def self.sex_offence_victim_type_options(_field)
-    {
-      values: %w[adult_male adult_female under_18],
-      on_values: %w[ under_18 ],
-      child_fields: [ details_field(:sex_offence_details) ]
-    }
-  end
 end

--- a/app/models/risk.rb
+++ b/app/models/risk.rb
@@ -1,16 +1,91 @@
 class Risk < ApplicationRecord
   belongs_to :detainee
   include Questionable
-
-  QUESTION_FIELDS =
-    %w[ open_acct suicide rule_45 csra verbal_abuse physical_abuse violent
-        stalker_harasser_bully sex_offence non_association_markers
-        current_e_risk category_a
-        restricted_status substance_supply substance_use conceals_weapons arson
-        damage_to_property interpreter_required hearing_speach_sight
-        can_read_and_write ]
+  include Considerable
 
   def question_fields
-    QUESTION_FIELDS
+    self.class.considerations
   end
+
+  def self.csra_and_details_type_options(_field)
+    {
+      values: %w[ high standard unknown ],
+      on_values: %w[ high ],
+      child_fields: [ details_field(:csra_details) ]
+    }
+  end
+
+  def self.sex_offence_victim_type_options(_field)
+    {
+      values: %w[adult_male adult_female under_18],
+      on_values: %w[ under_18 ],
+      child_fields: [ details_field(:sex_offence_details) ]
+    }
+  end
+
+  consideration :damage_to_property, type: :ternary_and_details_field
+  consideration :non_association_markers, type: :ternary_and_details_field
+  consideration :open_acct, type: :ternary
+  consideration :suicide, type: :ternary_and_details_field
+  consideration :rule_45, type: :ternary_and_details_field
+  consideration :csra, type: :csra_and_details
+  consideration :verbal_abuse, type: :ternary_and_details_field
+  consideration :physical_abuse, type: :ternary_and_details_field
+  consideration :current_e_risk, type: :ternary_and_details_field
+  consideration :category_a, type: :ternary_and_details_field
+  consideration :restricted_status, type: :ternary_and_details_field
+  consideration :substance_supply, type: :ternary_and_details_field
+  consideration :substance_use, type: :ternary_and_details_field
+  consideration :conceals_weapons, type: :ternary_and_details_field
+  consideration :hearing_speach_sight, type: :ternary_and_details_field
+  consideration :can_read_and_write, type: :ternary_and_details_field
+
+  consideration :stalker_harasser_bully, type: :ternary, child_fields: [
+    boolean_and_details_field(:hostage_taker),
+    boolean_and_details_field(:stalker),
+    boolean_and_details_field(:harasser),
+    boolean_and_details_field(:intimidator),
+    boolean_and_details_field(:bully)
+  ]
+
+  consideration :violent, type: :ternary, child_fields: [
+    boolean_and_details_field(:prison_staff),
+    boolean_and_details_field(:risk_to_females),
+    boolean_and_details_field(:escort_or_court_staff),
+    boolean_and_details_field(:healthcare_staff),
+    boolean_and_details_field(:other_detainees),
+    boolean_and_details_field(:homophobic),
+    boolean_and_details_field(:racist),
+    boolean_and_details_field(:public_offence_related),
+    boolean_and_details_field(:police)
+  ]
+
+  consideration :sex_offence, type: :ternary, child_fields: [
+    values_and_details_field(:sex_offence_victim, type: :sex_offence_victim)
+  ]
+
+  consideration :interpreter_required, type: :ternary, child_fields: [
+    details_field(:language)
+  ]
+
+  consideration :arson, type: :ternary, child_fields: [
+    details_field(:arson_value, values: %w[ index_offence behavioural_issue small_risk ]),
+    details_field(:arson_details)
+  ]
+
+
+  # # RiskPrintPresenter
+  #   summarize_section(:violent, {
+  #     prison_staff: true,
+  #     risk_to_females: true,
+  #     escort_or_court_staff: true,
+  #     healthcare_staff: true,
+  #     other_detainees: true,
+  #     homophobic: true,
+  #     racist: true,
+  #     public_offence_related: true,
+  #     police: true
+  #   })
+
+
 end

--- a/app/models/risk.rb
+++ b/app/models/risk.rb
@@ -31,7 +31,6 @@ class Risk < ApplicationRecord
   consideration :csra, type: :csra_and_details
   consideration :verbal_abuse, type: :ternary_and_details_field
   consideration :physical_abuse, type: :ternary_and_details_field
-  consideration :current_e_risk, type: :ternary_and_details_field
   consideration :category_a, type: :ternary_and_details_field
   consideration :restricted_status, type: :ternary_and_details_field
   consideration :substance_supply, type: :ternary_and_details_field
@@ -66,6 +65,10 @@ class Risk < ApplicationRecord
 
   consideration :interpreter_required, type: :ternary, child_fields: [
     details_field(:language)
+  ]
+
+  consideration :current_e_risk, type: :ternary, child_fields: [
+    details_field(:current_e_risk_details, values: %w[ e_list_standard e_list_escort e_list_heightened ])
   ]
 
   consideration :arson, type: :ternary, child_fields: [

--- a/app/models/risk.rb
+++ b/app/models/risk.rb
@@ -11,7 +11,7 @@ class Risk < ApplicationRecord
     {
       values: %w[ high standard unknown ],
       on_values: %w[ high ],
-      child_fields: [ details_field(:csra_details) ]
+      child_fields: [details_field(:csra_details)]
     }
   end
 
@@ -19,7 +19,7 @@ class Risk < ApplicationRecord
     {
       values: %w[adult_male adult_female under_18],
       on_values: %w[ under_18 ],
-      child_fields: [ details_field(:sex_offence_details) ]
+      child_fields: [details_field(:sex_offence_details)]
     }
   end
 

--- a/spec/models/risk_spec.rb
+++ b/spec/models/risk_spec.rb
@@ -20,6 +20,26 @@ RSpec.describe Risk, type: :model do
       end
     end
 
+    describe "#violent_on?" do
+      let(:result) { subject.violent_on? }
+
+      context "when the violent field is set to 'yes'" do
+        before { subject.violent = 'yes' }
+
+        it "returns true" do
+          expect(result).to be true
+        end
+      end
+
+      context "when the violent field is set to 'no'" do
+        before { subject.violent = 'no' }
+
+        it "returns false" do
+          expect(result).to be false
+        end
+      end
+    end
+
     describe "#on_values_for" do
       let(:result) { subject.on_values_for(field) }
 
@@ -92,6 +112,12 @@ RSpec.describe Risk, type: :model do
           homophobic_details racist racist_details public_offence_related
           public_offence_related_details police police_details
         ]
+      end
+    end
+
+    describe "./field/_on_values" do
+      it "returns an array of values" do
+        expect(subject.violent_on_values).to eql ['yes']
       end
     end
   end

--- a/spec/models/risk_spec.rb
+++ b/spec/models/risk_spec.rb
@@ -1,93 +1,98 @@
 require 'rails_helper'
 
 RSpec.describe Risk, type: :model do
-  it { is_expected.to belong_to(:detainee) }
-  it_behaves_like 'questionable'
+  describe "instance methods" do
+    subject { described_class.new }
 
-  subject { described_class.new}
+    it { is_expected.to belong_to(:detainee) }
+    it_behaves_like 'questionable'
 
-  describe "#question_fields" do
-    let(:result) { subject.question_fields }
+    describe "#question_fields" do
+      let(:result) { subject.question_fields }
 
-    it "returns all the considerations for this model instance" do
-      expect(result).to match_array %i[ open_acct suicide rule_45 csra verbal_abuse physical_abuse violent
-        stalker_harasser_bully sex_offence non_association_markers
-        current_e_risk category_a
-        restricted_status substance_supply substance_use conceals_weapons arson
-        damage_to_property interpreter_required hearing_speach_sight
-        can_read_and_write ]
-    end
-  end
-
-  describe "#children_of(:violent)" do
-    let(:result) { subject.children_of(:violent) }
-
-    it "returns all the direct child fields of the named branch" do
-      expect(result).to match_array %i[ prison_staff risk_to_females escort_or_court_staff
-        healthcare_staff other_detainees homophobic racist public_offence_related police ]
-    end
-  end
-
-  describe "#children_of(:violent, recursive: true)" do
-    let(:result) { subject.children_of(:violent, recursive: true) }
-
-    it "recursively queries all the children and childrens children etc of the named branch" do
-      expect(result).to match_array %i[
-        prison_staff prison_staff_details risk_to_females risk_to_females_details
-        escort_or_court_staff escort_or_court_staff_details healthcare_staff
-        healthcare_staff_details other_detainees other_detainees_details homophobic
-        homophobic_details racist racist_details public_offence_related
-        public_offence_related_details police police_details
-      ]
-    end
-  end
-
-  describe "#on_values_for" do
-    let(:result) { subject.on_values_for(field) }
-
-    context "ternary" do
-      let(:field) { :verbal_abuse }
-
-      it "returns the standard ternary ['yes']" do
-        expect(result).to eql verbal_abuse: ['yes']
+      it "returns all the considerations for this model instance" do
+        expect(result).to match_array %i[ open_acct suicide rule_45 csra verbal_abuse physical_abuse violent
+          stalker_harasser_bully sex_offence non_association_markers
+          current_e_risk category_a
+          restricted_status substance_supply substance_use conceals_weapons arson
+          damage_to_property interpreter_required hearing_speach_sight
+          can_read_and_write ]
       end
     end
 
-    context "boolean" do
-      let(:field) { :stalker }
+    describe "#on_values_for" do
+      let(:result) { subject.on_values_for(field) }
 
-      it "returns the standard boolean [true]" do
-        expect(result).to eql stalker: [true]
+      context "ternary" do
+        let(:field) { :verbal_abuse }
+
+        it "returns the standard ternary ['yes']" do
+          expect(result).to eql verbal_abuse: ['yes']
+        end
       end
-    end
 
-    context "csra" do
-      let(:field) { :csra }
+      context "boolean" do
+        let(:field) { :stalker }
 
-      it "returns the special CSRA case of ['high']" do
-        expect(result).to eql csra: ['high']
+        it "returns the standard boolean [true]" do
+          expect(result).to eql stalker: [true]
+        end
       end
-    end
 
-    context "sex_offence_victim" do
-      let(:field) { :sex_offence_victim }
+      context "csra" do
+        let(:field) { :csra }
 
-      it "returns the special Sex Offence case of ['under_18']" do
-        expect(result).to eql sex_offence_victim: ['under_18']
+        it "returns the special CSRA case of ['high']" do
+          expect(result).to eql csra: ['high']
+        end
       end
-    end
 
-    context "with an array of fields" do
-      let(:field) { [:current_e_risk, :hostage_taker, :sex_offence_victim] }
+      context "sex_offence_victim" do
+        let(:field) { :sex_offence_victim }
 
-      it "returns the on_values for each item in the input array" do
-        expect(result).to eql ({
-          current_e_risk: ['yes'],
-          hostage_taker: [true],
-          sex_offence_victim: ['under_18']
-        })
+        it "returns the special Sex Offence case of ['under_18']" do
+          expect(result).to eql sex_offence_victim: ['under_18']
+        end
+      end
+
+      context "with an array of fields" do
+        let(:field) { [:current_e_risk, :hostage_taker, :sex_offence_victim] }
+
+        it "returns the on_values for each item in the input array" do
+          expect(result).to eql ({
+            current_e_risk: ['yes'],
+            hostage_taker: [true],
+            sex_offence_victim: ['under_18']
+          })
+        end
       end
     end
   end
 
+  describe "class methods" do
+    subject { described_class }
+
+    describe ".children_of(:violent)" do
+      let(:result) { subject.children_of(:violent) }
+
+      it "returns all the direct child fields of the named branch" do
+        expect(result).to match_array %i[ prison_staff risk_to_females escort_or_court_staff
+          healthcare_staff other_detainees homophobic racist public_offence_related police ]
+      end
+    end
+
+    describe ".children_of(:violent, recursive: true)" do
+      let(:result) { subject.children_of(:violent, recursive: true) }
+
+      it "recursively queries all the children and childrens children etc of the named branch" do
+        expect(result).to match_array %i[
+          prison_staff prison_staff_details risk_to_females risk_to_females_details
+          escort_or_court_staff escort_or_court_staff_details healthcare_staff
+          healthcare_staff_details other_detainees other_detainees_details homophobic
+          homophobic_details racist racist_details public_offence_related
+          public_offence_related_details police police_details
+        ]
+      end
+    end
+  end
 end

--- a/spec/models/risk_spec.rb
+++ b/spec/models/risk_spec.rb
@@ -82,9 +82,9 @@ RSpec.describe Risk, type: :model do
 
       it "returns the on_values for each item in the input array" do
         expect(result).to eql ({
-          current_e_risk: 'yes',
-          hostage_taker: true,
-          sex_offence_victim: 'under_18'
+          current_e_risk: ['yes'],
+          hostage_taker: [true],
+          sex_offence_victim: ['under_18']
         })
       end
     end

--- a/spec/models/risk_spec.rb
+++ b/spec/models/risk_spec.rb
@@ -3,4 +3,91 @@ require 'rails_helper'
 RSpec.describe Risk, type: :model do
   it { is_expected.to belong_to(:detainee) }
   it_behaves_like 'questionable'
+
+  subject { described_class.new}
+
+  describe "#question_fields" do
+    let(:result) { subject.question_fields }
+
+    it "returns all the considerations for this model instance" do
+      expect(result).to match_array %i[ open_acct suicide rule_45 csra verbal_abuse physical_abuse violent
+        stalker_harasser_bully sex_offence non_association_markers
+        current_e_risk category_a
+        restricted_status substance_supply substance_use conceals_weapons arson
+        damage_to_property interpreter_required hearing_speach_sight
+        can_read_and_write ]
+    end
+  end
+
+  describe "#children_of(:violent)" do
+    let(:result) { subject.children_of(:violent) }
+
+    it "returns all the direct child fields of the named branch" do
+      expect(result).to match_array %i[ prison_staff risk_to_females escort_or_court_staff
+        healthcare_staff other_detainees homophobic racist public_offence_related police ]
+    end
+  end
+
+  describe "#children_of(:violent, recursive: true)" do
+    let(:result) { subject.children_of(:violent, recursive: true) }
+
+    it "recursively queries all the children and childrens children etc of the named branch" do
+      expect(result).to match_array %i[
+        prison_staff prison_staff_details risk_to_females risk_to_females_details
+        escort_or_court_staff escort_or_court_staff_details healthcare_staff
+        healthcare_staff_details other_detainees other_detainees_details homophobic
+        homophobic_details racist racist_details public_offence_related
+        public_offence_related_details police police_details
+      ]
+    end
+  end
+
+  describe "#on_values_for" do
+    let(:result) { subject.on_values_for(field) }
+
+    context "ternary" do
+      let(:field) { :verbal_abuse }
+
+      it "returns the standard ternary ['yes']" do
+        expect(result).to eql verbal_abuse: ['yes']
+      end
+    end
+
+    context "boolean" do
+      let(:field) { :stalker }
+
+      it "returns the standard boolean [true]" do
+        expect(result).to eql stalker: [true]
+      end
+    end
+
+    context "csra" do
+      let(:field) { :csra }
+
+      it "returns the special CSRA case of ['high']" do
+        expect(result).to eql csra: ['high']
+      end
+    end
+
+    context "sex_offence_victim" do
+      let(:field) { :sex_offence_victim }
+
+      it "returns the special Sex Offence case of ['under_18']" do
+        expect(result).to eql sex_offence_victim: ['under_18']
+      end
+    end
+
+    context "with an array of fields" do
+      let(:field) { [:current_e_risk, :hostage_taker, :sex_offence_victim] }
+
+      it "returns the on_values for each item in the input array" do
+        expect(result).to eql ({
+          current_e_risk: 'yes',
+          hostage_taker: true,
+          sex_offence_victim: 'under_18'
+        })
+      end
+    end
+  end
+
 end

--- a/spec/support/matchers/validate_attribute_reset_configuration.rb
+++ b/spec/support/matchers/validate_attribute_reset_configuration.rb
@@ -40,8 +40,12 @@ class ValidateAttributeResetConfiguration
   end
 
   def has_configuration
-    resettable_attributes.any? { |i| i.values == expected_as_tuple } ||
+    resettable_attributes.any? { |i| compare_tuples(i.values, expected_as_tuple ) } ||
       set_error(missing_configuration_error_text)
+  end
+
+  def compare_tuples(this, that)
+    this.each_with_index.any? { |el, i| el == that[i] }
   end
 
   def subject_has_reader_method_for_master_attribute


### PR DESCRIPTION
introduces Considerations to the model layer. The intent here is to move information about model semantics out of the form layer, so it is queryable and reusable. The short-term goal of this is to reduce duplication of this info across the codebase. Longer term, it is hoped this will make it easier to reason about the relationships between schema fields. 
