### PR TITLE
Fix minor deprecation warning related with Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,3 +61,9 @@ Style/PredicateName:
 
 Style/MultilineOperationIndentation:
   EnforcedStyle: indented
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/IndentArray:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ group :development do
   gem 'binding_of_caller'
   gem 'listen', '~> 3.0.5'
   gem 'meta_request'
-  gem 'rubocop', '~> 0.35.1', require: false
+  gem 'rubocop', '~> 0.45.0', require: false
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,8 +65,6 @@ GEM
     addressable (2.4.0)
     arel (7.1.2)
     ast (2.3.0)
-    astrolabe (1.3.1)
-      parser (~> 2.2)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -182,7 +180,7 @@ GEM
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
     orm_adapter (0.5.0)
-    parser (2.3.1.2)
+    parser (2.3.1.4)
       ast (~> 2.2)
     pg (0.18.4)
     phantomjs (2.1.1.0)
@@ -262,13 +260,12 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.35.1)
-      astrolabe (~> 1.3)
-      parser (>= 2.2.3.0, < 3.0)
+    rubocop (0.45.0)
+      parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
-      tins (<= 1.6.0)
+      unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
     rubyzip (1.2.0)
     safe_yaml (1.0.4)
@@ -316,12 +313,12 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
-    tins (1.6.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uber (0.0.15)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
+    unicode-display_width (1.1.1)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -376,7 +373,7 @@ DEPENDENCIES
   reform-rails
   rspec-its
   rspec-rails
-  rubocop (~> 0.35.1)
+  rubocop (~> 0.45.0)
   sass-rails (~> 5.0)
   selenium-webdriver
   shoulda-matchers
@@ -393,4 +390,4 @@ RUBY VERSION
    ruby 2.3.0p0
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/app/controllers/detainee_details_controller.rb
+++ b/app/controllers/detainee_details_controller.rb
@@ -1,5 +1,5 @@
 class DetaineeDetailsController < DetaineeController
-  skip_before_action :redirect_unless_document_editable, only: %i[ new create ]
+  skip_before_action :redirect_unless_document_editable, only: %i[new create]
 
   def new
     form = Forms::DetaineeDetails.new(Detainee.new(prison_number: params[:prison_number]))

--- a/app/controllers/healthcare_controller.rb
+++ b/app/controllers/healthcare_controller.rb
@@ -28,7 +28,7 @@ class HealthcareController < DetaineeController
   end
 
   def confirm
-    fail unless healthcare.all_questions_answered?
+    raise unless healthcare.all_questions_answered?
     healthcare_workflow.confirm_with_user!(user: current_user)
     redirect_to profile_path(active_move)
   end

--- a/app/controllers/move_controller.rb
+++ b/app/controllers/move_controller.rb
@@ -4,7 +4,7 @@ class MoveController < ApplicationController
   def move
     @_move ||= Move.find(params[:move_id])
   end
-  alias_method :active_move, :move
+  alias active_move move
 
   def detainee
     move.detainee

--- a/app/controllers/risks_controller.rb
+++ b/app/controllers/risks_controller.rb
@@ -29,7 +29,7 @@ class RisksController < DetaineeController
 
   # what does error state look like?
   def confirm
-    fail unless risk.all_questions_answered?
+    raise unless risk.all_questions_answered?
     risk_workflow.confirm_with_user!(user: current_user)
     redirect_to profile_path(active_move)
   end

--- a/app/models/concerns/questionable.rb
+++ b/app/models/concerns/questionable.rb
@@ -9,7 +9,7 @@ module Questionable
 
   def questions_answered_yes
     question_fields.count do |question|
-      %w[ yes high ].include?(public_send(question))
+      %w[yes high].include?(public_send(question))
     end
   end
 

--- a/app/models/concerns/questionable.rb
+++ b/app/models/concerns/questionable.rb
@@ -1,6 +1,6 @@
 module Questionable
   def all_questions_answered?
-    questions_not_answered == 0
+    questions_not_answered.zero?
   end
 
   def no_questions_answered?

--- a/app/models/date_picker.rb
+++ b/app/models/date_picker.rb
@@ -1,5 +1,5 @@
 class DatePicker
-  FORMAT = '%d/%m/%Y'
+  FORMAT = '%d/%m/%Y'.freeze
 
   def initialize(date_from_session)
     if date_from_session.present?

--- a/app/models/forms/detainee_details.rb
+++ b/app/models/forms/detainee_details.rb
@@ -1,6 +1,6 @@
 module Forms
   class DetaineeDetails < Forms::Base
-    GENDERS = %w[male female]
+    GENDERS = %w[male female].freeze
 
     property :prison_number, type: StrictString
     property :surname,       type: StrictString

--- a/app/models/forms/detainee_details.rb
+++ b/app/models/forms/detainee_details.rb
@@ -1,6 +1,6 @@
 module Forms
   class DetaineeDetails < Forms::Base
-    GENDERS = %w[ male female ]
+    GENDERS = %w[male female]
 
     property :prison_number, type: StrictString
     property :surname,       type: StrictString

--- a/app/models/forms/healthcare/medication.rb
+++ b/app/models/forms/healthcare/medication.rb
@@ -1,7 +1,7 @@
 module Forms
   module Healthcare
     class Medication < Forms::Base
-      CARRIER_VALUES = %w[ escort detainee ]
+      CARRIER_VALUES = %w[escort detainee]
 
       property :description,    type: StrictString
       property :administration, type: StrictString

--- a/app/models/forms/healthcare/medication.rb
+++ b/app/models/forms/healthcare/medication.rb
@@ -1,7 +1,7 @@
 module Forms
   module Healthcare
     class Medication < Forms::Base
-      CARRIER_VALUES = %w[escort detainee]
+      CARRIER_VALUES = %w[escort detainee].freeze
 
       property :description,    type: StrictString
       property :administration, type: StrictString

--- a/app/models/forms/moves/destination.rb
+++ b/app/models/forms/moves/destination.rb
@@ -1,7 +1,7 @@
 module Forms
   module Moves
     class Destination < Forms::Base
-      MUST_RETURN_VALUES = %w[must_return must_not_return unknown]
+      MUST_RETURN_VALUES = %w[must_return must_not_return unknown].freeze
 
       property :establishment, type: StrictString
       property :must_return,   type: StrictString, default: 'unknown'

--- a/app/models/forms/moves/destination.rb
+++ b/app/models/forms/moves/destination.rb
@@ -1,7 +1,7 @@
 module Forms
   module Moves
     class Destination < Forms::Base
-      MUST_RETURN_VALUES = %w[ must_return must_not_return unknown ]
+      MUST_RETURN_VALUES = %w[must_return must_not_return unknown]
 
       property :establishment, type: StrictString
       property :must_return,   type: StrictString, default: 'unknown'

--- a/app/models/forms/moves/information.rb
+++ b/app/models/forms/moves/information.rb
@@ -6,7 +6,7 @@ module Forms
         production_to_court
         police_production
         other
-      ]
+      ].freeze
 
       property :from,             type: StrictString, default: 'HMP Bedford'
       property :to,               type: StrictString

