### PR TITLE
Makes ACCT status field not mandatory in risk to self form

### DIFF
--- a/app/models/forms/risk/risk_to_self.rb
+++ b/app/models/forms/risk/risk_to_self.rb
@@ -8,7 +8,7 @@ module Forms
         type: StrictString,
         options: ACCT_STATUSES,
         option_with_details: ACCT_STATUS_WITH_DETAILS,
-        allow_blank: false
+        allow_blank: true
 
       property :date_of_most_recently_closed_acct, type: TextDate
       reset attributes: %i[date_of_most_recently_closed_acct],

--- a/spec/forms/risk/risk_to_self_spec.rb
+++ b/spec/forms/risk/risk_to_self_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe Forms::Risk::RiskToSelf, type: :form do
   }
 
   describe '#validate' do
+    specify { is_expected.to validate_inclusion_of(:acct_status).in_array(%w(open post_closure closed_in_last_6_months not_available)) }
+
+    context 'when ACCT status is empty' do
+      specify { expect(form.validate(acct_status: nil)).to be_truthy }
+      specify { expect(form.validate(acct_status: '')).to be_truthy }
+    end
+
     context 'when ACCT status requires additional details' do
       let(:params) {
         {


### PR DESCRIPTION
[Trello #408](https://trello.com/c/F1SEt0i4/408-bug-save-and-view-profile-control-on-risk-to-self-question-in-risk-section-should-not-force-an-error)

When answering Risk to Self question for the first time, a user should be able to view the Risk to Self question without answering question and then saving page and viewing profile