### PR TITLE
Concealed weapons changes

### DIFF
--- a/app/models/forms/risk/concealed_weapons.rb
+++ b/app/models/forms/risk/concealed_weapons.rb
@@ -1,7 +1,40 @@
 module Forms
   module Risk
     class ConcealedWeapons < Forms::Base
-      optional_details_field :conceals_weapons
+      optional_details_field :conceals_weapons, default: 'unknown'
+      optional_details_field :conceals_drugs, default: 'unknown'
+      optional_field :conceals_mobile_phone_or_other_items, default: 'unknown'
+      optional_checkbox :conceals_mobile_phones
+      optional_checkbox :conceals_sim_cards
+      optional_checkbox_with_details :conceals_other_items, :conceals_mobile_phone_or_other_items
+      reset attributes: %i[
+        conceals_mobile_phones conceals_sim_cards
+        conceals_other_items conceals_other_items_details
+      ], if_falsey: :conceals_mobile_phone_or_other_items
+
+      validate :valid_conceals_mobile_phone_or_other_items_options,
+        if: -> { conceals_mobile_phone_or_other_items == 'yes' }
+
+      def valid_conceals_mobile_phone_or_other_items_options
+        if selected_conceals_mobile_phone_or_other_items_options.none?
+          errors.add(:base, :minimum_one_option, options: conceals_mobile_phone_or_other_items_options.join(', '))
+        end
+      end
+
+      private
+
+      def selected_conceals_mobile_phone_or_other_items_options
+        [conceals_mobile_phones,
+         conceals_sim_cards,
+         conceals_other_items]
+      end
+
+      def conceals_mobile_phone_or_other_items_options
+        %i[conceals_mobile_phones conceals_sim_cards
+           conceals_other_items].map do |attr|
+          I18n.t(attr, scope: [:helpers, :label, :concealed_weapons])
+        end
+      end
     end
   end
 end

--- a/app/models/sections/risk_assessment/concealed_weapons_section.rb
+++ b/app/models/sections/risk_assessment/concealed_weapons_section.rb
@@ -5,8 +5,22 @@ module RiskAssessment
     end
 
     def questions
-      %w[conceals_weapons]
+      %w[conceals_weapons conceals_drugs conceals_mobile_phones
+         conceals_sim_cards conceals_other_items]
     end
-    alias mandatory_questions questions
+
+    def mandatory_questions
+      %w[conceals_weapons conceals_drugs conceals_mobile_phone_or_other_items]
+    end
+
+    private
+
+    def question_dependencies
+      {
+        conceals_mobile_phone_or_other_items: %i[
+          conceals_mobile_phones conceals_sim_cards conceals_other_items
+        ]
+      }
+    end
   end
 end

--- a/app/views/risks/_concealed_weapons.html.slim
+++ b/app/views/risks/_concealed_weapons.html.slim
@@ -1,1 +1,10 @@
 = f.radio_toggle_with_textarea :conceals_weapons
+= f.radio_toggle_with_textarea :conceals_drugs
+= f.radio_toggle :conceals_mobile_phone_or_other_items do
+  fieldset
+    span.form-hint
+      | Select all that apply
+
+    = f.checkbox :conceals_mobile_phones
+    = f.checkbox :conceals_sim_cards
+    = f.checkbox_with_textarea :conceals_other_items

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,7 +12,8 @@ en:
         hearing_speach_sight: Does the detainee have hearing / speech / sight impairments?
         interpreter_required: Interpreter required?
       concealed_weapons:
-        conceals_weapons: Concealed weapons, mobile phones or other items
+        conceals_weapons: Conceals weapons
+        conceals_mobile_phone_or_other_items: Conceals mobile phones, SIMs or other items
       harassments:
         harassment: Harasser
         intimidation: Intimidator / bully
@@ -84,6 +85,13 @@ en:
       concealed_weapons:
         conceals_weapons_choices:
           unknown: Clear selection
