### PR TITLE
Fix very poor error handling for risk assessment confirmation

### DIFF
--- a/app/assets/stylesheets/moving_people_safely/_alerts.scss
+++ b/app/assets/stylesheets/moving_people_safely/_alerts.scss
@@ -18,3 +18,9 @@
 .alert--alert {
   @include alert-variant(#F4D188, #FAF1C5)
 }
+
+.alert--error {
+  border: 5px solid #B10E1E;
+  color: #B10E1E;
+  font-weight: bold;
+}

--- a/app/controllers/risks_controller.rb
+++ b/app/controllers/risks_controller.rb
@@ -25,11 +25,14 @@ class RisksController < DetaineeController
     render 'summary/risk'
   end
 
-  # what does error state look like?
   def confirm
-    raise unless risk.all_questions_answered?
-    risk_workflow.confirm_with_user!(user: current_user)
-    redirect_to profile_path(active_move)
+    if risk.all_questions_answered?
+      risk_workflow.confirm_with_user!(user: current_user)
+      redirect_to profile_path(active_move)
+    else
+      flash.now[:error] = t('alerts.unable_to_confirm_incomplete_risk_assessment')
+      render 'summary/risk'
+    end
   end
 
   private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -427,3 +427,4 @@ en:
     detainee_already_exists: "Detainee already exists. You've been redirected to the next relevant form"
     detainee:
       pre_filling_unavailable: "Pre-filling unavailable. Please fill in the details manually"
+    unable_to_confirm_incomplete_risk_assessment: Risk assessment cannot be confirmed until all mandatory answered are filled

--- a/spec/factories/detainee_factory.rb
+++ b/spec/factories/detainee_factory.rb
@@ -37,5 +37,9 @@ FactoryGirl.define do
     trait :with_no_current_offences do
       association :offences, :with_no_current_offences, factory: :offences, strategy: :build
     end
+
+    trait :with_incomplete_risk_assessment do
+      association :risk, :incomplete, strategy: :build
+    end
   end
 end

--- a/spec/factories/risk_factory.rb
+++ b/spec/factories/risk_factory.rb
@@ -32,5 +32,11 @@ FactoryGirl.define do
     trait :with_high_csra do
       csra 'high'
     end
+
+    trait :incomplete do
+      rule_45 'unknown'
+      harassment 'unknown'
+      conceals_weapons 'unknown'
+    end
   end
 end

--- a/spec/factories/workflow_factory.rb
+++ b/spec/factories/workflow_factory.rb
@@ -1,17 +1,17 @@
 FactoryGirl.define do
   factory :workflow do
-    status 0
+    status :not_started
 
     trait :incomplete do
-      status 2
+      status :incomplete
     end
 
     trait :confirmed do
-      status 4
+      status :confirmed
     end
 
     trait :issued do
-      status 5
+      status :issued
     end
   end
 

--- a/spec/requests/confirm_risk_assessment_request_spec.rb
+++ b/spec/requests/confirm_risk_assessment_request_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe 'Confirm risk assessment requests', type: :request do
+  let(:detainee) { FactoryGirl.create(:detainee) }
+
+  context 'when user is not autenticated' do
+    it 'redirects the user to the login page' do
+      put "/#{detainee.id}/risk/confirm"
+      expect(response.status).to eq(302)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  context 'when user is autenticated' do
+    before { sign_in FactoryGirl.create(:user) }
+
+    context 'but there is no active move' do
+      before do
+        FactoryGirl.create(:move, :issued, detainee: detainee)
+      end
+
+      it 'redirects the user to the login page' do
+        put "/#{detainee.id}/risk/confirm"
+        expect(response.status).to eq(302)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context 'and the risk assessment is not yet complete' do
+      let(:detainee) { FactoryGirl.create(:detainee, :with_incomplete_risk_assessment) }
+      let(:create_move) { FactoryGirl.create(:move, :with_incomplete_risk_workflow, detainee: detainee) }
+      let(:risk_workflow) { create_move.risk_workflow }
+
+      before { create_move }
+
+      it 'sets a flash error' do
+        put "/#{detainee.id}/risk/confirm"
+        expect(response.status).to eq(200)
+        expect(flash[:error]).to eq('Risk assessment cannot be confirmed until all mandatory answered are filled')
+      end
+
+      it 'does not change the state of the risk workflow' do
+        expect {
+          put "/#{detainee.id}/risk/confirm"
+        }.not_to change { risk_workflow.reload.status }.from('incomplete')
+      end
+    end
+
+    context 'and the risk assessment is complete' do
+      let(:create_move) { FactoryGirl.create(:move, :with_incomplete_risk_workflow, detainee: detainee) }
+      alias move create_move
+      let(:risk_workflow) { move.risk_workflow }
+
+      before { create_move }
+
+      it 'redirects to the profile page' do
+        put "/#{detainee.id}/risk/confirm"
+        expect(response.status).to eq(302)
+        expect(response).to redirect_to(profile_path(move))
+      end
+
+      it 'marks risk workflow as confirmed' do
+        expect {
+          put "/#{detainee.id}/risk/confirm"
+        }.to change { risk_workflow.reload.status }.from('incomplete').to('confirmed')
+      end
+    end
+  end
+end


### PR DESCRIPTION
- The current implementation was just raising an exception which would
just end up in a 500 error
- The new implementation sets a flash error with the appropriate message
and renders the current page being displayed
- Added some style to display error alerts
- Fixed factory traits for workflows that had status numbers that didn't
match the enum set in the model
- Added a request test to assert all the behaviour changes