### PR TITLE
Split risk of hostage taking into new section

### DIFF
--- a/app/form_builders/mps_form_builder.rb
+++ b/app/form_builders/mps_form_builder.rb
@@ -75,12 +75,15 @@ class MpsFormBuilder < GovukElementsFormBuilder::FormBuilder
     style = 'optional-checkbox-section-wrapper'
     style << ' mps-hide' unless object.public_send("#{attribute}_on?")
     content_tag(:div, class: 'js-checkbox-show-hide form-group') do
-      label(attribute, class: 'block-label') do
-        content_tag(:div, class: 'controls-optional-checkbox-section') do
-          check_box attribute
-        end +
-          localized_label(attribute)
-      end
+      safe_join([
+        label(attribute, class: 'block-label') do
+          content_tag(:div, class: 'controls-optional-checkbox-section') do
+            check_box attribute
+          end +
+            localized_label(attribute)
+        end,
+        (content_tag(:div, class: style) { yield } if block_given?)
+      ])
     end
   end
 

--- a/app/models/forms/risk/harassments.rb
+++ b/app/models/forms/risk/harassments.rb
@@ -4,6 +4,15 @@ module Forms
       optional_details_field :harassment, default: 'unknown'
 
       optional_field :intimidation, default: 'unknown'
+
+      validate :valid_intimidation_options, if: proc { |f| f.intimidation == 'yes' }
+
+      def valid_intimidation_options
+        unless selected_intimidation_options.any?
+          errors.add(:base, :minimum_one_option, options: intimidation_options.join(', '))
+        end
+      end
+
       optional_checkbox_with_details :intimidation_to_staff, :intimidation
       optional_checkbox_with_details :intimidation_to_public, :intimidation
       optional_checkbox_with_details :intimidation_to_other_detainees, :intimidation
@@ -15,6 +24,22 @@ module Forms
         intimidation_to_other_detainees intimidation_to_other_detainees_details
         intimidation_to_witnesses intimidation_to_witnesses_details
       ], if_falsey: :intimidation
+
+      private
+
+      def selected_intimidation_options
+        [intimidation_to_staff,
+         intimidation_to_public,
+         intimidation_to_other_detainees,
+         intimidation_to_witnesses]
+      end
+
+      def intimidation_options
+        %i[intimidation_to_staff intimidation_to_public
+           intimidation_to_other_detainees intimidation_to_witnesses].map do |attr|
+          I18n.t(attr, scope: [:helpers, :label, :harassments])
+        end
+      end
     end
   end
 end

--- a/app/models/forms/risk/hostage_taker.rb
+++ b/app/models/forms/risk/hostage_taker.rb
@@ -1,0 +1,43 @@
+module Forms
+  module Risk
+    class HostageTaker < Forms::Base
+      optional_field :hostage_taker, default: 'unknown'
+      optional_checkbox :staff_hostage_taker
+      optional_checkbox :prisoners_hostage_taker
+      optional_checkbox :public_hostage_taker
+
+      reset attributes: %i[
+        staff_hostage_taker date_most_recent_staff_hostage_taker_incident
+        prisoners_hostage_taker date_most_recent_prisoners_hostage_taker_incident
+        public_hostage_taker date_most_recent_public_hostage_taker_incident
+      ], if_falsey: :hostage_taker
+
+      property :date_most_recent_staff_hostage_taker_incident, type: TextDate
+      reset attributes: %i[date_most_recent_staff_hostage_taker_incident],
+            if_falsey: :staff_hostage_taker,
+            enabled_value: true
+
+      validates :date_most_recent_staff_hostage_taker_incident,
+        date: { not_in_the_future: true },
+        if: -> { staff_hostage_taker == true }
+
+      property :date_most_recent_prisoners_hostage_taker_incident, type: TextDate
+      reset attributes: %i[date_most_recent_prisoners_hostage_taker_incident],
+            if_falsey: :prisoners_hostage_taker,
+            enabled_value: true
+
+      validates :date_most_recent_prisoners_hostage_taker_incident,
+        date: { not_in_the_future: true },
+        if: -> { prisoners_hostage_taker == true }
+
+      property :date_most_recent_public_hostage_taker_incident, type: TextDate
+      reset attributes: %i[date_most_recent_public_hostage_taker_incident],
+            if_falsey: :public_hostage_taker,
+            enabled_value: true
+
+      validates :date_most_recent_public_hostage_taker_incident,
+        date: { not_in_the_future: true },
+        if: -> { public_hostage_taker == true }
+    end
+  end
+end