--- a/app/models/forms/risk/arson.rb
+++ b/app/models/forms/risk/arson.rb
@@ -1,7 +1,7 @@
 module Forms
   module Risk
     class Arson < Forms::Base
-      ARSON_VALUES = %w[index_offence behavioural_issue small_risk]
+      ARSON_VALUES = %w[index_offence behavioural_issue small_risk].freeze
 
       optional_details_field :arson
       property :arson_value, type: StrictString

--- a/app/models/forms/risk/arson.rb
+++ b/app/models/forms/risk/arson.rb
@@ -1,7 +1,7 @@
 module Forms
   module Risk
     class Arson < Forms::Base
-      ARSON_VALUES = %w[ index_offence behavioural_issue small_risk ]
+      ARSON_VALUES = %w[index_offence behavioural_issue small_risk]
 
       optional_details_field :arson
       property :arson_value, type: StrictString

--- a/app/models/forms/risk/communication.rb
+++ b/app/models/forms/risk/communication.rb
@@ -7,7 +7,7 @@ module Forms
         presence: true,
         if: -> { interpreter_required == TOGGLE_YES }
 
-      reset attributes: %i[ language ], if_falsey: :interpreter_required
+      reset attributes: %i[language], if_falsey: :interpreter_required
 
       optional_details_field :hearing_speach_sight
       optional_details_field :can_read_and_write

