### PR TITLE
Improve error messages when fetching detainee details fails

### DIFF
--- a/app/services/api_detainee_details_mapper.rb
+++ b/app/services/api_detainee_details_mapper.rb
@@ -1,0 +1,72 @@
+require 'countries'
+
+class ApiDetaineeDetailsMapper
+  attr_reader :prison_number, :details
+
+  def initialize(prison_number, details)
+    @prison_number = prison_number
+    @details = details.with_indifferent_access
+  end
+
+  def call
+    {
+      prison_number: prison_number,
+      forenames: mapped_forenames,
+      surname: details[:surname],
+      date_of_birth: mapped_dob,
+      gender: mapped_gender,
+      nationalities: mapped_nationality,
+      pnc_number: details[:pnc_number],
+      cro_number: details[:cro_number]
+    }.with_indifferent_access
+  end
+
+  private
+
+  def dob
+    details[:date_of_birth]
+  end
+
+  def mapped_dob
+    return unless dob.present?
+    Date.parse(dob).strftime('%d/%m/%Y')
+  rescue
+    nil
+  end
+
+  def given_name
+    details[:given_name]
+  end
+
+  def middle_names
+    details[:middle_names]
+  end
+
+  def names
+    [given_name, middle_names]
+  end
+
+  def mapped_forenames
+    present_names = names.select(&:present?)
+    return if present_names.empty?
+    present_names.join(' ')
+  end
+
+  def gender
+    details[:gender]
+  end
+
+  def mapped_gender
+    { 'm' => 'male', 'f' => 'female' }[gender.downcase] if gender.present?
+  end
+
+  def nationality_code
+    details[:nationality_code]
+  end
+
+  def mapped_nationality
+    return unless nationality_code.present?
+    country = ISO3166::Country.new(nationality_code)
+    (country && country.nationality) || nationality_code
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -417,5 +417,6 @@ en:
   alerts:
     detainee_already_exists: "Detainee already exists. You've been redirected to the next relevant form"
     detainee:
-      pre_filling_unavailable: "Pre-filling unavailable. Please fill in the details manually"
+      pre_filling_unavailable: "Look-Up function is not currently available. Please enter person details manually or try again later"
+      details_not_found: "No record for that prison reference exists. Please check the reference used or enter the details manually"
     unable_to_confirm_incomplete_risk_assessment: Risk assessment cannot be confirmed until all mandatory answered are filled

--- a/spec/requests/new_detainee_request_spec.rb
+++ b/spec/requests/new_detainee_request_spec.rb
@@ -34,5 +34,58 @@ RSpec.describe 'New detainee requests', type: :request do
         expect(response).not_to redirect_to root_path
       end
     end
+
+    it 'does not set a flash error message if no prison number is provided' do
+      get '/detainee/new'
+      expect(flash[:warning]).to eq(nil)
+    end
+
+    context 'when a prison number is provided' do
+      let(:prison_number) { 'ABC123' }
+      let(:request_path) { "/detainee/new?prison_number=#{prison_number}" }
+
+      context 'when detainee details cannot be prefetched' do
+        before do
+          stub_offenders_api_request(:get, '/offenders/search',
+                                     with: { params: { noms_id: prison_number } },
+                                     return: { body: {}, status: 201 })
+        end
+
+        it 'sets a flash error message indicating the details could not be prefetched' do
+          get request_path
+          expect(flash[:warning]).to eq('Look-Up function is not currently available. Please enter person details manually or try again later')
+        end
+      end
+
+      context 'when there are no records for the provided prison number' do
+        let(:body) { [].to_json }
+
+        before do
+          stub_offenders_api_request(:get, '/offenders/search',
+                                     with: { params: { noms_id: prison_number } },
+                                     return: { body: body, status: 200 })
+        end
+
+        it 'sets a flash error message indicating there no records in the API for the provided prison number' do
+          get request_path
+          expect(flash[:warning]).to eq('No record for that prison reference exists. Please check the reference used or enter the details manually')
+        end
+      end
+
+      context 'when api returns invalid json' do
+        let(:body) { 'not-valid-json' }
+
+        before do
+          stub_offenders_api_request(:get, '/offenders/search',
+                                     with: { params: { noms_id: prison_number } },
+                                     return: { body: body, status: 200 })
+        end
+
+        it 'sets a flash error message indicating the details could not be prefetched' do
+          get request_path
+          expect(flash[:warning]).to eq('Look-Up function is not currently available. Please enter person details manually or try again later')
+        end
+      end
+    end
   end
 end