--- a/app/models/forms/risk/hostage_taker.rb
+++ b/app/models/forms/risk/hostage_taker.rb
@@ -2,6 +2,15 @@ module Forms
   module Risk
     class HostageTaker < Forms::Base
       optional_field :hostage_taker, default: 'unknown'
+
+      validate :valid_hostage_taker_options, if: proc { |f| f.hostage_taker == 'yes' }
+
+      def valid_hostage_taker_options
+        unless selected_hostage_taker_options.any?
+          errors.add(:base, :minimum_one_option, options: hostage_taker_options.join(', '))
+        end
+      end
+
       optional_checkbox :staff_hostage_taker
       optional_checkbox :prisoners_hostage_taker
       optional_checkbox :public_hostage_taker
@@ -38,6 +47,18 @@ module Forms
       validates :date_most_recent_public_hostage_taker_incident,
         date: { not_in_the_future: true },
         if: -> { public_hostage_taker == true }
+
+      private
+
+      def selected_hostage_taker_options
+        [staff_hostage_taker, prisoners_hostage_taker, public_hostage_taker]
+      end
+
+      def hostage_taker_options
+        %i[staff_hostage_taker prisoners_hostage_taker public_hostage_taker].map do |attr|
+          I18n.t(attr, scope: [:helpers, :label, :hostage_taker])
+        end
+      end
     end
   end
 end

--- a/app/models/risk_workflow.rb
+++ b/app/models/risk_workflow.rb
@@ -1,6 +1,6 @@
 class RiskWorkflow < Workflow
   def self.sections
