### PR TITLE
Super-basic analytics framework using exported logs and Kibana

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,10 @@ gem 'reform-rails'
 gem 'virtus'
 gem 'wicked'
 
+group :production do
+  gem 'logstasher'
+end
+
 group :development, :test do
   gem 'factory_girl_rails'
   gem 'faker'

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'virtus'
 gem 'wicked'
 
 group :production do
-  gem 'logstasher'
+  gem 'logstasher', github: 'shadabahmed/logstasher', ref: '4b19d78d6d043c042fa6c17d3980702015e8645f'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,12 @@ GEM
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    logstash-event (1.2.02)
+    logstasher (1.0.1)
+      activerecord (>= 4.0)
+      activesupport (>= 4.0)
+      logstash-event (~> 1.2.0)
+      request_store
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -227,6 +233,7 @@ GEM
     representable (3.0.0)
       declarative (~> 0.0.5)
       uber (~> 0.0.15)
+    request_store (1.3.1)
     responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
     rspec-core (3.5.0)
@@ -352,6 +359,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   listen (~> 3.0.5)
+  logstasher
   meta_request
   pg (~> 0.18)
   pry-byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,15 @@
 GIT
+  remote: git://github.com/shadabahmed/logstasher.git
+  revision: 4b19d78d6d043c042fa6c17d3980702015e8645f
+  ref: 4b19d78d6d043c042fa6c17d3980702015e8645f
+  specs:
+    logstasher (1.0.1)
+      activerecord (>= 4.0)
+      activesupport (>= 4.0)
+      logstash-event (~> 1.2.0)
+      request_store
+
+GIT
   remote: https://github.com/ministryofjustice/govuk_elements_form_builder.git
   revision: a27071223a9ab2338dd69b357c88365c902a6fdf
   specs:
@@ -150,11 +161,6 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     logstash-event (1.2.02)
-    logstasher (1.0.1)
-      activerecord (>= 4.0)
-      activesupport (>= 4.0)
-      logstash-event (~> 1.2.0)
-      request_store
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -359,7 +365,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   listen (~> 3.0.5)
-  logstasher
+  logstasher!
   meta_request
   pg (~> 0.18)
   pry-byebug

--- a/app/services/analytics_event.rb
+++ b/app/services/analytics_event.rb
@@ -1,13 +1,8 @@
 class AnalyticsEvent
   def self.publish(event, **params)
     instrumentation_class = instrumentation_class_from_params(params)
-    instrumentation_class.instrument(event, **params)
-  end
-
-  def self.publish_with_timings(event, **params)
-    instrumentation_class = instrumentation_class_from_params(params)
     instrumentation_class.instrument(event, **params) do
-      yield
+      yield if block_given?
     end
   end
 

--- a/app/services/analytics_event.rb
+++ b/app/services/analytics_event.rb
@@ -1,0 +1,19 @@
+class AnalyticsEvent
+  def self.publish(event, **params)
+    instrumentation_class = instrumentation_class_from_params(params)
+    instrumentation_class.instrument(event, **params)
+  end
+
+  def self.publish_with_timings(event, **params)
+    instrumentation_class = instrumentation_class_from_params(params)
+    instrumentation_class.instrument(event, **params) do
+      yield
+    end
+  end
+
+  private
+
+  def self.instrumentation_class_from_params(params)
+    params.delete(:instrumentation_class) { |_| ActiveSupport::Notifications }
+  end
+end

--- a/app/services/analytics_event.rb
+++ b/app/services/analytics_event.rb
@@ -11,8 +11,6 @@ class AnalyticsEvent
     end
   end
 
-  private
-
   def self.instrumentation_class_from_params(params)
     params.delete(:instrumentation_class) { |_| ActiveSupport::Notifications }
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,18 +44,10 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  config.log_level = :debug
-  config.log_tags = [ :request_id ]
-  config.log_formatter = ::Logger::Formatter.new
-  config.logstasher.enabled = false
-
-  # this is only going to happen when we are in a docker environment
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    config.logstasher.enabled = true
-    config.logstasher.suppress_app_log = true
-    config.logstasher.log_level = Logger::INFO
-    config.logstasher.logger_path = STDOUT
-  end
+  config.logstasher.enabled = true
+  config.logstasher.suppress_app_log = true
+  config.logstasher.log_level = Logger::INFO
+  config.logstasher.logger_path = STDOUT
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,12 +44,18 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
   config.log_level = :debug
-
-  # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
+  config.log_formatter = ::Logger::Formatter.new
+  config.logstasher.enabled = false
+
+  # this is only going to happen when we are in a docker environment
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    config.logstasher.enabled = true
+    config.logstasher.suppress_app_log = true
+    config.logstasher.log_level = Logger::INFO
+    config.logstasher.logger_path = STDOUT
+  end
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -69,19 +75,6 @@ Rails.application.configure do
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
-
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
-  # Use a different logger for distributed setups.
-  # require 'syslog/logger'
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger = ActiveSupport::TaggedLogging.new(logger)
-  end
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false

--- a/spec/services/analytics_event_spec.rb
+++ b/spec/services/analytics_event_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe AnalyticsEvent do
+  subject { described_class }
+  let(:instrumentation_class) { double(:notifications) }
+
+  describe ".publish" do
+    it "pushes the event to the instrumentation class" do
+      expect(instrumentation_class).to receive(:instrument).with(:event, params: :hash)
+      subject.publish(:event, params: :hash, instrumentation_class: instrumentation_class)
+    end
+  end
+
+  describe ".publish_with_timings" do
+    it "pushes the event to the instrumentation class, yielding a block" do
+      proc = Proc.new { :proc }
+      expect(instrumentation_class).to receive(:instrument).with(:event, params: :hash, &proc)
+      subject.publish_with_timings(:event, params: :hash, instrumentation_class: instrumentation_class) do
+        proc
+      end
+    end
+  end
+end

--- a/spec/services/analytics_event_spec.rb
+++ b/spec/services/analytics_event_spec.rb
@@ -7,14 +7,11 @@ RSpec.describe AnalyticsEvent do
       expect(instrumentation_class).to receive(:instrument).with(:event, params: :hash)
       subject.publish(:event, params: :hash, instrumentation_class: instrumentation_class)
     end
-  end
 
-  describe ".publish_with_timings" do
-    it "pushes the event to the instrumentation class, yielding a block" do
-      proc = Proc.new { :proc }
-      expect(instrumentation_class).to receive(:instrument).with(:event, params: :hash, &proc)
-      subject.publish_with_timings(:event, params: :hash, instrumentation_class: instrumentation_class) do
-        proc
+    it "yields a block if given" do
+      expect(instrumentation_class).to receive(:instrument).and_yield
+      subject.publish(:event, instrumentation_class: instrumentation_class) do
+        :block
       end
     end
   end


### PR DESCRIPTION
Introduces LogStash, which replaces the Rails logger with an Elastic Stack compatible JSON implementation. The plan is to use ELK to retrieve basic low-volume behavioural analytics via the included AnalyticsEvent publisher. 

The current release of the LogStasher gem is slightly behind master and there's a needed bugfix in the main trunk, so I've had to pin the gem to the commit at master/HEAD as of today. Once the LogStash gem moves beyond release 1.0.1 this can be dropped.
