### PR TITLE
Security risk changes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,8 +37,15 @@ Metrics/AbcSize:
   Exclude:
     - 'spec/**/*'
 
+Metrics/ClassLength:
+  Exclude:
+    - 'app/form_builders/mps_form_builder.rb'
+
 Metrics/MethodLength:
   Max: 15
+  Exclude:
+    - 'app/form_builders/mps_form_builder.rb'
+
 
 # Allow ===. It's useful.
 Style/CaseEquality:

--- a/app/form_builders/mps_form_builder.rb
+++ b/app/form_builders/mps_form_builder.rb
@@ -4,6 +4,56 @@ class MpsFormBuilder < GovukElementsFormBuilder::FormBuilder
     ' panel panel-border-narrow'
   end
 
+  def radio_button_fieldset(attribute, options = {})
+    content_tag :div,
+      class: form_group_classes(attribute),
+      id: form_group_id(attribute) do
+      content_tag :fieldset, fieldset_options(attribute, options) do
+        safe_join([
+                    fieldset_legend(attribute, options),
+                    radio_inputs(attribute, options)
+                  ], "\n")
+      end
+    end
+  end
+
+  def fieldset_legend(attribute, options = {})
+    tags = []
+    legend = content_tag(:legend) do
+      if options.fetch(:legend, true)
+        tags << content_tag(
+          :span,
+          fieldset_text(attribute),
+          class: 'form-label-bold'
+        )
+      end
+
+      if error_for? attribute
+        tags << content_tag(
+          :span,
+          error_full_message_for(attribute),
+          class: 'error-message'
+        )
+      end
+
+      hint = hint_text attribute
+      tags << content_tag(:span, hint, class: 'form-hint') if hint
+
+      safe_join tags
+    end
+    legend.html_safe
+  end
+
+  def radio_inputs(attribute, options)
+    choices = options[:choices] || [:yes, :no]
+    choices.map do |choice|
+      label(attribute, class: 'block-label', value: choice) do |_tag|
+        input = radio_button(attribute, choice)
+        input + localized_label("#{attribute}_choices.#{choice}")
+      end
+    end
+  end
+
   def radio_toggle(attribute, options = {}, &_blk)
     style = 'optional-section-wrapper'
     style << ' mps-hide' unless object.public_send("#{attribute}_on?")

--- a/app/models/forms/base.rb
+++ b/app/models/forms/base.rb
@@ -97,7 +97,7 @@ module Forms
             (public_send(field_name) && toggle.nil?) ||
               (public_send(field_name) && public_send(toggle) == TOGGLE_YES)
           }
-        reset attributes: ["#{field_name}_details"], if_falsey: field_name, enabled_value: true
+        reset attributes: [:"#{field_name}_details"], if_falsey: field_name, enabled_value: true
       end
 
       def singularize(field_name)

--- a/app/models/forms/risk/security.rb
+++ b/app/models/forms/risk/security.rb
@@ -2,26 +2,78 @@ module Forms
   module Risk
     class Security < Forms::Base
       E_RISK_VALUES = %w[e_list_standard e_list_escort e_list_heightened].freeze
-      optional_field :current_e_risk
+      optional_field :current_e_risk, default: 'unknown'
 
       property :current_e_risk_details, type: StrictString
       reset attributes: %i[current_e_risk_details],
             if_falsey: :current_e_risk
 
       validates :current_e_risk_details,
-        inclusion: { in: E_RISK_VALUES }, if: proc { |f| f.current_e_risk == 'yes' }
+        inclusion: { in: E_RISK_VALUES }, if: -> { current_e_risk == 'yes' }
 
-      optional_details_field :category_a
-      optional_details_field :restricted_status
-      property :escape_pack,
-        type: Axiom::Types::Boolean, default: false
-      property :escape_risk_assessment,
-        type: Axiom::Types::Boolean, default: false
-      property :cuffing_protocol,
-        type: Axiom::Types::Boolean, default: false
+      optional_field :previous_escape_attempts, default: 'unknown'
+
+      validate :valid_previous_escape_attempts_options,
+        if: -> { previous_escape_attempts == 'yes' }
+
+      def valid_previous_escape_attempts_options
+        if selected_previous_escape_attempts_options.none?
+          errors.add(:base, :minimum_one_option, options: previous_escape_attempts_options.join(', '))
+        end
+      end
+
+      optional_checkbox_with_details :prison_escape_attempt, :previous_escape_attempts
+      optional_checkbox_with_details :court_escape_attempt, :previous_escape_attempts
+      optional_checkbox_with_details :police_escape_attempt, :previous_escape_attempts
+      optional_checkbox_with_details :other_type_escape_attempt, :previous_escape_attempts
+
+      reset attributes: %i[
+        prison_escape_attempt prison_escape_attempt_details
+        court_escape_attempt court_escape_attempt_details
+        police_escape_attempt police_escape_attempt_details
+        other_type_escape_attempt other_type_escape_attempt_details
+      ], if_falsey: :previous_escape_attempts
+
+      optional_field :category_a, default: 'unknown'
+
+      optional_field :escort_risk_assessment, default: 'unknown'
+      property :escort_risk_assessment_completion_date, type: TextDate
+      reset attributes: %i[escort_risk_assessment_completion_date],
+            if_falsey: :escort_risk_assessment,
+            enabled_value: 'yes'
+
+      validates :escort_risk_assessment_completion_date,
+        date: { not_in_the_future: true },
+        if: -> { escort_risk_assessment == 'yes' }
+
+      optional_field :escape_pack, default: 'unknown'
+      property :escape_pack_completion_date, type: TextDate
+      reset attributes: %i[escape_pack_completion_date],
+            if_falsey: :escape_pack,
+            enabled_value: 'yes'
+
+      validates :escape_pack_completion_date,
+        date: { not_in_the_future: true },
+        if: -> { escape_pack == 'yes' }
 
       def e_risk_values
         E_RISK_VALUES