-    %i[risk_to_self risk_from_others violence harassments
+    %i[risk_to_self risk_from_others violence hostage_taker harassments
        sex_offences non_association_markers security substance_misuse
        concealed_weapons arson communication]
   end

--- a/app/models/sections/risk_assessment/hostage_taker_section.rb
+++ b/app/models/sections/risk_assessment/hostage_taker_section.rb
@@ -1,0 +1,23 @@
+module RiskAssessment
+  class HostageTakerSection < BaseSection
+    def name
+      'hostage_taker'
+    end
+
+    def questions
+      %w[staff_hostage_taker prisoners_hostage_taker public_hostage_taker]
+    end
+
+    def mandatory_questions
+      %w[hostage_taker]
+    end
+
+    private
+
+    def question_dependencies
+      {
+        hostage_taker: %i[staff_hostage_taker prisoners_hostage_taker public_hostage_taker]
+      }
+    end
+  end
+end

--- a/app/views/risks/_hostage_taker.html.slim
+++ b/app/views/risks/_hostage_taker.html.slim
@@ -1,0 +1,11 @@
+= f.radio_toggle :hostage_taker do
+  fieldset
+    span.form-hint
+      | Select all that apply
+
+    = f.checkbox :staff_hostage_taker do
+      = f.text_field :date_most_recent_staff_hostage_taker_incident
+    = f.checkbox :prisoners_hostage_taker do
+      = f.text_field :date_most_recent_prisoners_hostage_taker_incident
+    = f.checkbox :public_hostage_taker do
+      = f.text_field :date_most_recent_public_hostage_taker_incident

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,8 @@ en:
       harassments:
         harassment: Harasser
         intimidation: Intimidator / bully
+      hostage_taker:
+        hostage_taker: History of taking hostages
       information:
         has_destinations: Are there establishments the detainee must or must not be sent?
         reason: Reason for move
@@ -100,6 +102,15 @@ en:
         intimidation_to_public: Public
         intimidation_to_other_detainees: Prisoners
         intimidation_to_witnesses: Witnesses
+      hostage_taker:
+        hostage_taker:
+          unknown: Clear selection
+        staff_hostage_taker: Staff
+        public_hostage_taker: Public
+        prisoners_hostage_taker: Prisoners
+        date_most_recent_staff_hostage_taker_incident: Date of most recent incident
+        date_most_recent_prisoners_hostage_taker_incident: Date of most recent incident
+        date_most_recent_public_hostage_taker_incident: Date of most recent incident
       information:
         from: From
         to: To
@@ -228,6 +239,10 @@ en:
         intimidation_to_public_details: Give details
         intimidation_to_other_detainees_details: Give details
         intimidation_to_witnesses_details: Give details
+      hostage_taker:
+        date_most_recent_staff_hostage_taker_incident: DD/MM/YYYY
+        date_most_recent_prisoners_hostage_taker_incident: DD/MM/YYYY
+        date_most_recent_public_hostage_taker_incident: DD/MM/YYYY
       information:
         reason_details: Give details
         date : DD/MM/YYYY
@@ -315,6 +330,7 @@ en:
         communication: Communication / language difficulties
         concealed_weapons: Concealed weapons or other items
         harassments: Risk to others - harasser and/or bully
+        hostage_taker: Risk to others - hostage taker
         non_association_markers: Risk to others
         risk_to_self: Risk to self
         risk_from_others: Risk from others
@@ -378,6 +394,7 @@ en:
         communication: Communication / language difficulties
         concealed_weapons: Concealed weapons or other items
         harassments: "Risk to others: Harasser / intimidator / bully"
+        hostage_taker: "Risk to others: Hostage taker"
         mental: Mental healthcare
         needs: Medical health needs
         non_association_markers: Risk to others

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -417,6 +417,7 @@ en:
     attributes:
       base:
         minimum_current_offence: 'At least one current offence needs to be provided'
+        minimum_one_option: 'At least one option (%{options}) needs to be provided'
   alerts:
     detainee_already_exists: "Detainee already exists. You've been redirected to the next relevant form"
     detainee:

--- a/db/migrate/20161220105613_remove_old_hostage_taker_columns.rb
+++ b/db/migrate/20161220105613_remove_old_hostage_taker_columns.rb
@@ -1,0 +1,8 @@
+class RemoveOldHostageTakerColumns < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :risks, :hostage_taker
+    remove_column :risks, :hostage_taker_details
+    remove_column :risks, :stalker
+    remove_column :risks, :stalker_details
+  end
+end

--- a/db/migrate/20161220105908_add_new_hostage_taker_columns.rb
+++ b/db/migrate/20161220105908_add_new_hostage_taker_columns.rb
@@ -1,0 +1,11 @@
+class AddNewHostageTakerColumns < ActiveRecord::Migration[5.0]
+  def change
+    add_column :risks, :hostage_taker, :string
+    add_column :risks, :staff_hostage_taker, :boolean
+    add_column :risks, :date_most_recent_staff_hostage_taker_incident, :date
+    add_column :risks, :prisoners_hostage_taker, :boolean
+    add_column :risks, :date_most_recent_prisoners_hostage_taker_incident, :date
+    add_column :risks, :public_hostage_taker, :boolean
+    add_column :risks, :date_most_recent_public_hostage_taker_incident, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161216112144) do
+ActiveRecord::Schema.define(version: 20161220105908) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -120,9 +120,9 @@ ActiveRecord::Schema.define(version: 20161216112144) do
   end
 
   create_table "risks", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "rule_45",                                      default: "unknown"
-    t.string   "csra",                                         default: "unknown"
-    t.string   "violent",                                      default: "unknown"
+    t.string   "rule_45",                                           default: "unknown"
+    t.string   "csra",                                              default: "unknown"
+    t.string   "violent",                                           default: "unknown"
     t.boolean  "prison_staff"
     t.text     "prison_staff_details"
     t.boolean  "risk_to_females"
@@ -141,50 +141,46 @@ ActiveRecord::Schema.define(version: 20161216112144) do
     t.text     "public_offence_related_details"
     t.boolean  "police"
     t.text     "police_details"
-    t.string   "stalker_harasser_bully",                       default: "unknown"
-    t.boolean  "hostage_taker"
-    t.text     "hostage_taker_details"
-    t.boolean  "stalker"
-    t.text     "stalker_details"
+    t.string   "stalker_harasser_bully",                            default: "unknown"
     t.boolean  "harasser"
     t.text     "harasser_details"
     t.boolean  "intimidator"
     t.text     "intimidator_details"
     t.boolean  "bully"
     t.text     "bully_details"
-    t.string   "sex_offence",                                  default: "unknown"
+    t.string   "sex_offence",                                       default: "unknown"
     t.string   "sex_offence_victim"
     t.text     "sex_offence_details"
-    t.string   "non_association_markers",                      default: "unknown"
+    t.string   "non_association_markers",                           default: "unknown"
     t.text     "non_association_markers_details"