--- a/app/models/forms/risk/risk_from_others.rb
+++ b/app/models/forms/risk/risk_from_others.rb
@@ -7,9 +7,9 @@ module Forms
 
       concerning :CsraSection do
         included do
-          CSRA_HIGH = 'high'
-          CSRA_STANDARD = 'standard'
-          CSRA_TOGGLE_CHOICES = [CSRA_HIGH, CSRA_STANDARD, DEFAULT_CHOICE]
+          CSRA_HIGH = 'high'.freeze
+          CSRA_STANDARD = 'standard'.freeze
+          CSRA_TOGGLE_CHOICES = [CSRA_HIGH, CSRA_STANDARD, DEFAULT_CHOICE].freeze
 
           _define_attribute_is_on(:csra, 'high')
           property(:csra, type: StrictString, default: DEFAULT_CHOICE)

--- a/app/models/forms/risk/risk_from_others.rb
+++ b/app/models/forms/risk/risk_from_others.rb
@@ -22,7 +22,7 @@ module Forms
             presence: true,
             if: -> { csra == CSRA_HIGH }
 
-          reset attributes: %i[ csra_details ],
+          reset attributes: %i[csra_details],
                 if_falsey: :csra, enabled_value: CSRA_HIGH
         end
 

--- a/app/models/forms/risk/security.rb
+++ b/app/models/forms/risk/security.rb
@@ -1,7 +1,7 @@
 module Forms
   module Risk
     class Security < Forms::Base
-      E_RISK_VALUES = %w[ e_list_standard e_list_escort e_list_heightened ]
+      E_RISK_VALUES = %w[e_list_standard e_list_escort e_list_heightened]
       optional_details_field :current_e_risk
       validates :current_e_risk_details,
         inclusion: { in: E_RISK_VALUES },

--- a/app/models/forms/risk/security.rb
+++ b/app/models/forms/risk/security.rb
@@ -1,7 +1,7 @@
 module Forms
   module Risk
     class Security < Forms::Base
-      E_RISK_VALUES = %w[e_list_standard e_list_escort e_list_heightened]
+      E_RISK_VALUES = %w[e_list_standard e_list_escort e_list_heightened].freeze
       optional_details_field :current_e_risk
       validates :current_e_risk_details,
         inclusion: { in: E_RISK_VALUES },

--- a/app/models/forms/risk/sex_offences.rb
+++ b/app/models/forms/risk/sex_offences.rb
@@ -1,8 +1,8 @@
 module Forms
   module Risk
     class SexOffences < Forms::Base
-      UNDER_18 = 'under_18'
-      VICTIM_VALUES = ['adult_male', 'adult_female', UNDER_18]
+      UNDER_18 = 'under_18'.freeze
+      VICTIM_VALUES = ['adult_male', 'adult_female', UNDER_18].freeze
 
       optional_field :sex_offence
 

--- a/app/models/forms/risk/sex_offences.rb
+++ b/app/models/forms/risk/sex_offences.rb
@@ -11,7 +11,7 @@ module Forms
 
       property :sex_offence_victim, type: StrictString
 
-      reset attributes: %i[ sex_offence_details ],
+      reset attributes: %i[sex_offence_details],
             if_falsey: :sex_offence_victim, enabled_value: UNDER_18
 
       property :sex_offence_details, type: StrictString

--- a/app/models/healthcare.rb
+++ b/app/models/healthcare.rb
@@ -4,7 +4,7 @@ class Healthcare < ApplicationRecord
 
   QUESTION_FIELDS =
     %w[ physical_issues mental_illness phobias personal_hygiene
-        personal_care allergies dependencies has_medications mpv ]
+        personal_care allergies dependencies has_medications mpv ].freeze
 
   has_many :medications, dependent: :destroy
 

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -12,7 +12,8 @@ class Move < ApplicationRecord
       order(created_at: :desc).
       eager_load(
         :detainee,
-        :workflow)
+        :workflow
+      )
   end)
 
   scope :active, -> { joins(:workflow).merge(Workflow.not_issued) }