+      end
+
+      private
+
+      def selected_previous_escape_attempts_options
+        [prison_escape_attempt,
+         court_escape_attempt,
+         police_escape_attempt,
+         other_type_escape_attempt]
+      end
+
+      def previous_escape_attempts_options
+        %i[prison_escape_attempt court_escape_attempt
+           police_escape_attempt other_type_escape_attempt].map do |attr|
+          I18n.t(attr, scope: [:helpers, :label, :security])
+        end
       end
     end
   end

--- a/app/models/forms/risk/security.rb
+++ b/app/models/forms/risk/security.rb
@@ -2,10 +2,15 @@ module Forms
   module Risk
     class Security < Forms::Base
       E_RISK_VALUES = %w[e_list_standard e_list_escort e_list_heightened].freeze
-      optional_details_field :current_e_risk
+      optional_field :current_e_risk
+
+      property :current_e_risk_details, type: StrictString
+      reset attributes: %i[current_e_risk_details],
+            if_falsey: :current_e_risk
+
       validates :current_e_risk_details,
-        inclusion: { in: E_RISK_VALUES },
-        allow_blank: true
+        inclusion: { in: E_RISK_VALUES }, if: proc { |f| f.current_e_risk == 'yes' }
+
       optional_details_field :category_a
       optional_details_field :restricted_status
       property :escape_pack,

--- a/app/models/sections/risk_assessment/security_section.rb
+++ b/app/models/sections/risk_assessment/security_section.rb
@@ -5,11 +5,23 @@ module RiskAssessment
     end
 
     def questions
-      %w[current_e_risk category_a restricted_status escape_pack escape_risk_assessment cuffing_protocol]
+      %w[current_e_risk prison_escape_attempt court_escape_attempt
+         police_escape_attempt other_type_escape_attempt category_a
+         escort_risk_assessment escape_pack]
     end
 
     def mandatory_questions
-      %w[current_e_risk category_a restricted_status]
+      %w[current_e_risk previous_escape_attempts category_a
+         escort_risk_assessment escape_pack]
+    end
+
+    private
+
+    def question_dependencies
+      {
+        previous_escape_attempts: %i[prison_escape_attempt court_escape_attempt
+                                     police_escape_attempt other_type_escape_attempt]
+      }
     end
   end
 end

--- a/app/views/risks/_security.html.slim
+++ b/app/views/risks/_security.html.slim
@@ -1,6 +1,6 @@
 = f.radio_toggle :current_e_risk do
   .form-group
-    = f.radio_button_fieldset :current_e_risk_details, choices: f.object.e_risk_values
+    = f.radio_button_fieldset :current_e_risk_details, choices: f.object.e_risk_values, legend: false
 = f.radio_toggle_with_textarea :category_a
 = f.radio_toggle_with_textarea :restricted_status
 

--- a/app/views/risks/_security.html.slim
+++ b/app/views/risks/_security.html.slim
@@ -1,11 +1,21 @@
 = f.radio_toggle :current_e_risk do
   .form-group
     = f.radio_button_fieldset :current_e_risk_details, choices: f.object.e_risk_values, legend: false
-= f.radio_toggle_with_textarea :category_a
-= f.radio_toggle_with_textarea :restricted_status
 
-fieldset.checkbox-list
-  legend.heading-small = t('helpers.fieldset.security.documents')
-  = f.label_with_checkbox :escape_pack
-  = f.label_with_checkbox :escape_risk_assessment
-  = f.label_with_checkbox :cuffing_protocol
+= f.radio_toggle :previous_escape_attempts do
+  fieldset
+    span.form-hint
+      | Select all that apply
+
+    = f.checkbox_with_textarea :prison_escape_attempt
+    = f.checkbox_with_textarea :court_escape_attempt
+    = f.checkbox_with_textarea :police_escape_attempt
+    = f.checkbox_with_textarea :other_type_escape_attempt
+
+= f.radio_toggle :category_a
+
+= f.radio_toggle :escort_risk_assessment do
+  = f.text_field :escort_risk_assessment_completion_date
+
+= f.radio_toggle :escape_pack do
+  = f.text_field :escape_pack_completion_date

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,8 +42,7 @@ en:
         acct_status: Detainee's most recent ACCT status
       security:
         category_a: Category A?
-        current_e_risk: Current E-risk?
-        current_e_risk_details: ''
+        current_e_risk: Currently on E list?
         restricted_status: Restricted status?
         documents: "Ensure the following documents accompany the detainee:"
       sex_offences:
@@ -63,26 +62,26 @@ en:
         violence_to_staff: Violent to staff
     label:
       allergies:
-        allergies:
+        allergies_choices:
           unknown: Clear selection
       arson:
-        arson_value:
+        arson_value_choices:
           index_offence: Arson is the index offence
           behavioural_issue: Arson is a behavioural issue
           small_risk: Small risk of arson during move
-        arson:
+        arson_choices:
           unknown: Clear selection
-        damage_to_property:
+        damage_to_property_choices:
           unknown: Clear selection
       communication:
-        can_read_and_write:
+        can_read_and_write_choices:
           unknown: Clear selection
-        hearing_speach_sight:
+        hearing_speach_sight_choices:
           unknown: Clear selection
-        interpreter_required:
+        interpreter_required_choices:
           unknown: Clear selection
       concealed_weapons:
-        conceals_weapons:
+        conceals_weapons_choices:
           unknown: Clear selection
       detainee_details:
         surname: Surname
@@ -93,16 +92,16 @@ en:
         gender: Gender
         aliases: Aliases
       harassments:
-        harassment:
+        harassment_choices:
           unknown: Clear selection
-        intimidation:
+        intimidation_choices:
           unknown: Clear selection
         intimidation_to_staff: Staff
         intimidation_to_public: Public
         intimidation_to_other_detainees: Prisoners
         intimidation_to_witnesses: Witnesses
       hostage_taker:
-        hostage_taker:
+        hostage_taker_choices:
           unknown: Clear selection
         staff_hostage_taker: Staff
         public_hostage_taker: Public
@@ -115,48 +114,48 @@ en:
         to: To
         date: Date of move
         reason_details: Reason details
-        has_destinations:
+        has_destinations_choices:
           unknown: Clear selection
         destinations:
           establishment: Establishment
           reasons: List the reasons, eg medical treatment, medical hold, treatment programmes or offender behaviour.
       mental:
-        mental_illness:
+        mental_illness_choices:
           unknown: Clear selection
-        phobias:
+        phobias_choices:
           unknown: Clear selection
       needs:
-        dependencies:
+        dependencies_choices:
           unknown: Clear selection
-        has_medications:
+        has_medications_choices:
           unknown: Clear selection
         medications:
           description: What is it?
           administration: How is it given?
           carrier: Who carries it?
       non_association_markers:
-        non_association_markers:
+        non_association_markers_choices:
           unknown: Clear selection
         non_association_markers_details: Non-association markers details
       offences:
         release_date: The detainee's confirmed release date
         not_for_release: The detainee is 'not for release'
-        has_past_offences:
+        has_past_offences_choices:
           unknown: Clear selection
       physical:
-        physical_issues:
+        physical_issues_choices:
           unknown: Clear selection
       risk_from_others:
-        rule_45:
+        rule_45_choices:
           unknown: Clear selection
-        csra:
+        csra_choices:
           unknown: Clear selection
-        victim_of_abuse:
+        victim_of_abuse_choices:
           unknown: Clear selection
-        high_profile:
+        high_profile_choices:
           unknown: Clear selection
       risk_to_self:
-        acct_status:
+        acct_status_choices:
           open: ACCT Open
           post_closure: ACCT Post Closure
           closed_in_last_6_months: ACCT Closed, in the last 6 months
@@ -164,36 +163,37 @@ en:
         acct_status_details: Give details of known methods and triggers
         date_of_most_recently_closed_acct: Date of most recently closed ACCT
       security:
-        category_a:
+        category_a_choices:
           unknown: Clear selection
         category_a_details: Give details
-        current_e_risk:
+        current_e_risk_choices:
           unknown: Clear selection
-        current_e_risk_details:
+        current_e_risk_details: E list type
+        current_e_risk_details_choices:
           e_list_standard: E-List-Standard
           e_list_escort: E-List-Escort
           e_list_heightened: E-List-Heightened
-        restricted_status:
+        restricted_status_choices:
           unknown: Clear selection
       sex_offences:
-        sex_offence:
+        sex_offence_choices:
           unknown: Clear selection
         sex_offence_adult_male_victim: Adult male
         sex_offence_adult_female_victim: Adult female
         sex_offence_under18_victim: Under 18
         sex_offence_under18_victim_details: Under 18 victim details
       social:
-        personal_hygiene:
+        personal_hygiene_choices:
           unknown: Clear selection
-        personal_care:
+        personal_care_choices:
           unknown: Clear selection
       substance_misuse:
-        alcohol:
+        substance_supply_choices:
           unknown: Clear selection
-        drugs:
+        substance_use_choices:
           unknown: Clear selection
       transport:
-        mpv:
+        mpv_choices:
           unknown: Clear selection
         mpv_details: MPV details
       violence:
@@ -208,16 +208,16 @@ en:
         racist: Racist
         racist_details: Details for risk of violence due to racist discrimination
         risk_to_females: Risk to females
-        violence_due_to_discrimination:
+        violence_due_to_discrimination_choices:
           unknown: Clear selection
-        violence_to_general_public:
+        violence_to_general_public_choices:
           unknown: Clear selection
         violence_to_general_public_details: Violent to the general public details
-        violence_to_staff:
+        violence_to_staff_choices:
           unknown: Clear selection
         violence_to_staff_custody: Staff custody
         violence_to_staff_community: Staff community
-        violence_to_other_detainees:
+        violence_to_other_detainees_choices:
           unknown: Clear selection
     hint:
       allergies:
@@ -281,7 +281,7 @@ en:
         date_of_most_recently_closed_acct: DD/MM/YYYY
       security:
         category_a_details: Give details
-        current_e_risk: Please see PSI 2011/56 Management and Security of Escape List (E List prisoners)
+        current_e_risk: Check PSI 2011/56 Management and Security of Escape List (E List prisoners)
         restricted_status: Please see PSI 08/2013 The Review of Security Category - CAT A Restricted Status
         restricted_status_details: Give details
       sex_offences:
@@ -337,7 +337,7 @@ en:
         non_association_markers: Risk to others
         risk_to_self: Risk to self
         risk_from_others: Risk from others
-        security: Security
+        security: Escape status/history
         sex_offences: Sex offender
         substance_misuse: Substance risk
         violence: Risk to others - discrimination

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,10 +41,11 @@ en:
       risk_to_self:
         acct_status: Detainee's most recent ACCT status
       security:
-        category_a: Category A?
-        current_e_risk: Currently on E list?
-        restricted_status: Restricted status?
-        documents: "Ensure the following documents accompany the detainee:"
+        category_a: Category A or Restricted status
+        current_e_risk: Currently on E list
+        escape_pack: Escape Pack completed for this journey
+        escort_risk_assessment: Escort Risk Assessment completed for this journey
+        previous_escape_attempts: Made previous escape attempts
       sex_offences:
         sex_offence: Sex offender
       social:
@@ -165,7 +166,6 @@ en:
       security:
         category_a_choices:
           unknown: Clear selection
-        category_a_details: Give details
         current_e_risk_choices:
           unknown: Clear selection
         current_e_risk_details: E list type
@@ -173,8 +173,22 @@ en:
           e_list_standard: E-List-Standard
           e_list_escort: E-List-Escort
           e_list_heightened: E-List-Heightened
-        restricted_status_choices:
+        escape_pack_choices:
           unknown: Clear selection
