### PR TITLE
Arson and damage risk changes

### DIFF
--- a/app/models/forms/risk/arson.rb
+++ b/app/models/forms/risk/arson.rb
@@ -1,19 +1,8 @@
 module Forms
   module Risk
     class Arson < Forms::Base
-      ARSON_VALUES = %w[index_offence behavioural_issue small_risk].freeze
-
-      optional_details_field :arson
-      property :arson_value, type: StrictString
-      optional_details_field :damage_to_property
-
-      validates :arson_value,
-        inclusion: { in: ARSON_VALUES },
-        allow_blank: true
-
-      def arson_values
-        ARSON_VALUES
-      end
+      optional_field :arson, default: 'unknown'
+      optional_field :damage_to_property, default: 'unknown'
     end
   end
 end

--- a/app/views/risks/_arson.html.slim
+++ b/app/views/risks/_arson.html.slim
@@ -1,7 +1,2 @@
-= f.radio_toggle :arson do
-  .form-group
-    = f.radio_button_fieldset :arson_value,
-      choices: f.object.arson_values
-  = f.text_area_without_label :arson_details
-
-= f.radio_toggle_with_textarea :damage_to_property
+= f.radio_toggle :arson
+= f.radio_toggle :damage_to_property

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,9 +4,9 @@ en:
       allergies:
         allergies: Allergies?
       arson:
-        arson: Arson?
+        arson: Arson is a behavioural issue
         arson_value: ''
-        damage_to_property: Damage to property?
+        damage_to_property: Damage to property
       communication:
         can_read_and_write: Does the detainee have reading / writing issues?
         hearing_speach_sight: Does the detainee have hearing / speech / sight impairments?
@@ -247,7 +247,10 @@ en:
         allergies_details: Give details and explain the significance
       arson:
         arson_details: Give details of last arson attack, including date
-        damage_to_property: Eg damage to own cell, to others' property, check adjudications
+        damage_to_property_html: |
+          Such as damage to own cell or other people's things
+          </br>
+          Check adjudications for more information
         damage_to_property_details: Give details
       communication:
         can_read_and_write_details: Record any barriers (including language barriers) to reading or written communication

--- a/db/migrate/20161228115106_remove_arson_risk_old_columns.rb
+++ b/db/migrate/20161228115106_remove_arson_risk_old_columns.rb
@@ -1,0 +1,7 @@
+class RemoveArsonRiskOldColumns < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :risks, :arson_details
+    remove_column :risks, :arson_value
+    remove_column :risks, :damage_to_property_details
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161223155924) do
+ActiveRecord::Schema.define(version: 20161228115106) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -160,10 +160,7 @@ ActiveRecord::Schema.define(version: 20161223155924) do
     t.string   "conceals_weapons",                                  default: "unknown"
     t.text     "conceals_weapons_details"
     t.string   "arson",                                             default: "unknown"
-    t.text     "arson_details"
-    t.string   "arson_value"
     t.string   "damage_to_property",                                default: "unknown"
-    t.text     "damage_to_property_details"
     t.string   "interpreter_required",                              default: "unknown"
     t.text     "language"
     t.string   "hearing_speach_sight",                              default: "unknown"

--- a/spec/features/pages/risk.rb
+++ b/spec/features/pages/risk.rb
@@ -268,12 +268,15 @@ module Page
     def fill_in_arson
       if @risk.arson == 'yes'
         choose 'arson_arson_yes'
-        choose "arson_arson_value_#{@risk.arson_value}"
-        fill_in 'arson_arson_details', with: @risk.arson_details
       else
         choose 'arson_arson_no'
       end
-      fill_in_optional_details('Damage to property?', @risk, :damage_to_property)
+
+      if @risk.damage_to_property == 'yes'
+        choose 'arson_damage_to_property_yes'
+      else
+        choose 'arson_damage_to_property_no'
+      end
       save_and_continue
     end
 

--- a/spec/forms/risk/arson_spec.rb
+++ b/spec/forms/risk/arson_spec.rb
@@ -7,20 +7,13 @@ RSpec.describe Forms::Risk::Arson, type: :form do
   let(:params) {
     {
       'arson' => 'yes',
-      'arson_value' => 'index_offence',
-      'arson_details' => 'Burnt entire forests',
-      'damage_to_property' => 'yes',
-      'damage_to_property_details' => 'Several garages',
+      'damage_to_property' => 'yes'
     }
   }
 
   describe '#validate' do
-    it { is_expected.to validate_optional_details_field(:damage_to_property) }
-    it { is_expected.to validate_optional_details_field(:arson) }
-    it {
-      is_expected.to validate_inclusion_of(:arson_value).
-        in_array(%w[ index_offence behavioural_issue small_risk ])
-    }
+    it { is_expected.to validate_optional_field(:damage_to_property) }
+    it { is_expected.to validate_optional_field(:arson) }
   end
 
   describe '#save' do


### PR DESCRIPTION
[Trello #373](https://trello.com/c/7iamqjYF/373-1-as-someone-working-in-security-in-a-prison-when-filling-in-a-digital-per-i-want-to-be-able-to-complete-details-about-whether-a)

- Remove unnecessary question in the new Risk of Arson section design
- Change Risk of Arson form to match the requirements for the new design