--- a/spec/services/api_detainee_details_mapper_spec.rb
+++ b/spec/services/api_detainee_details_mapper_spec.rb
@@ -1,0 +1,168 @@
+require 'rails_helper'
+
+RSpec.describe ApiDetaineeDetailsMapper do
+  let(:prison_number) { 'ABC123' }
+  let(:given_name) { 'John' }
+  let(:middle_names) { 'C.' }
+  let(:surname) { 'Doe' }
+  let(:date_of_birth) { '1969-01-23' }
+  let(:gender) { 'm' }
+  let(:nationality_code) { 'FR' }
+  let(:pnc_number) { '12344' }
+  let(:cro_number) { '54321' }
+  let(:hash) {
+    {
+      'noms_id' => prison_number,
+      'given_name' => given_name,
+      'middle_names' => middle_names,
+      'surname' => surname,
+      'date_of_birth' => date_of_birth,
+      'gender' => gender,
+      'nationality_code' => nationality_code,
+      'pnc_number' => pnc_number,
+      'cro_number' => cro_number
+    }
+  }
+  let(:expected_result) {
+    {
+      prison_number: prison_number,
+      forenames: 'John C.',
+      surname: 'Doe',
+      date_of_birth: '23/01/1969',
+      gender: 'male',
+      nationalities: 'French',
+      pnc_number: '12344',
+      cro_number: '54321'
+    }.with_indifferent_access
+  }
+
+  subject(:mapper) { described_class.new(prison_number, hash) }
+
+  it 'returns a mapped hash with all the mandatory details' do
+    result = mapper.call
+    expected_result = {
+      prison_number: prison_number,
+      forenames: 'John C.',
+      surname: 'Doe',
+      date_of_birth: '23/01/1969',
+      gender: 'male',
+      nationalities: 'French',
+      pnc_number: '12344',
+      cro_number: '54321'
+    }.with_indifferent_access
+    expect(result).to eq(expected_result)
+  end
+
+  context 'when retrieved given name is empty' do
+    let(:given_name) { nil }
+
+    it 'returns the forenames containing only the middle names' do
+      expect(mapper.call).to eq(expected_result.merge('forenames' => 'C.'))
+    end
+  end
+
+  context 'when retrieved middle names is empty' do
+    let(:middle_names) { '' }
+
+    it 'returns the forenames containing only the given name' do
+      expect(mapper.call).to eq(expected_result.merge('forenames' => 'John'))
+    end
+  end
+
+  context 'when neither retrieved given name or middle names are present' do
+    let(:given_name) { '' }
+    let(:middle_names) { '' }
+
+    it 'returns the forenames as nil' do
+      expect(mapper.call).to eq(expected_result.merge('forenames' => nil))
+    end
+  end
+
+  context 'when retrieved surname is nil' do
+    let(:surname) { nil }
+
+    it 'returns the surname as nil' do
+      expect(mapper.call).to eq(expected_result.merge('surname' => nil))
+    end
+  end
+
+  context 'when retrieved date of birth is nil' do
+    let(:date_of_birth) { nil }
+
+    it 'returns the date of birth as nil' do
+      expect(mapper.call).to eq(expected_result.merge('date_of_birth' => nil))
+    end
+  end
+
+  context 'when retrieved date of birth is invalid' do
+    let(:date_of_birth) { 'not-a-date' }
+
+    it 'returns the date of birth as nil' do
+      expect(mapper.call).to eq(expected_result.merge('date_of_birth' => nil))
+    end
+  end
+
+  context 'when retrieved gender is nil' do
+    let(:gender) { nil }
+
+    it 'returns the gender as nil' do
+      expect(mapper.call).to eq(expected_result.merge('gender' => nil))
+    end
+  end
+
+  context 'when retrieved gender is neither male or female' do
+    let(:gender) { 'o' }
+
+    it 'returns the gender as nil' do
+      expect(mapper.call).to eq(expected_result.merge('gender' => nil))
+    end
+  end
+
+  context 'when retrieved gender is male' do
+    let(:gender) { 'm' }
+
+    it 'returns the gender as male' do
+      expect(mapper.call).to eq(expected_result.merge('gender' => 'male'))
+    end
+  end
+
+  context 'when retrieved gender is female' do
+    let(:gender) { 'f' }
+
+    it 'returns the gender as female' do
+      expect(mapper.call).to eq(expected_result.merge('gender' => 'female'))
+    end
+  end
+
+  context 'when retrieved nationality code is empty' do
+    let(:nationality_code) { '' }
+
+    it 'returns the nationalities as nil' do
+      expect(mapper.call).to eq(expected_result.merge('nationalities' => nil))
+    end
+  end
+
+  context 'when retrieved nationality code is not recognizable' do
+    let(:nationality_code) { 'RANDOM-NC' }
+
+    it 'returns the nationality code' do
+      expect(mapper.call).to eq(expected_result.merge('nationalities' => 'RANDOM-NC'))
+    end
+  end
+
+  context 'when retrieved PNC number is empty' do
+    let(:pnc_number) { nil }
+
+    it 'returns the PNC number as nil' do
+      expect(mapper.call).to eq(expected_result.merge('pnc_number' => nil))
+    end
+  end
+
+  context 'when retrieved CRO number is empty' do
+    let(:cro_number) { nil }
+
+    it 'returns the CRO number as nil' do
+      expect(mapper.call).to eq(expected_result.merge('cro_number' => nil))
+    end
+  end
+end