+        escort_risk_assessment_choices:
+          unknown: Clear selection
+        escape_pack_completion_date: 'Escape Pack completed on:'
+        escort_risk_assessment_completion_date: 'Escort Risk Assessment completed on:'
+        previous_escape_attempts_choices:
+          unknown: Clear selection
+        prison_escape_attempt: Prison
+        prison_escape_attempt_details: Last prison escape attempt details
+        court_escape_attempt: Court
+        court_escape_attempt_details: Last court escape attempt details
+        police_escape_attempt: Police
+        police_escape_attempt_details: Last police escape attempt details
+        other_type_escape_attempt: Other
+        other_type_escape_attempt_details: Last other type of escape attempt details
       sex_offences:
         sex_offence_choices:
           unknown: Clear selection
@@ -280,10 +294,14 @@ en:
         suicide_details: Give details
         date_of_most_recently_closed_acct: DD/MM/YYYY
       security:
-        category_a_details: Give details
+        category_a: Check PSI 08/2013 The Review of Security Category - CAT A Restricted Status
         current_e_risk: Check PSI 2011/56 Management and Security of Escape List (E List prisoners)
-        restricted_status: Please see PSI 08/2013 The Review of Security Category - CAT A Restricted Status
-        restricted_status_details: Give details
+        escape_pack_completion_date: DD/MM/YYYY
+        escort_risk_assessment_completion_date: DD/MM/YYYY
+        prison_escape_attempt_details: Give details of last escape attempt
+        court_escape_attempt_details: Give details of last escape attempt
+        police_escape_attempt_details: Give details of last escape attempt
+        other_type_escape_attempt_details: Give details of last escape attempt
       sex_offences:
         sex_offence_under18_victim_details: Give details - state gender and age when under 18, if known
       social:
@@ -373,11 +391,10 @@ en:
           acct_status: ACCT status
           suicide: Risk of suicide or self-harm
         security:
-          category_a: Category A
+          category_a: Category A or Restricted status
           current_e_risk: Current E risk
           escape_list: Escape list
           other_escape_risk_info: Other escape risk information
-          restricted_status: Restricted status
         substance_misuse:
           substance_supply: Substance supply
           substance_use: Substance use

--- a/db/migrate/20161222102630_remove_security_risk_old_columns.rb
+++ b/db/migrate/20161222102630_remove_security_risk_old_columns.rb
@@ -1,0 +1,9 @@
+class RemoveSecurityRiskOldColumns < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :risks, :restricted_status
+    remove_column :risks, :restricted_status_details
+    remove_column :risks, :escape_pack
+    remove_column :risks, :escape_risk_assessment
+    remove_column :risks, :cuffing_protocol
+  end
+end

