### PR TITLE
OS related ignores should be configured in the global git ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,3 @@
 
 # Ignore test artifacts
 /spec/examples.txt
-
-# OMG OSX
-.DS_Store


### PR DESCRIPTION
Self descriptive.

`~/.gitignore_global` should be updated in the developments machine, rather than making this changes in every single repo.