--- a/spec/services/detainee_details_fetcher_spec.rb
+++ b/spec/services/detainee_details_fetcher_spec.rb
@@ -5,7 +5,10 @@ RSpec.describe DetaineeDetailsFetcher do
   subject(:fetcher) { described_class.new(prison_number) }
 
   shared_examples_for 'empty response without API calls' do
-    specify { expect(fetcher.call).to eq({}) }
+    specify {
+      response = fetcher.call
+      expect(response.details).to eq({})
+    }
 
     it 'does not call the Offenders API' do
       expect(Rails.offenders_api_client).not_to receive(:get)
@@ -41,11 +44,15 @@ RSpec.describe DetaineeDetailsFetcher do
 
     include_examples 'request to Offenders API'
 
-    specify { expect(fetcher.call).to eq({}) }
+    specify {
+      response = fetcher.call
+      expect(response.details).to eq({})
+      expect(response.error).to eq('api_error')
+    }
   end
 
   context 'when Offenders API response does not contain a valid JSON response' do
-    let(:invalid_body) { {}.to_json }
+    let(:invalid_body) { 'not-valid-json' }
     before do
       stub_offenders_api_request(:get, '/offenders/search',
                                  with: { params: { noms_id: prison_number } },
@@ -54,7 +61,11 @@ RSpec.describe DetaineeDetailsFetcher do
 
     include_examples 'request to Offenders API'
 
-    specify { expect(fetcher.call).to eq({}) }
+    specify {
+      response = fetcher.call
+      expect(response.details).to eq({})
+      expect(response.error).to eq('api_error')
+    }
   end
 
   context 'when Offenders API response contains a valid JSON response' do
@@ -99,134 +110,9 @@ RSpec.describe DetaineeDetailsFetcher do
         pnc_number: '12344',
         cro_number: '54321'
       }.with_indifferent_access