--- a/app/models/risk.rb
+++ b/app/models/risk.rb
@@ -8,7 +8,7 @@ class Risk < ApplicationRecord
         current_e_risk category_a
         restricted_status substance_supply substance_use conceals_weapons arson
         damage_to_property interpreter_required hearing_speach_sight
-        can_read_and_write ]
+        can_read_and_write ].freeze
 
   def question_fields
     QUESTION_FIELDS

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -11,7 +11,7 @@ class Workflow < ApplicationRecord
     unconfirmed: 3,
     confirmed: 4,
     issued: 5
-  }
+  }.freeze
 
   enum status: WORKFLOW_STATES
 

--- a/app/presenters/dashboard_presenter.rb
+++ b/app/presenters/dashboard_presenter.rb
@@ -11,7 +11,7 @@ class DashboardPresenter
   end
 
   def render_risk_indicator
-    if count_of_incomplete_risk == 0
+    if count_of_incomplete_risk.zero?
       cl = 'risk complete'
       title = 'Risk completed'
     else
@@ -23,7 +23,7 @@ class DashboardPresenter
   end
 
   def render_health_indicator
-    if count_of_incomplete_healthcare == 0
+    if count_of_incomplete_healthcare.zero?
       cl = 'healthcare complete'
       title = 'Health completed'
     else
@@ -35,7 +35,7 @@ class DashboardPresenter
   end
 
   def render_offences_indicator
-    if count_of_incomplete_offences == 0
+    if count_of_incomplete_offences.zero?
       cl = 'offences complete'
       title = 'Offences completed'
     else

--- a/lib/nomis/models/details.rb
+++ b/lib/nomis/models/details.rb
@@ -18,7 +18,7 @@ module Nomis
     attribute :working_name,    Boolean
     attribute :agency_location, String
 
-    %i[ forenames surname ].each do |attr|
+    %i[forenames surname].each do |attr|
       attribute attr, String
       define_method(attr) { super()&.strip.humanize }
     end

--- a/lib/nomis/models/details.rb
+++ b/lib/nomis/models/details.rb
@@ -23,7 +23,7 @@ module Nomis
       define_method(attr) { super()&.strip.humanize }
     end
 
-    alias_method :current?, :working_name
+    alias current? working_name
 
     def nationalities
       super.presence &&

--- a/lib/tasks/features_runner.rake
+++ b/lib/tasks/features_runner.rake
@@ -1,4 +1,4 @@
-if %w[ development test ].include? Rails.env
+if %w[development test].include? Rails.env
   require 'rspec/core/rake_task'
 
   namespace :features do

--- a/lib/tasks/jasmine_runner.rake
+++ b/lib/tasks/jasmine_runner.rake
@@ -1,3 +1,3 @@
-if %w[ development test ].include? Rails.env
+if %w[development test].include? Rails.env
   task(:default).prerequisites << task('jasmine:ci')
 end

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,4 +1,4 @@
-if %w[ development test ].include? Rails.env
+if %w[development test].include? Rails.env
   require 'rubocop/rake_task'
   RuboCop::RakeTask.new
 


### PR DESCRIPTION
Whenever running a `rake` command a deprecation warning is currently being displayed:

```bash
> bundle exec rake -vT
[DEPRECATION] `last_comment` is deprecated.  Please use `last_description` instead.
rake about                              # List versions of all Rails frameworks and the environment
```

The offending gem causing this issue seems to be `rubocop` as mentioned in the [following post](https://codedump.io/share/j6nZB0MLIIlA/1/how-to-detect-what-causes-a-deprecation-warning-in-rake)

This updates the gem (which consequently) solves the deprecation warning. 

Due to the nature of the update, I **had to fix some of the new Rubocop offences**. I've intentionally left some of them disabled (for now) as they need a little bit more look into.