-    t.string   "current_e_risk",                               default: "unknown"
+    t.string   "current_e_risk",                                    default: "unknown"
     t.text     "current_e_risk_details"
-    t.string   "category_a",                                   default: "unknown"
+    t.string   "category_a",                                        default: "unknown"
     t.text     "category_a_details"
-    t.string   "restricted_status",                            default: "unknown"
+    t.string   "restricted_status",                                 default: "unknown"
     t.text     "restricted_status_details"
     t.boolean  "escape_pack"
     t.boolean  "escape_risk_assessment"
     t.boolean  "cuffing_protocol"
-    t.string   "substance_supply",                             default: "unknown"
+    t.string   "substance_supply",                                  default: "unknown"
     t.text     "substance_supply_details"
-    t.string   "substance_use",                                default: "unknown"
+    t.string   "substance_use",                                     default: "unknown"
     t.text     "substance_use_details"
-    t.string   "conceals_weapons",                             default: "unknown"
+    t.string   "conceals_weapons",                                  default: "unknown"
     t.text     "conceals_weapons_details"
-    t.string   "arson",                                        default: "unknown"
+    t.string   "arson",                                             default: "unknown"
     t.text     "arson_details"
     t.string   "arson_value"
-    t.string   "damage_to_property",                           default: "unknown"
+    t.string   "damage_to_property",                                default: "unknown"
     t.text     "damage_to_property_details"
-    t.string   "interpreter_required",                         default: "unknown"
+    t.string   "interpreter_required",                              default: "unknown"
     t.text     "language"
-    t.string   "hearing_speach_sight",                         default: "unknown"
+    t.string   "hearing_speach_sight",                              default: "unknown"
     t.text     "hearing_speach_sight_details"
-    t.string   "can_read_and_write",                           default: "unknown"
+    t.string   "can_read_and_write",                                default: "unknown"
     t.text     "can_read_and_write_details"
-    t.datetime "created_at",                                                       null: false
-    t.datetime "updated_at",                                                       null: false
+    t.datetime "created_at",                                                            null: false
+    t.datetime "updated_at",                                                            null: false
     t.uuid     "detainee_id"
     t.string   "acct_status"
     t.text     "acct_status_details"
@@ -219,6 +215,13 @@ ActiveRecord::Schema.define(version: 20161216112144) do
     t.text     "intimidation_to_other_detainees_details"
     t.boolean  "intimidation_to_witnesses"
     t.text     "intimidation_to_witnesses_details"
+    t.string   "hostage_taker"
+    t.boolean  "staff_hostage_taker"
+    t.date     "date_most_recent_staff_hostage_taker_incident"
+    t.boolean  "prisoners_hostage_taker"
+    t.date     "date_most_recent_prisoners_hostage_taker_incident"
+    t.boolean  "public_hostage_taker"
+    t.date     "date_most_recent_public_hostage_taker_incident"
     t.index ["detainee_id"], name: "index_risks_on_detainee_id", using: :btree
   end
 

--- a/spec/factories/risk_factory.rb
+++ b/spec/factories/risk_factory.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
     violence_to_other_detainees 'no'
     violence_to_general_public 'no'
     harassment 'no'
+    hostage_taker 'no'
     intimidation 'no'
     sex_offence 'no'
     non_association_markers 'no'

--- a/spec/features/pages/risk.rb
+++ b/spec/features/pages/risk.rb
@@ -11,6 +11,7 @@ module Page
       fill_in_risk_to_self
       fill_in_risk_from_others
       fill_in_violence
+      fill_in_hostage_taker
       fill_in_harassments
       fill_in_sex_offences
       fill_in_non_association_markers
@@ -81,6 +82,39 @@ module Page
         fill_in 'violence_violence_to_general_public_details', with: @risk.violence_to_general_public_details
       else
         choose 'violence_violence_to_general_public_no'