--- a/db/migrate/20161222102920_add_security_risk_new_columns.rb
+++ b/db/migrate/20161222102920_add_security_risk_new_columns.rb
@@ -1,0 +1,17 @@
+class AddSecurityRiskNewColumns < ActiveRecord::Migration[5.0]
+  def change
+    add_column :risks, :previous_escape_attempts, :string
+    add_column :risks, :prison_escape_attempt, :boolean
+    add_column :risks, :prison_escape_attempt_details, :text
+    add_column :risks, :court_escape_attempt, :boolean
+    add_column :risks, :court_escape_attempt_details, :text
+    add_column :risks, :police_escape_attempt, :boolean
+    add_column :risks, :police_escape_attempt_details, :text
+    add_column :risks, :other_type_escape_attempt, :boolean
+    add_column :risks, :other_type_escape_attempt_details, :text
+    add_column :risks, :escort_risk_assessment, :string
+    add_column :risks, :escort_risk_assessment_completion_date, :date
+    add_column :risks, :escape_pack, :string
+    add_column :risks, :escape_pack_completion_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161221175619) do
+ActiveRecord::Schema.define(version: 20161222102920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -155,11 +155,6 @@ ActiveRecord::Schema.define(version: 20161221175619) do
     t.text     "current_e_risk_details"
     t.string   "category_a",                                        default: "unknown"
     t.text     "category_a_details"
-    t.string   "restricted_status",                                 default: "unknown"
-    t.text     "restricted_status_details"
-    t.boolean  "escape_pack"
-    t.boolean  "escape_risk_assessment"
-    t.boolean  "cuffing_protocol"
     t.string   "substance_supply",                                  default: "unknown"
     t.text     "substance_supply_details"
     t.string   "substance_use",                                     default: "unknown"
@@ -224,6 +219,19 @@ ActiveRecord::Schema.define(version: 20161221175619) do
     t.boolean  "sex_offence_adult_female_victim"
     t.boolean  "sex_offence_under18_victim"
     t.text     "sex_offence_under18_victim_details"
+    t.string   "previous_escape_attempts"
+    t.boolean  "prison_escape_attempt"
+    t.text     "prison_escape_attempt_details"
+    t.boolean  "court_escape_attempt"
+    t.text     "court_escape_attempt_details"
+    t.boolean  "police_escape_attempt"
+    t.text     "police_escape_attempt_details"
+    t.boolean  "other_type_escape_attempt"
+    t.text     "other_type_escape_attempt_details"
+    t.string   "escort_risk_assessment"
+    t.date     "escort_risk_assessment_completion_date"
+    t.string   "escape_pack"
+    t.date     "escape_pack_completion_date"
     t.index ["detainee_id"], name: "index_risks_on_detainee_id", using: :btree
   end
 

--- a/spec/factories/risk_factory.rb
+++ b/spec/factories/risk_factory.rb
@@ -15,11 +15,10 @@ FactoryGirl.define do
     sex_offence 'no'
     non_association_markers 'no'
     current_e_risk 'no'
+    previous_escape_attempts 'no'
     category_a 'no'
-    restricted_status 'no'
-    escape_pack false
-    escape_risk_assessment false
-    cuffing_protocol false
+    escape_pack 'no'
+    escort_risk_assessment 'no'
     substance_supply 'no'
     substance_use 'no'
     conceals_weapons 'no'

--- a/spec/features/pages/risk.rb
+++ b/spec/features/pages/risk.rb
@@ -158,18 +158,59 @@ module Page
     end
 
     def fill_in_security
+      fill_in_current_e_risk
+      fill_in_previous_escape_attempts
+      fill_in_category_a
+      fill_in_escort_risk_assessment
+      fill_in_escape_pack
+      save_and_continue
+    end
+
+    def fill_in_current_e_risk
       if @risk.current_e_risk == 'yes'
         choose 'security_current_e_risk_yes'
         choose "security_current_e_risk_details_#{@risk.current_e_risk_details}"
       else
         choose 'security_current_e_risk_no'
       end
-      fill_in_optional_details('Category A?', @risk, :category_a)
-      fill_in_optional_details('Restricted status?', @risk, :restricted_status)
-      check 'Escape pack' if @risk.escape_pack
-      check 'Escape risk assessment' if @risk.escape_risk_assessment
-      check 'Cuffing protocol'  if @risk.cuffing_protocol
-      save_and_continue
+    end
+
+    def fill_in_previous_escape_attempts
+      if @risk.previous_escape_attempts == 'yes'
+        choose 'security_previous_escape_attempts_yes'
+        fill_in_checkbox_with_details('Prison', @risk, :prison_escape_attempt)
+        fill_in_checkbox_with_details('Court', @risk, :court_escape_attempt)
+        fill_in_checkbox_with_details('Police', @risk, :police_escape_attempt)
+        fill_in_checkbox_with_details('Other', @risk, :other_type_escape_attempt)
+      else
+        choose 'security_previous_escape_attempts_no'
+      end
+    end
+
+    def fill_in_category_a
+      if @risk.category_a == 'yes'
+        choose 'security_category_a_yes'
+      else
+        choose 'security_category_a_no'
+      end
+    end
+
+    def fill_in_escort_risk_assessment
+      if @risk.escort_risk_assessment == 'yes'
+        choose 'security_escort_risk_assessment_yes'
+        fill_in 'security_escort_risk_assessment_completion_date', with: @risk.escort_risk_assessment_completion_date
+      else
+        choose 'security_escort_risk_assessment_no'
+      end
+    end
+
+    def fill_in_escape_pack
+      if @risk.escape_pack == 'yes'
+        choose 'security_escape_pack_yes'
+        fill_in 'security_escape_pack_completion_date', with: @risk.escape_pack_completion_date
+      else
+        choose 'security_escape_pack_no'
+      end
     end
 
     def fill_in_non_association_markers

--- a/spec/features/pages/risk_summary.rb
+++ b/spec/features/pages/risk_summary.rb
@@ -14,7 +14,7 @@ module Page
       check_harassment_section(risk)
       check_sex_offences_section(risk)
       check_section(risk, 'non_association_markers', %w[ non_association_markers ])
-      check_section(risk, 'security', %w[ current_e_risk category_a restricted_status escape_pack escape_risk_assessment cuffing_protocol ])
+      check_security_section(risk)
       check_section(risk, 'substance_misuse', %w[ substance_supply substance_use ])
       check_section(risk, 'concealed_weapons', %w[ conceals_weapons ])
       check_section(risk, 'arson', %w[ arson damage_to_property ])
@@ -152,6 +152,30 @@ module Page
         check_section(risk, 'sex_offences', fields)
       else
         check_section_is_all_no(risk, 'sex_offences', fields)
+      end
+    end
+
+    def check_security_section(risk)
+      check_current_e_risk(risk)
+      check_previous_escape_attempts(risk)
+      check_question(risk, 'security', 'category_a')
+      check_question(risk, 'security', 'escort_risk_assessment')
+      check_question(risk, 'security', 'escape_pack')
+    end
+
+    def check_current_e_risk(risk)
+      if risk.current_e_risk == 'yes'
+        check_question(risk, 'security', 'current_e_risk_details')
+      end
+    end
+
+    def check_previous_escape_attempts(risk)
+      fields = %w[prison_escape_attempt court_escape_attempt
+                  police_escape_attempt other_type_escape_attempt]
+      if risk.previous_escape_attempts == 'yes'
+        check_section(risk, 'security', fields)
+      else
+        check_section_is_all_no(risk, 'security', fields)
       end
     end
   end

--- a/spec/forms/offences_spec.rb
+++ b/spec/forms/offences_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Forms::Offences, type: :form do
     end
 
     describe 'details fields associated with checkboxes' do
-      it { is_expected.to be_configured_to_reset(['not_for_release_details']).when(:not_for_release).not_set_to(true) }
+      it { is_expected.to be_configured_to_reset([:not_for_release_details]).when(:not_for_release).not_set_to(true) }
     end
   end
 

--- a/spec/forms/risk/harassments_spec.rb
+++ b/spec/forms/risk/harassments_spec.rb
@@ -61,10 +61,10 @@ RSpec.describe Forms::Risk::Harassments, type: :form do
       end
 
       describe 'details fields associated with checkboxes' do
-        it { is_expected.to be_configured_to_reset(['intimidation_to_staff_details']).when(:intimidation_to_staff).not_set_to(true) }
-        it { is_expected.to be_configured_to_reset(['intimidation_to_public_details']).when(:intimidation_to_public).not_set_to(true) }
-        it { is_expected.to be_configured_to_reset(['intimidation_to_other_detainees_details']).when(:intimidation_to_other_detainees).not_set_to(true) }
-        it { is_expected.to be_configured_to_reset(['intimidation_to_witnesses_details']).when(:intimidation_to_witnesses).not_set_to(true) }
+        it { is_expected.to be_configured_to_reset([:intimidation_to_staff_details]).when(:intimidation_to_staff).not_set_to(true) }
+        it { is_expected.to be_configured_to_reset([:intimidation_to_public_details]).when(:intimidation_to_public).not_set_to(true) }
+        it { is_expected.to be_configured_to_reset([:intimidation_to_other_detainees_details]).when(:intimidation_to_other_detainees).not_set_to(true) }
+        it { is_expected.to be_configured_to_reset([:intimidation_to_witnesses_details]).when(:intimidation_to_witnesses).not_set_to(true) }
       end
     end
   end

--- a/spec/forms/risk/security_spec.rb
+++ b/spec/forms/risk/security_spec.rb
@@ -8,25 +8,48 @@ RSpec.describe Forms::Risk::Security, type: :form do
     {
       'current_e_risk' => 'yes',
       'current_e_risk_details' => 'e_list_standard',
+      'previous_escape_attempts' => 'yes',
+      'prison_escape_attempt' => '1',
+      'prison_escape_attempt_details' => 'prison escape attempt details',
+      'court_escape_attempt' => '1',
+      'court_escape_attempt_details' => 'court escape attempt details',
+      'police_escape_attempt' => '1',
+      'police_escape_attempt_details' => 'police escape attempt details',
+      'other_type_escape_attempt' => '1',
+      'other_type_escape_attempt_details' => 'other type escape attempt details',
       'category_a' => 'yes',
-      'category_a_details' => 'Category A present',
-      'restricted_status' => 'yes',
-      'restricted_status_details' => 'Restricted status present',
-      'escape_pack' => '1',
-      'escape_risk_assessment' => '1',
-      'cuffing_protocol' => '1'
+      'escape_pack' => 'yes',
+      'escape_pack_completion_date' => '23/03/2016',
+      'escort_risk_assessment' => 'yes',
+      'escort_risk_assessment_completion_date' => '10/12/2000'
     }
   }
 
   describe '#validate' do
