### PR TITLE
Change radios to checkboxes for risk trafficking options

### DIFF
--- a/app/models/forms/risk/substance_misuse.rb
+++ b/app/models/forms/risk/substance_misuse.rb
@@ -1,19 +1,31 @@
 module Forms
   module Risk
     class SubstanceMisuse < Forms::Base
-      SUBSTANCE_SUPPLY_VALUES = %w[drugs alcohol both].freeze
-
       optional_field :substance_supply, default: 'unknown'
-      property :substance_supply_details, type: StrictString
 
-      reset attributes: %i[substance_supply_details], if_falsey: :substance_supply
+      validate :valid_trafficking_options, if: proc { |f| f.substance_supply == 'yes' }
 
-      validates :substance_supply_details,
-        inclusion: { in: SUBSTANCE_SUPPLY_VALUES },
-        if: -> { substance_supply == 'yes' }
+      def valid_trafficking_options
+        unless selected_trafficking_options.any?
+          errors.add(:base, :minimum_one_option, options: trafficking_options.join(', '))
+        end
+      end
 
-      def substance_supply_values
-        SUBSTANCE_SUPPLY_VALUES
+      optional_checkbox :trafficking_drugs
+      optional_checkbox :trafficking_alcohol
+
+      reset attributes: %i[trafficking_drugs trafficking_alcohol], if_falsey: :substance_supply
+
+      private
+
+      def selected_trafficking_options
+        [trafficking_drugs, trafficking_alcohol]
+      end
+
+      def trafficking_options
+        %i[trafficking_drugs trafficking_alcohol].map do |attr|
+          I18n.t(attr, scope: [:helpers, :label, :substance_misuse])
+        end
       end
     end
   end

--- a/app/models/sections/risk_assessment/substance_misuse_section.rb
+++ b/app/models/sections/risk_assessment/substance_misuse_section.rb
@@ -5,8 +5,19 @@ module RiskAssessment
     end
 
     def questions
+      %w[trafficking_drugs trafficking_alcohol]
+    end
+
+    def mandatory_questions
       %w[substance_supply]
     end
-    alias mandatory_questions questions
+
+    private
+
+    def question_dependencies
+      {
+        substance_supply: %i[trafficking_drugs trafficking_alcohol]
+      }
+    end
   end
 end

--- a/app/views/risks/_substance_misuse.html.slim
+++ b/app/views/risks/_substance_misuse.html.slim
@@ -1,5 +1,7 @@
 = f.radio_toggle :substance_supply do
-  .form-group
-    = f.radio_button_fieldset :substance_supply_details,
-      choices: f.object.substance_supply_values,
-      legend: false
+  fieldset
+    span.form-hint
+      | Select all that apply
+
+    = f.checkbox :trafficking_drugs
+    = f.checkbox :trafficking_alcohol

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,8 @@ en:
         personal_care: Personal care issues?
       substance_misuse:
         substance_supply: Risk of detainee trafficking drugs or alcohol
+        trafficking_drugs: Drugs
+        trafficking_alcohol: Alcohol
       transport:
         mpv: Requires MPV?
       violence:
@@ -204,9 +206,8 @@ en:
       substance_misuse:
         substance_supply_choices:
           unknown: Clear selection
-        substance_supply_details: Details for risk of detainee trafficking drugs or alcohol
-        substance_supply_details_choices:
-          both: Both drugs and alcohol
+        trafficking_drugs: Drugs
+        trafficking_alcohol: Alcohol
       transport:
         mpv_choices:
           unknown: Clear selection
@@ -392,6 +393,8 @@ en:
           other_escape_risk_info: Other escape risk information
         substance_misuse:
           substance_supply: Risk of detainee trafficking drugs or alcohol
+          trafficking_drugs: Drugs
+          trafficking_alcohol: Alcohol
         transport:
           mpv: MPV
         violence:

--- a/db/migrate/20170112152831_add_new_substance_misuse_columns_to_risks.rb
+++ b/db/migrate/20170112152831_add_new_substance_misuse_columns_to_risks.rb
@@ -1,0 +1,7 @@
+class AddNewSubstanceMisuseColumnsToRisks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :risks, :trafficking_drugs, :boolean
+    add_column :risks, :trafficking_alcohol, :boolean
+    remove_column :risks, :substance_supply_details
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170103171218) do
+ActiveRecord::Schema.define(version: 20170112152831) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -158,7 +158,6 @@ ActiveRecord::Schema.define(version: 20170103171218) do
     t.string   "category_a",                                        default: "unknown"
     t.text     "category_a_details"
     t.string   "substance_supply",                                  default: "unknown"