+      end
+    end
+
+    def fill_in_hostage_taker
+      if @risk.hostage_taker == 'yes'
+        choose 'hostage_taker_hostage_taker_yes'
+        fill_in_staff_hostage_taker
+        fill_in_prisoners_hostage_taker
+        fill_in_public_hostage_taker
+      else
+        choose 'hostage_taker_hostage_taker_no'
+      end
+      save_and_continue
+    end
+
+    def fill_in_staff_hostage_taker
+      if @risk.staff_hostage_taker
+        check 'hostage_taker_staff_hostage_taker'
+        fill_in 'hostage_taker_date_most_recent_staff_hostage_taker_incident', with: @risk.date_most_recent_staff_hostage_taker_incident
+      end
+    end
+
+    def fill_in_prisoners_hostage_taker
+      if @risk.prisoners_hostage_taker
+        check 'hostage_taker_prisoners_hostage_taker'
+        fill_in 'hostage_taker_date_most_recent_prisoners_hostage_taker_incident', with: @risk.date_most_recent_prisoners_hostage_taker_incident
+      end
+    end
+
+    def fill_in_public_hostage_taker
+      if @risk.public_hostage_taker
+        check 'hostage_taker_public_hostage_taker'
+        fill_in 'hostage_taker_date_most_recent_public_hostage_taker_incident', with: @risk.date_most_recent_public_hostage_taker_incident
       end
     end
 

--- a/spec/features/pages/risk_summary.rb
+++ b/spec/features/pages/risk_summary.rb
@@ -10,6 +10,7 @@ module Page
       check_section(risk, 'risk_to_self', %w[acct_status])
       check_section(risk, 'risk_from_others', %w[ rule_45 csra victim_of_abuse high_profile ])
       check_violence_section(risk)
+      check_hostage_taker_section(risk)
       check_harassment_section(risk)
       check_section(risk, 'sex_offences', %w[ sex_offence ])
       check_section(risk, 'non_association_markers', %w[ non_association_markers ])
@@ -112,6 +113,15 @@ module Page
     def check_violence_to_general_public(risk)
       if risk.violence_to_general_public == 'yes'
         check_question(risk, 'violence', 'violence_to_general_public')
+      end
+    end
+
+    def check_hostage_taker_section(risk)
+      fields = %w[staff_hostage_taker prisoners_hostage_taker public_hostage_taker]
+      if risk.hostage_taker == 'yes'
+        check_section(risk, 'hostage_taker', fields)
+      else
+        check_section_is_all_no(risk, 'hostage_taker', fields)
       end
     end
 

--- a/spec/forms/risk/harassments_spec.rb
+++ b/spec/forms/risk/harassments_spec.rb
@@ -15,6 +15,21 @@ RSpec.describe Forms::Risk::Harassments, type: :form do
       context 'when intimidation is set to yes' do
         before { form.intimidation = 'yes' }
 
+        context 'but none of the checkboxes is selected' do
+          before do
+            form.intimidation_to_staff = false
+            form.intimidation_to_public = false
+            form.intimidation_to_other_detainees = false
+            form.intimidation_to_witnesses = false
+          end
+
+          it 'an invalid date error is added to the error list' do
+            expect(form).not_to be_valid
+            expect(form.errors.keys).to match_array([:base])
+            expect(form.errors[:base]).to match_array(['At least one option (Staff, Public, Prisoners, Witnesses) needs to be provided'])
+          end
+        end
+
         context 'and intimidation to staff is set to true' do
           before { subject.intimidation_to_staff = true }
           it { is_expected.to validate_presence_of(:intimidation_to_staff_details) }