+    shared_examples_for 'valid form' do
+      it 'no error is added to the error list' do
+        expect(form).to be_valid
+        expect(form.errors.keys).to be_empty
+      end
+    end
+
     it { is_expected.to validate_optional_field(:current_e_risk) }
-    it { is_expected.to validate_optional_details_field(:category_a) }
-    it { is_expected.to validate_optional_details_field(:restricted_status) }
+    it { is_expected.to validate_optional_field(:previous_escape_attempts) }
+    it { is_expected.to validate_optional_field(:category_a) }
+    it { is_expected.to validate_optional_field(:escort_risk_assessment) }
+    it { is_expected.to validate_optional_field(:escape_pack) }
 
     it 'coerces params' do
-      subject.validate(params)
-      coerced_params = params.merge('escape_pack' => true, 'escape_risk_assessment' => true, 'cuffing_protocol' => true)
-      expect(subject.to_nested_hash).to eq coerced_params
+      form.validate(params)
+      coerced_params = params.merge({
+        'prison_escape_attempt' => true,
+        'court_escape_attempt' => true,
+        'police_escape_attempt' => true,
+        'other_type_escape_attempt' => true,
+        'escape_pack_completion_date' => Date.new(2016, 3, 23),
+        'escort_risk_assessment_completion_date' => Date.new(2000, 12, 10)
+      })
+      expect(form.to_nested_hash).to eq(coerced_params)
     end
 
     context 'current_e_risk attribute' do
@@ -57,14 +80,223 @@ RSpec.describe Forms::Risk::Security, type: :form do
         end
       end
     end