+        conceals_drugs_choices:
+          unknown: Clear selection
+        conceals_mobile_phones: Mobile phones
+        conceals_mobile_phone_or_other_items_choices:
+          unknown: Clear selection
+        conceals_other_items: Other
+        conceals_sim_cards: SIM cards
       detainee_details:
         surname: Surname
         forenames: Forename(s)
@@ -246,8 +254,9 @@ en:
         hearing_speach_sight_details: Record any barriers (including language barriers) to verbal communication
         language: For which language?
       concealed_weapons:
-        conceals_weapons: Eg drugs, blade, mobile phone, cash, lighter, sim card
-        conceals_weapons_details: Give details
+        conceals_weapons_details: List the types of weapons and how they were hidden
+        conceals_drugs_details: Give details of previous incidents and methods used
+        conceals_other_items_details: Give details
       detainee_details:
         date_of_birth: DD/MM/YYYY
       harassments:
@@ -349,7 +358,7 @@ en:
       title:
         arson: Arson and damage to property
         communication: Communication / language difficulties
-        concealed_weapons: Concealed weapons or other items
+        concealed_weapons: Concealed weapons, drugs or other items
         harassments: Risk to others - harasser and/or bully
         hostage_taker: Risk to others - hostage taker
         non_association_markers: Risk to others
@@ -370,8 +379,6 @@ en:
           can_read_and_write: Reading / writing issues
           hearing_speach_sight: Hearing / speech / sight issues
           interpreter_required: Interpreter required
-        concealed_weapons:
-          conceals_weapons: Concealed weapons or other items
         harassments:
           harassment: Harasser
           intimidation: Intimidator / bully
@@ -414,7 +421,7 @@ en:
       titles:
         arson: Arson and damage to property
         communication: Communication / language difficulties
-        concealed_weapons: Concealed weapons or other items
+        concealed_weapons: Concealed weapons, drugs or other items
         harassments: "Risk to others: Harasser / intimidator / bully"
         hostage_taker: "Risk to others: Hostage taker"
         mental: Mental healthcare

--- a/db/migrate/20161223101818_add_conceals_weapons_risk_new_columns.rb
+++ b/db/migrate/20161223101818_add_conceals_weapons_risk_new_columns.rb
@@ -1,0 +1,11 @@
+class AddConcealsWeaponsRiskNewColumns < ActiveRecord::Migration[5.0]
+  def change
+    add_column :risks, :conceals_drugs, :string
+    add_column :risks, :conceals_drugs_details, :text
+    add_column :risks, :conceals_mobile_phone_or_other_items, :text
+    add_column :risks, :conceals_mobile_phones, :boolean
+    add_column :risks, :conceals_sim_cards, :boolean
+    add_column :risks, :conceals_other_items, :boolean
+    add_column :risks, :conceals_other_items_details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161222102920) do
+ActiveRecord::Schema.define(version: 20161223101818) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -232,6 +232,13 @@ ActiveRecord::Schema.define(version: 20161222102920) do
     t.date     "escort_risk_assessment_completion_date"
     t.string   "escape_pack"
     t.date     "escape_pack_completion_date"
+    t.string   "conceals_drugs"
+    t.text     "conceals_drugs_details"
+    t.text     "conceals_mobile_phone_or_other_items"
+    t.boolean  "conceals_mobile_phones"
+    t.boolean  "conceals_sim_cards"
+    t.boolean  "conceals_other_items"
+    t.text     "conceals_other_items_details"
     t.index ["detainee_id"], name: "index_risks_on_detainee_id", using: :btree
   end
 

--- a/spec/factories/risk_factory.rb
+++ b/spec/factories/risk_factory.rb
@@ -22,6 +22,8 @@ FactoryGirl.define do
     substance_supply 'no'
     substance_use 'no'
     conceals_weapons 'no'
+    conceals_drugs 'no'
+    conceals_mobile_phone_or_other_items 'no'
     arson 'no'
     damage_to_property 'no'
     interpreter_required 'no'

--- a/spec/features/pages/risk.rb
+++ b/spec/features/pages/risk.rb
@@ -225,8 +225,40 @@ module Page
     end
 
     def fill_in_concealed_weapons