-    t.text     "substance_supply_details"
     t.string   "conceals_weapons",                                  default: "unknown"
     t.text     "conceals_weapons_details"
     t.string   "arson",                                             default: "unknown"
@@ -230,6 +229,8 @@ ActiveRecord::Schema.define(version: 20170103171218) do
     t.boolean  "conceals_sim_cards"
     t.boolean  "conceals_other_items"
     t.text     "conceals_other_items_details"
+    t.boolean  "trafficking_drugs"
+    t.boolean  "trafficking_alcohol"
     t.index ["detainee_id"], name: "index_risks_on_detainee_id", using: :btree
   end
 

--- a/spec/features/pages/risk.rb
+++ b/spec/features/pages/risk.rb
@@ -214,11 +214,24 @@ module Page
     def fill_in_substance_misuse
       if @risk.substance_supply == 'yes'
         choose 'substance_misuse_substance_supply_yes'
-        fill_in 'substance_misuse_substance_supply_details', with: @risk.substance_supply_details
+        fill_in_trafficking_drugs
+        fill_in_trafficking_alcohol
       else
         choose 'substance_misuse_substance_supply_no'
       end
       save_and_continue
+    end
+
+    def fill_in_trafficking_drugs
+      if @risk.trafficking_drugs
+        check 'substance_misuse_trafficking_drugs'
+      end
+    end
+
+    def fill_in_trafficking_alcohol
+      if @risk.trafficking_alcohol
+        check 'substance_misuse_trafficking_alcohol'
+      end
     end
 
     def fill_in_concealed_weapons

--- a/spec/features/pages/risk_summary.rb
+++ b/spec/features/pages/risk_summary.rb
@@ -194,7 +194,12 @@ module Page
     end
 
     def check_substance_misuse_section(risk)
-      check_section(risk, 'substance_misuse', %w[substance_supply])
+      fields = %w[trafficking_drugs trafficking_alcohol]
+      if risk.substance_supply == 'yes'
+        check_section(risk, 'substance_misuse', fields)
+      else
+        check_section_is_all_no(risk, 'substance_misuse', fields)
+      end
     end
   end
 end

--- a/spec/forms/risk/substance_misuse_spec.rb
+++ b/spec/forms/risk/substance_misuse_spec.rb
@@ -7,39 +7,35 @@ RSpec.describe Forms::Risk::SubstanceMisuse, type: :form do
   let(:params) {
     {
       'substance_supply' => 'yes',
-      'substance_supply_details' => 'drugs',
+      'trafficking_drugs' => '1',
+      'trafficking_alcohol' => '1'
     }
   }
 
   describe '#validate' do
     it { is_expected.to validate_optional_field(:substance_supply) }
-    it do
-      is_expected.to be_configured_to_reset(%i[substance_supply_details])
-        .when(:substance_supply).not_set_to('yes')
-    end
-
-    context 'when substance_supply is set to unknown' do
-      before { form.substance_supply = 'unknown' }
-      it {
-        is_expected.not_to validate_inclusion_of(:substance_supply_details)
-          .in_array(%w[drugs alcohol both])
-      }
-    end
-
-    context 'when substance_supply is set to no' do
-      before { form.substance_supply = 'no' }
-      it {
-        is_expected.not_to validate_inclusion_of(:substance_supply_details)
-          .in_array(%w[drugs alcohol both])
-      }
-    end
 
     context 'when substance_supply is set to yes' do
       before { form.substance_supply = 'yes' }
-      it {
-        is_expected.to validate_inclusion_of(:substance_supply_details)
-          .in_array(%w[drugs alcohol both])
-      }
+
+      context 'but none of the checkboxes is selected' do
+        before do
+          form.trafficking_drugs = false
+          form.trafficking_alcohol = false
+        end
+
+        it 'an invalid date error is added to the error list' do
+          expect(form).not_to be_valid
+          expect(form.errors.keys).to match_array([:base])
+          expect(form.errors[:base]).to match_array(['At least one option (Drugs, Alcohol) needs to be provided'])
+        end
+      end
+    end
+
+    it do
+      is_expected.to be_configured_to_reset(%i[
+        trafficking_drugs trafficking_alcohol
+      ]).when(:substance_supply).not_set_to('yes')
     end
   end
 


### PR DESCRIPTION
[Trello #424](https://trello.com/c/yKOLdie4/424-risk-of-trafficking-drugs-and-alcohol-question-interaction-amend)

The requirements is for the user to be able to select either or both so
it makes sense the substance misuse section follows the same approach as
other risk sections, which is to display all the possible values as
checkboxes and the user can select all the ones that apply.