+
+    context 'previous_escape_attempts' do
+      it { is_expected.to validate_optional_field(:previous_escape_attempts) }
+
+      it do
+        is_expected.to be_configured_to_reset(%i[
+          prison_escape_attempt prison_escape_attempt_details
+          court_escape_attempt court_escape_attempt_details
+          police_escape_attempt police_escape_attempt_details
+          other_type_escape_attempt other_type_escape_attempt_details
+        ]).when(:previous_escape_attempts).not_set_to('yes')
+      end
+
+      it { is_expected.to be_configured_to_reset([:prison_escape_attempt_details]).when(:prison_escape_attempt).not_set_to(true) }
+      it { is_expected.to be_configured_to_reset([:court_escape_attempt_details]).when(:court_escape_attempt).not_set_to(true) }
+      it { is_expected.to be_configured_to_reset([:police_escape_attempt_details]).when(:police_escape_attempt).not_set_to(true) }
+      it { is_expected.to be_configured_to_reset([:other_type_escape_attempt_details]).when(:other_type_escape_attempt).not_set_to(true) }
+
+      context 'when is set to unknown' do
+        before { form.previous_escape_attempts = 'unknown' }
+        include_examples 'valid form'
+      end
+
+      context 'when is set to no' do
+        before { form.previous_escape_attempts = 'no' }
+        include_examples 'valid form'
+      end
+
+      context 'when is set to yes' do
+        before { form.previous_escape_attempts = 'yes' }
+
+        context 'and no type of escape attempt is selected' do
+          before do
+            form.prison_escape_attempt = false
+            form.court_escape_attempt = false
+            form.police_escape_attempt = false
+            form.other_type_escape_attempt = false
+          end
+
+          let(:attr_with_error) { :base }
+          let(:error_message) { 'At least one option (Prison, Court, Police, Other) needs to be provided' }
+
+          it { is_expected.not_to validate_presence_of(:prison_escape_attempt_details) }
+          it { is_expected.not_to validate_presence_of(:court_escape_attempt_details) }
+          it { is_expected.not_to validate_presence_of(:police_escape_attempt_details) }
+          it { is_expected.not_to validate_presence_of(:other_type_escape_attempt_details) }
+
+          it 'inclusion error is added to the error list' do
+            expect(form).not_to be_valid
+            expect(form.errors.keys).to match_array([attr_with_error])
+            expect(form.errors[attr_with_error]).to match_array([error_message])
+          end
+        end
+
+        context 'and prison escape attempt is set to true' do
+          before { form.prison_escape_attempt = true }
+
+          it { is_expected.to validate_presence_of(:prison_escape_attempt_details) }
+        end
+
+        context 'and court escape attempt is set to true' do
+          before { form.court_escape_attempt = true }
+
+          it { is_expected.to validate_presence_of(:court_escape_attempt_details) }
+        end
+
+        context 'and police escape attempt is set to true' do
+          before { form.police_escape_attempt = true }
+
+          it { is_expected.to validate_presence_of(:police_escape_attempt_details) }
+        end
+
+        context 'and other_type escape attempt is set to true' do
+          before { form.other_type_escape_attempt = true }
+
+          it { is_expected.to validate_presence_of(:other_type_escape_attempt_details) }
+        end
+      end
+    end
+
+    context 'category_a' do
+      it { is_expected.to validate_optional_field(:category_a) }
+    end
+
+    context 'escort_risk_assessment' do
+      it { is_expected.to validate_optional_field(:escort_risk_assessment) }
+      it { is_expected.to be_configured_to_reset([:escort_risk_assessment_completion_date]).when(:escort_risk_assessment).not_set_to('yes') }
+
+      context 'when is set to unknown' do
+        before { form.escort_risk_assessment = 'unknown' }
+        include_examples 'valid form'
+      end
+
+      context 'when is set to no' do
+        before { form.escort_risk_assessment = 'no' }
+        include_examples 'valid form'
+      end
+
+      context 'when is set to yes' do
+        before { form.escort_risk_assessment = 'yes' }
+
+        context 'but the completion date is not set' do
+          before { form.escort_risk_assessment_completion_date = nil }
+
+          let(:attr_with_error) { :escort_risk_assessment_completion_date }
+          let(:error_message) { 'is not a valid date' }
+
+          it 'adds an inclusion error to the form errors' do
+            expect(form).not_to be_valid
+            expect(form.errors.keys).to match_array([attr_with_error])
+            expect(form.errors[attr_with_error]).to match_array([error_message])
+          end
+        end
+
+        context 'but the completion date is not a valid date' do
+          before { form.escort_risk_assessment_completion_date = 'not-a-date' }
+
+          let(:attr_with_error) { :escort_risk_assessment_completion_date }
+          let(:error_message) { 'is not a valid date' }
+
+          it 'adds an inclusion error to the form errors' do
+            expect(form).not_to be_valid
+            expect(form.errors.keys).to match_array([attr_with_error])
+            expect(form.errors[attr_with_error]).to match_array([error_message])
+          end
+        end
+
+        context 'but the completion date is in the future' do
+          before { form.escort_risk_assessment_completion_date = Date.tomorrow }
+
+          let(:attr_with_error) { :escort_risk_assessment_completion_date }
+          let(:error_message) { 'is in the future' }
+
+          it 'adds an inclusion error to the form errors' do
+            expect(form).not_to be_valid
+            expect(form.errors.keys).to match_array([attr_with_error])
+            expect(form.errors[attr_with_error]).to match_array([error_message])
+          end
+        end
+
+        context 'and the completion date is valid' do
+          before { form.escort_risk_assessment_completion_date = '14/02/2016' }
+          include_examples 'valid form'
+        end
+      end
+    end
+
+    context 'escape_pack' do
+      it { is_expected.to validate_optional_field(:escape_pack) }
+      it { is_expected.to be_configured_to_reset([:escape_pack_completion_date]).when(:escape_pack).not_set_to('yes') }
+
+      context 'when is set to unknown' do
+        before { form.escape_pack = 'unknown' }
+        include_examples 'valid form'
+      end
+
+      context 'when is set to no' do
+        before { form.escape_pack = 'no' }
+        include_examples 'valid form'
+      end
+
+      context 'when is set to yes' do
+        before { form.escape_pack = 'yes' }
+
+        context 'but the completion date is not set' do
+          before { form.escape_pack_completion_date = nil }
+
+          let(:attr_with_error) { :escape_pack_completion_date }
+          let(:error_message) { 'is not a valid date' }
+
+          it 'adds an inclusion error to the form errors' do
+            expect(form).not_to be_valid
+            expect(form.errors.keys).to match_array([attr_with_error])
+            expect(form.errors[attr_with_error]).to match_array([error_message])
+          end
+        end
+
+        context 'but the completion date is not a valid date' do
+          before { form.escape_pack_completion_date = 'not-a-date' }
+
+          let(:attr_with_error) { :escape_pack_completion_date }
+          let(:error_message) { 'is not a valid date' }
+
+          it 'adds an inclusion error to the form errors' do
+            expect(form).not_to be_valid
+            expect(form.errors.keys).to match_array([attr_with_error])
+            expect(form.errors[attr_with_error]).to match_array([error_message])
+          end
+        end
+
+        context 'but the completion date is in the future' do
+          before { form.escape_pack_completion_date = Date.tomorrow }
+
+          let(:attr_with_error) { :escape_pack_completion_date }
+          let(:error_message) { 'is in the future' }
+
+          it 'adds an inclusion error to the form errors' do
+            expect(form).not_to be_valid
+            expect(form.errors.keys).to match_array([attr_with_error])
+            expect(form.errors[attr_with_error]).to match_array([error_message])
+          end
+        end
+
+        context 'and the completion date is valid' do
+          before { form.escape_pack_completion_date = '14/02/2016' }
+          include_examples 'valid form'
+        end
+      end
+    end
   end
 
   describe '#save' do
     it 'sets the data on the model' do
-      subject.validate(params)
-      subject.save
+      form.validate(params)
+      form.save
 
-      form_attributes = subject.to_nested_hash
+      form_attributes = form.to_nested_hash
       model_attributes = model.attributes
 
       expect(model_attributes).to include form_attributes

--- a/spec/forms/risk/security_spec.rb
+++ b/spec/forms/risk/security_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Forms::Risk::Security, type: :form do
   let(:model) { Risk.new }