-      fill_in_optional_details('Concealed weapons, mobile phones or other items', @risk, :conceals_weapons)
+      fill_in_optional_details('Conceals weapons', @risk, :conceals_weapons)
+      fill_in_optional_details('Conceals drugs', @risk, :conceals_drugs)
+      fill_in_concealed_mobile_phone_or_other_items
       save_and_continue
+    end
+
+    def fill_in_concealed_mobile_phone_or_other_items
+      if @risk.conceals_mobile_phone_or_other_items == 'yes'
+        choose 'concealed_weapons_conceals_mobile_phone_or_other_items_yes'
+        fill_in_concealed_mobile_phones
+        fill_in_concealed_sim_cards
+        fill_in_concealed_other_items
+      else
+        choose 'concealed_weapons_conceals_mobile_phone_or_other_items_no'
+      end
+    end
+
+    def fill_in_concealed_mobile_phones
+      if @risk.conceals_mobile_phones
+        check 'concealed_weapons_conceals_mobile_phones'
+      end
+    end
+
+    def fill_in_concealed_sim_cards
+      if @risk.conceals_other_items
+        check 'concealed_weapons_conceals_sim_cards'
+      end
+    end
+
+    def fill_in_concealed_other_items
+      if @risk.conceals_other_items
+        check 'concealed_weapons_conceals_other_items'
+        fill_in 'concealed_weapons_conceals_other_items_details', with: @risk.conceals_other_items_details
+      end
     end
 
     def fill_in_arson

--- a/spec/features/pages/risk_summary.rb
+++ b/spec/features/pages/risk_summary.rb
@@ -16,7 +16,7 @@ module Page
       check_section(risk, 'non_association_markers', %w[ non_association_markers ])
       check_security_section(risk)
       check_section(risk, 'substance_misuse', %w[ substance_supply substance_use ])
-      check_section(risk, 'concealed_weapons', %w[ conceals_weapons ])
+      check_concealed_weapons_section(risk)
       check_section(risk, 'arson', %w[ arson damage_to_property ])
       check_section(risk, 'communication', %w[ interpreter_required hearing_speach_sight can_read_and_write ])
     end
@@ -176,6 +176,22 @@ module Page
         check_section(risk, 'security', fields)
       else
         check_section_is_all_no(risk, 'security', fields)
+      end
+    end
+
+    def check_concealed_weapons_section(risk)
+      check_section(risk, 'concealed_weapons', %w[conceals_weapons])
+      check_section(risk, 'concealed_weapons', %w[conceals_drugs])
+      check_conceals_mobile_phone_or_other_items(risk)
+    end
+
+    def check_conceals_mobile_phone_or_other_items(risk)
+      fields = %w[conceals_mobile_phones conceals_sim_cards
+                  conceals_other_items]
+      if risk.conceals_mobile_phone_or_other_items == 'yes'
+        check_section(risk, 'concealed_weapons', fields)
+      else
+        check_section_is_all_no(risk, 'concealed_weapons', fields)
       end
     end
   end

--- a/spec/forms/risk/concealed_weapons_spec.rb
+++ b/spec/forms/risk/concealed_weapons_spec.rb
@@ -2,25 +2,92 @@ require 'rails_helper'
 
 RSpec.describe Forms::Risk::ConcealedWeapons, type: :form do
   let(:model) { Risk.new }
-  subject { described_class.new(model) }
+  subject(:form) { described_class.new(model) }
 
   let(:params) {
     {
       'conceals_weapons' => 'yes',
       'conceals_weapons_details' => 'Guns and rifles',
+      'conceals_drugs' => 'yes',
+      'conceals_drugs_details' => 'Guns and rifles',
+      'conceals_mobile_phone_or_other_items' => 'yes',
+      'conceals_mobile_phones' => '1',
+      'conceals_sim_cards' => '1',
+      'conceals_other_items' => '1',
+      'conceals_other_items_details' => 'Other items'
     }
   }
 
   describe '#validate' do
+    shared_examples_for 'valid form' do
+      it 'no error is added to the error list' do
+        expect(form).to be_valid
+        expect(form.errors.keys).to be_empty
+      end
+    end
+
     it { is_expected.to validate_optional_details_field(:conceals_weapons) }
