### PR TITLE
Add new validations to risk of violence section

### DIFF
--- a/app/models/forms/risk/violence.rb
+++ b/app/models/forms/risk/violence.rb
@@ -10,10 +10,28 @@ module Forms
                            other_violence_due_to_discrimination other_violence_due_to_discrimination_details],
             if_falsey: :violence_due_to_discrimination
 
+      validate :valid_violence_due_to_discrimination_options,
+        if: -> { violence_due_to_discrimination == 'yes' }
+
+      def valid_violence_due_to_discrimination_options
+        if selected_violence_due_to_discrimination_options.none?
+          errors.add(:base, :minimum_one_option, options: violence_due_to_discrimination_options.join(', '))
+        end
+      end
+
       optional_field :violence_to_staff, default: 'unknown'
       optional_checkbox :violence_to_staff_custody
       optional_checkbox :violence_to_staff_community
       reset attributes: %i[violence_to_staff_custody violence_to_staff_community], if_falsey: :violence_to_staff
+
+      validate :valid_violence_to_staff_options,
+        if: -> { violence_to_staff == 'yes' }
+
+      def valid_violence_to_staff_options
+        if selected_violence_to_staff_options.none?
+          errors.add(:base, :minimum_one_option, options: violence_to_staff_options.join(', '))
+        end
+      end
 
       optional_field :violence_to_other_detainees, default: 'unknown'
       optional_checkbox_with_details :co_defendant, :violence_to_other_detainees
@@ -24,7 +42,53 @@ module Forms
                            other_violence_to_other_detainees_details],
             if_falsey: :violence_to_other_detainees
 
+      validate :valid_violence_to_other_detainees_options,
+        if: -> { violence_to_other_detainees == 'yes' }
+
+      def valid_violence_to_other_detainees_options
+        if selected_violence_to_other_detainees_options.none?
+          errors.add(:base, :minimum_one_option, options: violence_to_other_detainees_options.join(', '))
+        end
+      end
+
       optional_details_field :violence_to_general_public, default: 'unknown'
+
+      private
+
+      def selected_violence_due_to_discrimination_options
+        [risk_to_females,
+         homophobic,
+         racist,
+         other_violence_due_to_discrimination]
+      end
+
+      def violence_due_to_discrimination_options
+        %i[risk_to_females homophobic racist
+           other_violence_due_to_discrimination].map do |attr|
+          I18n.t(attr, scope: [:helpers, :label, :violence])
+        end
+      end
+
+      def selected_violence_to_staff_options
+        [violence_to_staff_custody,
+         violence_to_staff_community]
+      end
+
+      def violence_to_staff_options
+        %i[violence_to_staff_custody violence_to_staff_community].map do |attr|
+          I18n.t(attr, scope: [:helpers, :label, :violence])
+        end
+      end
+
+      def selected_violence_to_other_detainees_options
+        [co_defendant, gang_member, other_violence_to_other_detainees]
+      end
+
+      def violence_to_other_detainees_options
+        %i[co_defendant gang_member other_violence_to_other_detainees].map do |attr|
+          I18n.t(attr, scope: [:helpers, :label, :violence])
+        end
+      end
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -214,6 +214,7 @@ en:
       violence:
         co_defendant: Co-defendant
         co_defendant_details: Co-defendant violence details
+        gang_member: Gang member
         gang_member_details: Gang member violence details
         homophobic: Homosexuals
         other_violence_due_to_discrimination: Other

--- a/spec/forms/risk/violence_spec.rb
+++ b/spec/forms/risk/violence_spec.rb
@@ -11,6 +11,24 @@ RSpec.describe Forms::Risk::Violence, type: :form do
       context 'when violent due to discrimination is set to yes' do
         before { form.violence_due_to_discrimination = 'yes' }
 
+        context 'and no type of discrimination is selected' do
+          before do
+            form.risk_to_females = false
+            form.homophobic = false
+            form.racist = false
+            form.other_violence_due_to_discrimination = false
+          end
+
+          let(:attr_with_error) { :base }
+          let(:error_message) { 'At least one option (Risk to females, Homosexuals, Racist, Other) needs to be provided' }
+
+          it 'inclusion error is added to the error list' do
+            expect(form).not_to be_valid
+            expect(form.errors.keys).to match_array([attr_with_error])
+            expect(form.errors[attr_with_error]).to match_array([error_message])
+          end
+        end
+
         context 'when racist is set to true' do
           before { subject.racist = true }
           it { is_expected.to validate_presence_of(:racist_details) }
@@ -45,10 +63,51 @@ RSpec.describe Forms::Risk::Violence, type: :form do
           violence_to_staff_custody violence_to_staff_community
         ]).when(:violence_to_staff).not_set_to('yes')
       end
+
+      context 'when violence to staff is set to yes' do
+        before { form.violence_to_staff = 'yes' }
+
+        context 'and no type of violence is selected' do
+          before do
+            form.violence_to_staff_custody = false
+            form.violence_to_staff_community = false
+          end
+
+          let(:attr_with_error) { :base }
+          let(:error_message) { 'At least one option (Staff custody, Staff community) needs to be provided' }
+
+          it 'inclusion error is added to the error list' do
+            expect(form).not_to be_valid
+            expect(form.errors.keys).to match_array([attr_with_error])
+            expect(form.errors[attr_with_error]).to match_array([error_message])
+          end
+        end
+      end
     end
 
     context "for violence to other detainees" do
       it { is_expected.to validate_optional_field(:violence_to_other_detainees) }
+
+      context 'when violent to other detainees is set to yes' do
+        before { form.violence_to_other_detainees = 'yes' }
+
+        context 'and no type of violence is selected' do
+          before do
+            form.co_defendant = false
+            form.gang_member = false
+            form.other_violence_to_other_detainees = false
+          end
+
+          let(:attr_with_error) { :base }
+          let(:error_message) { 'At least one option (Co-defendant, Gang member, Other known conflicts) needs to be provided' }
+
+          it 'inclusion error is added to the error list' do
+            expect(form).not_to be_valid
+            expect(form.errors.keys).to match_array([attr_with_error])
+            expect(form.errors[attr_with_error]).to match_array([error_message])
+          end
+        end
+      end
 
       context 'when violent to other detainees is set to yes' do
         before { form.violence_to_other_detainees = 'yes' }


### PR DESCRIPTION
[Trello #420](https://trello.com/c/NT6rb7Qu/420-3-bug-error-states-risk-question-3-as-someone-working-in-security-in-a-prison-when-filling-in-a-digital-per-i-want-to-be-able-to)

Some of the questions in the violence section, when answered yes
required some extra information to be supplied. These changes ensure
that the necessary information is provided, otherwise an error will be
displayed.