-  subject { described_class.new(model) }
+  subject(:form) { described_class.new(model) }
 
   let(:params) {
     {
@@ -19,7 +19,7 @@ RSpec.describe Forms::Risk::Security, type: :form do
   }
 
   describe '#validate' do
-    it { is_expected.to validate_optional_details_field(:current_e_risk) }
+    it { is_expected.to validate_optional_field(:current_e_risk) }
     it { is_expected.to validate_optional_details_field(:category_a) }
     it { is_expected.to validate_optional_details_field(:restricted_status) }
 
@@ -27,6 +27,35 @@ RSpec.describe Forms::Risk::Security, type: :form do
       subject.validate(params)
       coerced_params = params.merge('escape_pack' => true, 'escape_risk_assessment' => true, 'cuffing_protocol' => true)
       expect(subject.to_nested_hash).to eq coerced_params
+    end
+
+    context 'current_e_risk attribute' do
+      shared_examples_for 'no current E risks' do
+        it do
+          is_expected.
+            not_to validate_inclusion_of(:current_e_risk_details).
+            in_array(%w[e_list_standard e_list_escort e_list_heightened])
+        end
+      end
+
+      context "when current_e_risk is set to no" do
+        before { form.current_e_risk = 'no' }
+        include_examples 'no current E risks'
+      end
+
+      context "when current_e_risk is set to unknown" do
+        before { form.current_e_risk = 'unknown' }
+        include_examples 'no current E risks'
+      end
+
+      context "when current_e_risk is set to yes" do
+        before { form.current_e_risk = 'yes' }
+        it do
+          is_expected.
+            to validate_inclusion_of(:current_e_risk_details).
+            in_array(%w[e_list_standard e_list_escort e_list_heightened])
+        end
+      end
     end
   end
 

--- a/spec/forms/risk/violence_spec.rb
+++ b/spec/forms/risk/violence_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe Forms::Risk::Violence, type: :form do
       end
 
       describe 'details fields associated with checkboxes' do
-        it { is_expected.not_to be_configured_to_reset(['risk_to_females_details']).when(:risk_to_females).not_set_to(true) }
-        it { is_expected.not_to be_configured_to_reset(['homophobic_details']).when(:homophobic).not_set_to(true) }
-        it { is_expected.to be_configured_to_reset(['racist_details']).when(:racist).not_set_to(true) }
-        it { is_expected.to be_configured_to_reset(['other_violence_due_to_discrimination_details']).when(:other_violence_due_to_discrimination).not_set_to(true) }
+        it { is_expected.not_to be_configured_to_reset([:risk_to_females_details]).when(:risk_to_females).not_set_to(true) }
+        it { is_expected.not_to be_configured_to_reset([:homophobic_details]).when(:homophobic).not_set_to(true) }
+        it { is_expected.to be_configured_to_reset([:racist_details]).when(:racist).not_set_to(true) }
+        it { is_expected.to be_configured_to_reset([:other_violence_due_to_discrimination_details]).when(:other_violence_due_to_discrimination).not_set_to(true) }
       end
     end
 
@@ -76,10 +76,10 @@ RSpec.describe Forms::Risk::Violence, type: :form do
       end
 
       describe 'details fields associated with checkboxes' do
-        it { is_expected.not_to be_configured_to_reset(['risk_to_females_details']).when(:risk_to_females).not_set_to(true) }
-        it { is_expected.not_to be_configured_to_reset(['homophobic_details']).when(:homophobic).not_set_to(true) }
-        it { is_expected.to be_configured_to_reset(['racist_details']).when(:racist).not_set_to(true) }
-        it { is_expected.to be_configured_to_reset(['other_violence_due_to_discrimination_details']).when(:other_violence_due_to_discrimination).not_set_to(true) }
+        it { is_expected.not_to be_configured_to_reset([:risk_to_females_details]).when(:risk_to_females).not_set_to(true) }
+        it { is_expected.not_to be_configured_to_reset([:homophobic_details]).when(:homophobic).not_set_to(true) }
+        it { is_expected.to be_configured_to_reset([:racist_details]).when(:racist).not_set_to(true) }
+        it { is_expected.to be_configured_to_reset([:other_violence_due_to_discrimination_details]).when(:other_violence_due_to_discrimination).not_set_to(true) }
       end
     end
 

--- a/spec/models/risk_workflow_spec.rb
+++ b/spec/models/risk_workflow_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe RiskWorkflow do
 
   describe '.sections' do
     specify {
-      expect(described_class.sections).to match_array(%i[risk_to_self risk_from_others violence hostage_taker harassments sex_offences non_association_markers security substance_misuse concealed_weapons arson communication])
+      expect(described_class.sections)
+        .to match_array(%i[risk_to_self risk_from_others violence hostage_taker
+                           harassments sex_offences non_association_markers security
+                           substance_misuse concealed_weapons arson communication])
     }
   end
 
@@ -17,8 +20,8 @@ RSpec.describe RiskWorkflow do
           %w[ acct_status rule_45 csra victim_of_abuse high_profile violence_due_to_discrimination
               violence_to_staff violence_to_other_detainees violence_to_general_public
               hostage_taker harassment intimidation sex_offence non_association_markers
-              current_e_risk category_a
-              restricted_status substance_supply substance_use conceals_weapons arson
+              current_e_risk previous_escape_attempts category_a escort_risk_assessment
+              escape_pack substance_supply substance_use conceals_weapons arson
               damage_to_property interpreter_required hearing_speach_sight
               can_read_and_write ])
     end


### PR DESCRIPTION
[Trello #350](https://trello.com/c/dyXCb5M5/350-5-as-someone-working-in-security-in-a-prison-when-filling-in-a-digital-per-i-want-to-be-able-to-complete-security-details-as-par)

 - Removes unnecessary questions for security risk section that are no
    longer used
- Adds new columns for new questions required by the security risk
    section
 - Change form for security risk section to comply with the new
    requirements

As an added feature of this PR, it support a more flexible way of localising the data of the application, which was a bit limited by the restrictions that the use of the gov-form-builder gem sets on the application.