--- a/spec/forms/risk/hostage_taker_spec.rb
+++ b/spec/forms/risk/hostage_taker_spec.rb
@@ -1,0 +1,181 @@
+require 'rails_helper'
+
+RSpec.describe Forms::Risk::HostageTaker, type: :form do
+  let(:model) { Risk.new }
+  subject(:form) { described_class.new(model) }
+
+  describe '#validate' do
+    context "for hostage taker" do
+      context 'when hostage taker is set to yes' do
+        before { form.hostage_taker = 'yes' }
+
+        context 'and staff hostage taker is set to true' do
+          before { form.staff_hostage_taker = true }
+
+          context 'but date of most recent incident is not present' do
+            before { form.date_most_recent_staff_hostage_taker_incident = nil }
+
+            let(:attr_with_error) { :date_most_recent_staff_hostage_taker_incident }
+            let(:error_message) { 'is not a valid date' }
+
+            it 'an invalid date error is added to the error list' do
+              expect(form).not_to be_valid
+              expect(form.errors.keys).to match_array([attr_with_error])
+              expect(form.errors[attr_with_error]).to match_array([error_message])
+            end
+          end
+
+          context 'but date of most recent incident is invalid' do
+            before { form.date_most_recent_staff_hostage_taker_incident = 'not-a-date' }
+
+            let(:attr_with_error) { :date_most_recent_staff_hostage_taker_incident }
+            let(:error_message) { 'is not a valid date' }
+
+            it 'an invalid date error is added to the error list' do
+              expect(form).not_to be_valid
+              expect(form.errors.keys).to match_array([attr_with_error])
+              expect(form.errors[attr_with_error]).to match_array([error_message])
+            end
+          end
+
+          context 'but date of most recent incident is in the future' do
+            before { form.date_most_recent_staff_hostage_taker_incident = Date.tomorrow }
+
+            let(:attr_with_error) { :date_most_recent_staff_hostage_taker_incident }
+            let(:error_message) { 'is in the future' }
+
+            it 'a date in the future error is added to the error list' do
+              expect(form).not_to be_valid
+              expect(form.errors.keys).to match_array([attr_with_error])
+              expect(form.errors[attr_with_error]).to match_array([error_message])
+            end
+          end
+        end
+
+        context 'and prisoners hostage taker is set to true' do
+          before { form.prisoners_hostage_taker = true }
+
+          context 'but date of most recent incident is not present' do
+            before { form.date_most_recent_prisoners_hostage_taker_incident = nil }
+
+            let(:attr_with_error) { :date_most_recent_prisoners_hostage_taker_incident }
+            let(:error_message) { 'is not a valid date' }
+
+            it 'an invalid date error is added to the error list' do
+              expect(form).not_to be_valid
+              expect(form.errors.keys).to match_array([attr_with_error])
+              expect(form.errors[attr_with_error]).to match_array([error_message])
+            end
+          end
+
+          context 'but date of most recent incident is invalid' do
+            before { form.date_most_recent_prisoners_hostage_taker_incident = 'not-a-date' }
+
+            let(:attr_with_error) { :date_most_recent_prisoners_hostage_taker_incident }
+            let(:error_message) { 'is not a valid date' }
+
+            it 'an invalid date error is added to the error list' do
+              expect(form).not_to be_valid
+              expect(form.errors.keys).to match_array([attr_with_error])
+              expect(form.errors[attr_with_error]).to match_array([error_message])
+            end
+          end
+
+          context 'but date of most recent incident is in the future' do
+            before { form.date_most_recent_prisoners_hostage_taker_incident = Date.tomorrow }
+
+            let(:attr_with_error) { :date_most_recent_prisoners_hostage_taker_incident }
+            let(:error_message) { 'is in the future' }
+
+            it 'a date in the future error is added to the error list' do
+              expect(form).not_to be_valid
+              expect(form.errors.keys).to match_array([attr_with_error])
+              expect(form.errors[attr_with_error]).to match_array([error_message])
+            end
+          end
+        end
+
+        context 'and public hostage taker is set to true' do
+          before { form.public_hostage_taker = true }
+
+          context 'but date of most recent incident is not present' do
+            before { form.date_most_recent_public_hostage_taker_incident = nil }
+
+            let(:attr_with_error) { :date_most_recent_public_hostage_taker_incident }
+            let(:error_message) { 'is not a valid date' }
+
+            it 'an invalid date error is added to the error list' do
+              expect(form).not_to be_valid
+              expect(form.errors.keys).to match_array([attr_with_error])
+              expect(form.errors[attr_with_error]).to match_array([error_message])
+            end
+          end
+
+          context 'but date of most recent incident is invalid' do
+            before { form.date_most_recent_public_hostage_taker_incident = 'not-a-date' }
+
+            let(:attr_with_error) { :date_most_recent_public_hostage_taker_incident }
+            let(:error_message) { 'is not a valid date' }
+
+            it 'an invalid date error is added to the error list' do
+              expect(form).not_to be_valid
+              expect(form.errors.keys).to match_array([attr_with_error])
+              expect(form.errors[attr_with_error]).to match_array([error_message])
+            end
+          end
+
+          context 'but date of most recent incident is in the future' do
+            before { form.date_most_recent_public_hostage_taker_incident = Date.tomorrow }
+
+            let(:attr_with_error) { :date_most_recent_public_hostage_taker_incident }
+            let(:error_message) { 'is in the future' }
+
+            it 'a date in the future error is added to the error list' do
+              expect(form).not_to be_valid
+              expect(form.errors.keys).to match_array([attr_with_error])
+              expect(form.errors[attr_with_error]).to match_array([error_message])
+            end
+          end
+        end
+      end
+
+      it do
+        is_expected.to be_configured_to_reset(%i[
+          staff_hostage_taker date_most_recent_staff_hostage_taker_incident
+          prisoners_hostage_taker date_most_recent_prisoners_hostage_taker_incident
+          public_hostage_taker date_most_recent_public_hostage_taker_incident
+        ]).when(:hostage_taker).not_set_to('yes')
+      end
+
+      describe 'fields associated with checkboxes' do
+        it { is_expected.to be_configured_to_reset([:date_most_recent_staff_hostage_taker_incident]).when(:staff_hostage_taker).not_set_to(true) }
+        it { is_expected.to be_configured_to_reset([:date_most_recent_prisoners_hostage_taker_incident]).when(:prisoners_hostage_taker).not_set_to(true) }
+        it { is_expected.to be_configured_to_reset([:date_most_recent_public_hostage_taker_incident]).when(:public_hostage_taker).not_set_to(true) }
+      end
+    end
+  end
+
+  describe '#save' do
+    let(:params) {
+      {
+        'hostage_taker' => 'yes',
+        'staff_hostage_taker' => '1',
+        'date_most_recent_staff_hostage_taker_incident' => '20/11/1990',
+        'prisoners_hostage_taker' => '1',
+        'date_most_recent_prisoners_hostage_taker_incident' => '13/01/2004',
+        'public_hostage_taker' => '1',
+        'date_most_recent_public_hostage_taker_incident' => '02/03/2010'
+      }
+    }
+
+    it 'sets the data on the model' do
+      subject.validate(params)
+      subject.save
+
+      form_attributes = subject.to_nested_hash
+      model_attributes = model.attributes
+
+      expect(model_attributes).to include form_attributes
+    end
+  end
+end

