### PR TITLE
Fix bug in 'Other' reason for move details

### DIFF
--- a/app/form_builders/mps_form_builder.rb
+++ b/app/form_builders/mps_form_builder.rb
@@ -1,5 +1,5 @@
 class MpsFormBuilder < GovukElementsFormBuilder::FormBuilder
-  def radio_toggle(attribute, attribute_with_error = nil, choices = nil, &_blk)
+  def radio_toggle(attribute, attribute_with_error = nil, choices = nil, options = {}, &_blk)
     style = 'optional-section-wrapper'
     style << ' mps-hide' unless object.public_send("#{attribute}_on?")
     style << ' panel panel-border-narrow' unless error_for? attribute_with_error
@@ -9,16 +9,16 @@ class MpsFormBuilder < GovukElementsFormBuilder::FormBuilder
       safe_join([
         content_tag(:div, class: 'controls-optional-section') do
           radio_button_fieldset attribute,
-            choices: choices, inline: true
+            choices: choices, inline: options.fetch(:inline_choices, true)
         end,
         (content_tag(:div, class: style) { yield } if block_given?)
       ])
     end
   end
 
-  def radio_toggle_with_textarea(attribute)
+  def radio_toggle_with_textarea(attribute, options = {})
     attribute_details = :"#{attribute}_details"
-    radio_toggle(attribute, attribute_details) do
+    radio_toggle(attribute, attribute_details, options[:choices], options) do
       text_area_without_label attribute_details
     end
   end

--- a/app/models/forms/base.rb
+++ b/app/models/forms/base.rb
@@ -48,11 +48,11 @@ module Forms
         instance_methods.include?(method_name)
       end
 
-      def optional_field(field_name)
-        _define_attribute_is_on(field_name, TOGGLE_YES)
-        property(field_name, type: String)
+      def optional_field(field_name, options = {})
+        _define_attribute_is_on(field_name, options.fetch(:option_with_details, TOGGLE_YES))
+        property(field_name, type: options.fetch(:type, String))
         validates field_name,
-          inclusion: { in: TOGGLE_CHOICES },
+          inclusion: { in: options.fetch(:options, TOGGLE_CHOICES) },
           allow_blank: true
       end
 
@@ -63,6 +63,18 @@ module Forms
           presence: true,
           if: -> { public_send(field_name) == TOGGLE_YES }
         reset attributes: ["#{field_name}_details"], if_falsey: field_name
+      end
+
+      def property_with_details(field_name, options = {})
+        optional_field(field_name, options)
+        property("#{field_name}_details", type: StrictString)
+        option_with_details = options.fetch(:option_with_details, TOGGLE_YES)
+        validates "#{field_name}_details",
+          presence: true,
+          if: -> { public_send(field_name) == option_with_details }
+        reset attributes: ["#{field_name}_details"],
+          if_falsey: field_name,
+          enabled_value: option_with_details
       end
 
       def optional_checkbox(field_name, toggle = nil)

--- a/app/models/forms/moves/information.rb
+++ b/app/models/forms/moves/information.rb
@@ -12,25 +12,15 @@ module Forms
       property :to,               type: StrictString
       property :date,             type: TextDate
 
-      _define_attribute_is_on(:reason, REASON_WITH_DETAILS)
-      property :reason, type: StrictString
-      property :reason_details, type: StrictString
+      property_with_details :reason,
+        type: StrictString,
+        options: REASONS,
+        option_with_details: REASON_WITH_DETAILS
 
       optional_field :has_destinations
       prepopulated_collection :destinations
 
       delegate :persisted?, to: :model
-
-      validates :reason,
-        inclusion: { in: REASONS },
-        allow_blank: true
-
-      validates :reason_details,
-        presence: true,
-        if: -> { reason == REASON_WITH_DETAILS }
-      reset attributes: [:reason_details],
-            if_falsey: :reason,
-            enabled_value: REASON_WITH_DETAILS
 
       validate :validate_date
 

--- a/app/models/forms/moves/information.rb
+++ b/app/models/forms/moves/information.rb
@@ -1,18 +1,20 @@
 module Forms
   module Moves
     class Information < Forms::Base
-      REASONS = %w[
+      REASON_WITH_DETAILS = 'other'.freeze
+      REASONS = (%w[
         discharge_to_court
         production_to_court
         police_production
-        other
-      ].freeze
+      ] + [REASON_WITH_DETAILS]).freeze
 
       property :from,             type: StrictString, default: 'HMP Bedford'
       property :to,               type: StrictString
       property :date,             type: TextDate
-      property :reason,           type: StrictString
-      property :reason_details,   type: StrictString
+
+      _define_attribute_is_on(:reason, REASON_WITH_DETAILS)
+      property :reason, type: StrictString
+      property :reason_details, type: StrictString
 
       optional_field :has_destinations
       prepopulated_collection :destinations
@@ -25,7 +27,10 @@ module Forms
 
       validates :reason_details,
         presence: true,
-        if: -> { reason == 'other' }
+        if: -> { reason == REASON_WITH_DETAILS }
+      reset attributes: [:reason_details],
+            if_falsey: :reason,
+            enabled_value: REASON_WITH_DETAILS
 
       validate :validate_date
 

--- a/app/views/move_information/show.slim
+++ b/app/views/move_information/show.slim
@@ -9,13 +9,7 @@
     = f.text_field :from
     = f.text_field :to
     = f.text_field :date
-
-    .js-show-hide
-      .form-group.controls-optional-section
-        = f.radio_button_fieldset :reason,
-          choices: form.reasons
-      .form-group.panel.panel-border-narrow.optional-section-wrapper
-        = f.text_area :reason_details
+    = f.radio_toggle_with_textarea :reason, choices: form.reasons, inline_choices: false
 
     .multiple
       = f.radio_toggle :has_destinations do


### PR DESCRIPTION
[Trello](https://trello.com/c/HhYONuZc/338-bug-when-selecting-other-in-reason-for-move-in-move-details-page-it-shouldn-t-display-reason-details-above-give-details): When selecting 'Other' in Reason for move in Move details page it shouldn't display 'Reason details' above 'Give details'