### PR TITLE
Content changes for "risk from others" risk section

### DIFF
--- a/app/models/forms/risk/risk_from_others.rb
+++ b/app/models/forms/risk/risk_from_others.rb
@@ -2,8 +2,12 @@ module Forms
   module Risk
     class RiskFromOthers < Forms::Base
       optional_field :rule_45
-      optional_details_field :victim_of_abuse, default: 'unknown'
-      optional_details_field :high_profile, default: 'unknown'
+      optional_field :victim_of_abuse, default: 'unknown'
+      property :victim_of_abuse_details, type: StrictString
+      reset attributes: [:victim_of_abuse_details], if_falsey: :victim_of_abuse
+      optional_field :high_profile, default: 'unknown'
+      property :high_profile_details, type: StrictString
+      reset attributes: [:high_profile_details], if_falsey: :high_profile
 
       concerning :CsraSection do
         included do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,10 +34,10 @@ en:
       physical:
         physical_issues: Physical health needs?
       risk_from_others:
-        rule_45: Rule 45 (Detainee separated for their own protection)?
-        csra: CSRA (Cell Share Risk Assessment)?
-        victim_of_abuse: Is the detainee a victim or possible victim of abuse within prison?
-        high_profile: Is the detainee of high public interest?
+        rule_45: Rule 45
+        csra: CSRA
+        victim_of_abuse: Detainee a victim or possible victim of abuse in prison
+        high_profile: Detainee of high public interest
       risk_to_self:
         acct_status: Detainee's most recent ACCT status
       security:
@@ -268,7 +268,9 @@ en:
         physical_issues: Eg disabilities, prosthetic limbs, crutches.
         physical_issues_details: Give details and explain the significance
       risk_from_others:
-        victim_of_abuse_details: Give details
+        csra: Cell Sharing Risk Assessment
+        rule_45: Detainee separated for own protection
+        victim_of_abuse_details: Give details of the abuser (or potential abuser) if known
         high_profile_details: Give details
       risk_to_self:
         open_acct: |

--- a/spec/features/pages/risk.rb
+++ b/spec/features/pages/risk.rb
@@ -28,10 +28,10 @@ module Page
     end
 
     def fill_in_risk_from_others
-      fill_in_optional_details('Rule 45 (Detainee separated for their own protection)?', @risk, :rule_45)
-      fill_in_optional_details('CSRA (Cell Share Risk Assessment)?', @risk, :csra)
-      fill_in_optional_details('Is the detainee a victim or possible victim of abuse within prison?', @risk, :victim_of_abuse)
-      fill_in_optional_details('Is the detainee of high public interest?', @risk, :high_profile)
+      fill_in_optional_details('Rule 45', @risk, :rule_45)
+      fill_in_optional_details('CSRA', @risk, :csra)
+      fill_in_optional_details('Detainee a victim or possible victim of abuse in prison', @risk, :victim_of_abuse)
+      fill_in_optional_details('Detainee of high public interest', @risk, :high_profile)
       save_and_continue
     end
 

--- a/spec/forms/risk/risk_from_others_spec.rb
+++ b/spec/forms/risk/risk_from_others_spec.rb
@@ -21,8 +21,10 @@ RSpec.describe Forms::Risk::RiskFromOthers, type: :form do
 
   describe '#validate' do
     it { is_expected.to validate_optional_field(:rule_45) }
-    it { is_expected.to validate_optional_details_field(:victim_of_abuse) }
-    it { is_expected.to validate_optional_details_field(:high_profile) }
+    it { is_expected.to validate_optional_field(:victim_of_abuse) }
+    it { is_expected.to be_configured_to_reset([:victim_of_abuse_details]).when(:victim_of_abuse).not_set_to('yes') }
+    it { is_expected.to validate_optional_field(:high_profile) }
+    it { is_expected.to be_configured_to_reset([:high_profile_details]).when(:high_profile).not_set_to('yes') }
 
     describe 'csra attribute' do
       it do


### PR DESCRIPTION
[Trello #413](https://trello.com/c/QsaiYNEl/413-1-as-someone-working-in-security-in-a-prison-when-filling-in-a-digital-per-i-want-to-be-able-to-complete-details-about-risk-from)

- Wording changes
- Set some detail field optional, as per requirement