--- a/spec/forms/risk/hostage_taker_spec.rb
+++ b/spec/forms/risk/hostage_taker_spec.rb
@@ -9,6 +9,20 @@ RSpec.describe Forms::Risk::HostageTaker, type: :form do
       context 'when hostage taker is set to yes' do
         before { form.hostage_taker = 'yes' }
 
+        context 'but none of the checkboxes is selected' do
+          before do
+            form.staff_hostage_taker = false
+            form.prisoners_hostage_taker = false
+            form.public_hostage_taker = false
+          end
+
+          it 'an invalid date error is added to the error list' do
+            expect(form).not_to be_valid
+            expect(form.errors.keys).to match_array([:base])
+            expect(form.errors[:base]).to match_array(['At least one option (Staff, Prisoners, Public) needs to be provided'])
+          end
+        end
+
         context 'and staff hostage taker is set to true' do
           before { form.staff_hostage_taker = true }
 

--- a/spec/models/risk_workflow_spec.rb
+++ b/spec/models/risk_workflow_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RiskWorkflow do
 
   describe '.sections' do
     specify {
-      expect(described_class.sections).to match_array(%i[risk_to_self risk_from_others violence harassments sex_offences non_association_markers security substance_misuse concealed_weapons arson communication])
+      expect(described_class.sections).to match_array(%i[risk_to_self risk_from_others violence hostage_taker harassments sex_offences non_association_markers security substance_misuse concealed_weapons arson communication])
     }
   end
 
@@ -16,7 +16,7 @@ RSpec.describe RiskWorkflow do
       expect(described_class.mandatory_questions).to match_array(
           %w[ acct_status rule_45 csra victim_of_abuse high_profile violence_due_to_discrimination
               violence_to_staff violence_to_other_detainees violence_to_general_public
-              harassment intimidation sex_offence non_association_markers
+              hostage_taker harassment intimidation sex_offence non_association_markers
               current_e_risk category_a
               restricted_status substance_supply substance_use conceals_weapons arson
               damage_to_property interpreter_required hearing_speach_sight


### PR DESCRIPTION
[Trello #369](https://trello.com/c/hwiDYyNK/369-3-as-someone-working-in-security-in-a-prison-when-filling-in-a-digital-per-i-want-to-be-able-to-complete-details-about-a-detaine)

- Splits risk of hostage taking into a new section
- Removes columns that are no longer necessary for that section
- Adds new columns for the questions necessary for the hostage section
- Adds validation to both harassments and hostage taker risk sections to ensure if any of the main questions is answered 'Yes', the user needs to select at least one of the context options provided