+    it { is_expected.to validate_optional_details_field(:conceals_drugs) }
+
+    context 'conceals_mobile_phone_or_other_items' do
+      it { is_expected.to validate_optional_field(:conceals_mobile_phone_or_other_items) }
+
+      it do
+        is_expected.to be_configured_to_reset(%i[
+          conceals_mobile_phones conceals_sim_cards
+          conceals_other_items conceals_other_items_details
+        ]).when(:conceals_mobile_phone_or_other_items).not_set_to('yes')
+      end
+
+      it { is_expected.to be_configured_to_reset([:conceals_other_items_details]).when(:conceals_other_items).not_set_to(true) }
+
+      context 'when is set to unknown' do
+        before { form.conceals_mobile_phone_or_other_items = 'unknown' }
+        include_examples 'valid form'
+      end
+
+      context 'when is set to no' do
+        before { form.conceals_mobile_phone_or_other_items = 'no' }
+        include_examples 'valid form'
+      end
+
+      context 'when is set to yes' do
+        before { form.conceals_mobile_phone_or_other_items = 'yes' }
+
+        context 'and no type concealed other items is selected' do
+          before do
+            form.conceals_mobile_phones = false
+            form.conceals_sim_cards = false
+            form.conceals_other_items = false
+          end
+
+          let(:attr_with_error) { :base }
+          let(:error_message) { 'At least one option (Mobile phones, SIM cards, Other) needs to be provided' }
+
+          it { is_expected.not_to validate_presence_of(:conceals_other_items_details) }
+
+          it 'inclusion error is added to the error list' do
+            expect(form).not_to be_valid
+            expect(form.errors.keys).to match_array([attr_with_error])
+            expect(form.errors[attr_with_error]).to match_array([error_message])
+          end
+        end
+
+        context 'and other concealed items is set to true' do
+          before { form.conceals_other_items = true }
+
+          it { is_expected.to validate_presence_of(:conceals_other_items_details) }
+        end
+      end
+    end
   end
 
   describe '#save' do
     it 'sets the data on the model' do
-      subject.validate(params)
-      subject.save
+      form.validate(params)
+      form.save
 
-      form_attributes = subject.to_nested_hash
+      form_attributes = form.to_nested_hash
       model_attributes = model.attributes
 
       expect(model_attributes).to include form_attributes

--- a/spec/models/risk_workflow_spec.rb
+++ b/spec/models/risk_workflow_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe RiskWorkflow do
   describe '.mandatory_questions' do
     it 'returns the appropriate list of mandatory questions' do
       expect(described_class.mandatory_questions).to match_array(
-          %w[ acct_status rule_45 csra victim_of_abuse high_profile violence_due_to_discrimination
-              violence_to_staff violence_to_other_detainees violence_to_general_public
-              hostage_taker harassment intimidation sex_offence non_association_markers
-              current_e_risk previous_escape_attempts category_a escort_risk_assessment
-              escape_pack substance_supply substance_use conceals_weapons arson
-              damage_to_property interpreter_required hearing_speach_sight
-              can_read_and_write ])
+          %w[acct_status rule_45 csra victim_of_abuse high_profile violence_due_to_discrimination
+             violence_to_staff violence_to_other_detainees violence_to_general_public
+             hostage_taker harassment intimidation sex_offence non_association_markers
+             current_e_risk previous_escape_attempts category_a escort_risk_assessment
+             escape_pack substance_supply substance_use conceals_weapons conceals_drugs
+             conceals_mobile_phone_or_other_items  arson damage_to_property
+             interpreter_required hearing_speach_sight can_read_and_write])
     end
   end
 end


### PR DESCRIPTION
[Trello #372](https://trello.com/c/pyf6uYI1/372-3-as-someone-working-in-security-in-a-prison-when-filling-in-a-digital-per-i-want-to-be-able-to-complete-details-about-whether-a)

- Adds new questions necessary for the new designs for the "Concealed weapons, drugs or other items" risk section
-Makes use of the changes made in the security changes PR, namely the new localisation options.