-      expect(fetcher.call).to eq(expected_response)
-    end
-
-    context 'when retrieved given name is empty' do
-      let(:given_name) { nil }
-
-      it 'returns the forenames containing only the middle names' do
-        response = fetcher.call
-        expect(response[:forenames]).to eq('C.')
-      end
-    end
-
-    context 'when retrieved middle names is empty' do
-      let(:middle_names) { '' }
-
-      it 'returns the forenames containing only the given name' do
-        response = fetcher.call
-        expect(response[:forenames]).to eq('John')
-      end
-    end
-
-    context 'when neither retrieved given name or middle names are present' do
-      let(:given_name) { '' }
-      let(:middle_names) { '' }
-
-      it 'returns the forenames as nil' do
-        response = fetcher.call
-        expect(response[:forenames]).to eq(nil)
-      end
-    end
-
-    context 'when retrieved surname is nil' do
-      let(:surname) { nil }
-
-      it 'returns the surname as nil' do
-        response = fetcher.call
-        expect(response[:surname]).to eq(nil)
-      end
-    end
-
-    context 'when retrieved date of birth is nil' do
-      let(:date_of_birth) { nil }
-
-      it 'returns the date of birth as nil' do
-        response = fetcher.call
-        expect(response[:date_of_birth]).to eq(nil)
-      end
-    end
-
-    context 'when retrieved date of birth is invalid' do
-      let(:date_of_birth) { 'not-a-date' }
-
-      it 'returns the date of birth as nil' do
-        response = fetcher.call
-        expect(response[:date_of_birth]).to eq(nil)
-      end
-    end
-
-    context 'when retrieved gender is nil' do
-      let(:gender) { nil }
-
-      it 'returns the gender as nil' do
-        response = fetcher.call
-        expect(response[:gender]).to eq(nil)
-      end
-    end
-
-    context 'when retrieved gender is neither male or female' do
-      let(:gender) { 'o' }
-
-      it 'returns the gender as nil' do
-        response = fetcher.call
-        expect(response[:gender]).to eq(nil)
-      end
-    end
-
-    context 'when retrieved gender is male' do
-      let(:gender) { 'm' }
-
-      it 'returns the gender as male' do
-        response = fetcher.call
-        expect(response[:gender]).to eq('male')
-      end
-    end
-
-    context 'when retrieved gender is female' do
-      let(:gender) { 'f' }
-
-      it 'returns the gender as female' do
-        response = fetcher.call
-        expect(response[:gender]).to eq('female')
-      end
-    end
-
-    context 'when retrieved nationality code is empty' do
-      let(:nationality_code) { '' }
-
-      it 'returns the nationalities as nil' do
-        response = fetcher.call
-        expect(response[:nationalities]).to eq(nil)
-      end
-    end
-
-    context 'when retrieved nationality code is not recognizable' do
-      let(:nationality_code) { 'RANDOM-NC' }
-
-      it 'returns the nationality code' do
-        response = fetcher.call
-        expect(response[:nationalities]).to eq('RANDOM-NC')
-      end
-    end
-
-    context 'when retrieved PNC number is empty' do
-      let(:pnc_number) { nil }
-
-      it 'returns the PNC number as nil' do
-        response = fetcher.call
-        expect(response[:pnc_number]).to eq(nil)
-      end
-    end
-
-    context 'when retrieved CRO number is empty' do
-      let(:cro_number) { nil }
-
-      it 'returns the CRO number as nil' do
-        response = fetcher.call
-        expect(response[:cro_number]).to eq(nil)
-      end
+      response = fetcher.call
+      expect(response.details).to eq(expected_response)
+      expect(response.error).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
[Trello #403](https://trello.com/c/UlUutl0z/403-2-as-a-user-of-the-mps-system-where-for-a-new-profile-the-interface-is-unable-to-load-personal-details-i-need-to-know-if-this-is)

So far all errors where handled the same way and a single error message
was presented to the user. This piece of work ensure different error
message are displayed depending on the outcome of fetching the detainee
details:
- If the API is returning a response that is not 200 or does not contain
a valid response, an error message is now displayed indicating that
- If the API returns a valid response but the response is empty, the
error message indicates that there is no record of that detainee in the
API