### PR TITLE
Changes to the risk summary page

### DIFF
--- a/app/assets/stylesheets/moving_people_safely/_summary.scss
+++ b/app/assets/stylesheets/moving_people_safely/_summary.scss
@@ -51,11 +51,11 @@
     }
 
     .second-column {
-      width: 10%;
+      width: 20%;
     }
 
     .third-column {
-      width: 60%;
+      width: 50%;
     }
   }
 

--- a/app/models/forms/risk/risk_to_self.rb
+++ b/app/models/forms/risk/risk_to_self.rb
@@ -2,7 +2,7 @@ module Forms
   module Risk
     class RiskToSelf < Forms::Base
       ACCT_STATUS_WITH_DETAILS = 'closed_in_last_6_months'.freeze
-      ACCT_STATUSES = %w[open post_closure closed_in_last_6_months not_available].freeze
+      ACCT_STATUSES = %w[open post_closure closed_in_last_6_months none].freeze
 
       property_with_details :acct_status,
         type: StrictString,

--- a/app/models/sections/base_section.rb
+++ b/app/models/sections/base_section.rb
@@ -7,9 +7,37 @@ class BaseSection
     question_dependencies.select { |_scope, dependencies| dependencies.include?(question.to_sym) }.keys.first
   end
 
+  def question_has_details?(question)
+    !question_details(question).nil?
+  end
+
+  def question_details(question)
+    questions_details[question.to_sym]
+  end
+
+  def subsections
+    subsections_questions.keys
+  end
+
+  def has_subsections?
+    !subsections_questions.empty?
+  end
+
+  def questions_for_subsection(subsection)
+    subsections_questions.fetch(subsection.to_sym, [])
+  end
+
   private
 
   def question_dependencies
+    {}
+  end
+
+  def questions_details
+    {}
+  end
+
+  def subsections_questions
     {}
   end
 end

--- a/app/models/sections/risk_assessment/harassments_section.rb
+++ b/app/models/sections/risk_assessment/harassments_section.rb
@@ -21,5 +21,13 @@ module RiskAssessment
                          intimidation_to_other_detainees intimidation_to_witnesses]
       }
     end
+
+    def subsections_questions
+      {
+        harassment: %w[harassment],
+        intimidation: %w[intimidation_to_staff intimidation_to_public
+                         intimidation_to_other_detainees intimidation_to_witnesses]
+      }
+    end
   end
 end

--- a/app/models/sections/risk_assessment/hostage_taker_section.rb
+++ b/app/models/sections/risk_assessment/hostage_taker_section.rb
@@ -19,5 +19,13 @@ module RiskAssessment
         hostage_taker: %i[staff_hostage_taker prisoners_hostage_taker public_hostage_taker]
       }
     end
+
+    def questions_details
+      {
+        staff_hostage_taker: %i[date_most_recent_staff_hostage_taker_incident],
+        prisoners_hostage_taker: %i[date_most_recent_prisoners_hostage_taker_incident],
+        public_hostage_taker: %i[date_most_recent_public_hostage_taker_incident]
+      }
+    end
   end
 end

--- a/app/models/sections/risk_assessment/risk_to_self_section.rb
+++ b/app/models/sections/risk_assessment/risk_to_self_section.rb
@@ -8,5 +8,11 @@ module RiskAssessment
       %w[acct_status]
     end
     alias mandatory_questions questions
+
+    def questions_details
+      {
+        acct_status: %i[date_of_most_recently_closed_acct acct_status_details]
+      }
+    end
   end
 end

--- a/app/models/sections/risk_assessment/security_section.rb
+++ b/app/models/sections/risk_assessment/security_section.rb
@@ -23,5 +23,23 @@ module RiskAssessment
                                      police_escape_attempt other_type_escape_attempt]
       }
     end
+
+    def questions_details
+      {
+        current_e_risk: %i[current_e_risk_details],
+        escort_risk_assessment: %i[escort_risk_assessment_completion_date],
+        escape_pack: %i[escape_pack_completion_date]
+      }
+    end
+
+    def subsections_questions
+      {
+        escape_status: %w[current_e_risk],
+        previous_escape_attempts: %w[prison_escape_attempt court_escape_attempt
+                                     police_escape_attempt other_type_escape_attempt],
+        category_a: %w[category_a],
+        escort_details: %w[escort_risk_assessment escape_pack]
+      }
+    end
   end
 end

--- a/app/models/sections/risk_assessment/violence_section.rb
+++ b/app/models/sections/risk_assessment/violence_section.rb
@@ -23,5 +23,14 @@ module RiskAssessment
         violence_to_other_detainees: %i[co_defendant gang_member other_violence_to_other_detainees]
       }
     end
+
+    def subsections_questions
+      {
+        discrimination: %w[risk_to_females homophobic racist other_violence_due_to_discrimination],
+        violence_to_staff: %w[violence_to_staff_custody violence_to_staff_community],
+        violence_to_other_detainees: %w[co_defendant gang_member other_violence_to_other_detainees],
+        violence_to_general_public: %w[violence_to_general_public]
+      }
+    end
   end
 end

--- a/app/presenters/summary/assessment_section_presenter.rb
+++ b/app/presenters/summary/assessment_section_presenter.rb
@@ -3,6 +3,8 @@ module Summary
     attr_reader :section_name
     delegate :name, :questions, to: :section
     delegate :question_is_conditional?, :question_condition, to: :section
+    delegate :question_has_details?, :question_details, to: :section
+    delegate :subsections, :has_subsections?, :questions_for_subsection, to: :section
 
     def self.for(section, assessment)
       new(assessment, section: section)
@@ -14,7 +16,7 @@ module Summary
     end
 
     def answer_for(attribute)
-      return super(attribute) unless question_is_conditional?(attribute)
+      return default_answer(attribute) unless question_is_conditional?(attribute)
       if question_condition_unanswered?(attribute)
         "<span class='text-error'>Missing</span>"
       elsif question_condition_answered_yes?(attribute) && checkbox_checked?(attribute)
@@ -24,7 +26,30 @@ module Summary
       end
     end
 
+    def details_for(attribute)
+      return super(attribute) unless question_has_details?(attribute)
+      question_details(attribute).each_with_object([]) do |detail_attr, details|
+        details << detail_content(detail_attr) if public_send(detail_attr).present?
+      end.join('. ')
+    end
+
     private
+
+    def default_answer(attribute)
+      value = public_send(attribute)
+      case value
+      when 'unknown', nil
+        "<span class='text-error'>Missing</span>"
+      when 'no', false
+        'No'
+      when true
+        '<b>Yes</b>'
+      when 'standard'
+        'Standard'
+      else
+        "<b>#{answer_value(value)}</b>"
+      end
+    end
 
     def question_condition_unanswered?(attribute)
       public_send(question_condition(attribute)) == 'unknown'
@@ -36,6 +61,21 @@ module Summary
 
     def checkbox_checked?(attribute)
       public_send(attribute) == true
+    end
+
+    def detail_content(attribute)
+      [detail_label(attribute), answer_value(public_send(attribute))].join('')
+    end
+
+    def detail_label(attribute)
+      I18n.t!(attribute, scope: [:summary, :section, :questions, section_name])
+    rescue
+      nil
+    end
+
+    def answer_value(value)
+      default_value = value.respond_to?(:humanize) ? value.humanize : value
+      I18n.t(value, scope: [:summary, :section, :answers, section_name], default: default_value)
     end
   end
 end

--- a/app/presenters/summary/assessment_subsection_presenter.rb
+++ b/app/presenters/summary/assessment_subsection_presenter.rb
@@ -1,0 +1,20 @@
+module Summary
+  class AssessmentSubsectionPresenter < AssessmentSectionPresenter
+    attr_reader :section_name, :subsection_name
+    alias name subsection_name
+
+    def self.for(subsection, section, assessment)
+      new(assessment, section: section, subsection: subsection)
+    end
+
+    def initialize(object, options = {})
+      super(object, section: options.fetch(:section))
+      @section_name = options.fetch(:section)
+      @subsection_name = options.fetch(:subsection)
+    end
+
+    def questions
+      questions_for_subsection(subsection_name)
+    end
+  end
+end

--- a/app/presenters/summary/risk_subsection_presenter.rb
+++ b/app/presenters/summary/risk_subsection_presenter.rb
@@ -1,0 +1,9 @@
+module Summary
+  class RiskSubsectionPresenter < AssessmentSubsectionPresenter
+    private
+
+    def section
+      @section ||= RiskAssessment.section_for(section_name)
+    end
+  end
+end

--- a/app/views/risks/_harassments.html.slim
+++ b/app/views/risks/_harassments.html.slim
@@ -1,11 +1,17 @@
-= f.radio_toggle_with_textarea :harassment
+section
+  a#harassment_subsection
 
-= f.radio_toggle :intimidation do
-  fieldset
-    span.form-hint
-      | Targets for intimidation or bullying
+  = f.radio_toggle_with_textarea :harassment
 
-    = f.checkbox_with_textarea :intimidation_to_staff
-    = f.checkbox_with_textarea :intimidation_to_public
-    = f.checkbox_with_textarea :intimidation_to_other_detainees
-    = f.checkbox_with_textarea :intimidation_to_witnesses
+section
+  a#intimidation_subsection
+
+  = f.radio_toggle :intimidation do
+    fieldset
+      span.form-hint
+        | Targets for intimidation or bullying
+
+      = f.checkbox_with_textarea :intimidation_to_staff
+      = f.checkbox_with_textarea :intimidation_to_public
+      = f.checkbox_with_textarea :intimidation_to_other_detainees
+      = f.checkbox_with_textarea :intimidation_to_witnesses

--- a/app/views/risks/_security.html.slim
+++ b/app/views/risks/_security.html.slim
@@ -1,21 +1,33 @@
-= f.radio_toggle :current_e_risk do
-  .form-group
-    = f.radio_button_fieldset :current_e_risk_details, choices: f.object.e_risk_values, legend: false
+section
+  a#escape_status_subsection
 
-= f.radio_toggle :previous_escape_attempts do
-  fieldset
-    span.form-hint
-      | Select all that apply
+  = f.radio_toggle :current_e_risk do
+    .form-group
+      = f.radio_button_fieldset :current_e_risk_details, choices: f.object.e_risk_values, legend: false
 
-    = f.checkbox_with_textarea :prison_escape_attempt
-    = f.checkbox_with_textarea :court_escape_attempt
-    = f.checkbox_with_textarea :police_escape_attempt
-    = f.checkbox_with_textarea :other_type_escape_attempt
+section
+  a#previous_escape_attempts_subsection
 
-= f.radio_toggle :category_a
+  = f.radio_toggle :previous_escape_attempts do
+    fieldset
+      span.form-hint
+        | Select all that apply
 
-= f.radio_toggle :escort_risk_assessment do
-  = f.text_field :escort_risk_assessment_completion_date
+      = f.checkbox_with_textarea :prison_escape_attempt
+      = f.checkbox_with_textarea :court_escape_attempt
+      = f.checkbox_with_textarea :police_escape_attempt
+      = f.checkbox_with_textarea :other_type_escape_attempt
 
-= f.radio_toggle :escape_pack do
-  = f.text_field :escape_pack_completion_date
+section
+  a#category_a_subsection
+
+  = f.radio_toggle :category_a
+
+section
+  a#escort_details_subsection
+
+  = f.radio_toggle :escort_risk_assessment do
+    = f.text_field :escort_risk_assessment_completion_date
+
+  = f.radio_toggle :escape_pack do
+    = f.text_field :escape_pack_completion_date

--- a/app/views/risks/_violence.html.slim
+++ b/app/views/risks/_violence.html.slim
@@ -1,26 +1,38 @@
-= f.radio_toggle :violence_due_to_discrimination do
-  fieldset
-    span.form-hint
-      | Select all that apply
+section
+  a#discrimination_subsection
 
-    = f.checkbox :risk_to_females
-    = f.checkbox :homophobic
-    = f.checkbox_with_textarea :racist
-    = f.checkbox_with_textarea :other_violence_due_to_discrimination
+  = f.radio_toggle :violence_due_to_discrimination do
+    fieldset
+      span.form-hint
+        | Select all that apply
 
-= f.radio_toggle :violence_to_staff do
-  fieldset
-    span.form-hint
-      | Select all that apply
-    = f.checkbox :violence_to_staff_custody
-    = f.checkbox :violence_to_staff_community
+      = f.checkbox :risk_to_females
+      = f.checkbox :homophobic
+      = f.checkbox_with_textarea :racist
+      = f.checkbox_with_textarea :other_violence_due_to_discrimination
 
-= f.radio_toggle :violence_to_other_detainees do
-  fieldset
-    span.form-hint
-      | Select all that apply
-    = f.checkbox_with_textarea :co_defendant
-    = f.checkbox_with_textarea :gang_member
-    = f.checkbox_with_textarea :other_violence_to_other_detainees
+section
+  a#violence_to_staff_subsection
 
-= f.radio_toggle_with_textarea :violence_to_general_public
+  = f.radio_toggle :violence_to_staff do
+    fieldset
+      span.form-hint
+        | Select all that apply
+      = f.checkbox :violence_to_staff_custody
+      = f.checkbox :violence_to_staff_community
+
+section
+  a#violence_to_other_detainees_subsection
+
+  = f.radio_toggle :violence_to_other_detainees do
+    fieldset
+      span.form-hint
+        | Select all that apply
+      = f.checkbox_with_textarea :co_defendant
+      = f.checkbox_with_textarea :gang_member
+      = f.checkbox_with_textarea :other_violence_to_other_detainees
+
+section
+  a#violence_to_general_public_subsection
+
+  = f.radio_toggle_with_textarea :violence_to_general_public

--- a/app/views/summary/_section.html.slim
+++ b/app/views/summary/_section.html.slim
@@ -1,16 +1,24 @@
-table class="#{section}"
-  thead
-    tr
-     th.title colspan="2"
-       = t(".titles.#{section}")
-     th.edit
-       = link_to 'Change', path
-  tbody
-    - questions.each_with_index do |question, i|
-      tr class=(%w[even odd][i%2] + ' ' + question.underscore)
-       td.first-column
-         = t(".questions.#{section}.#{question}")
-       td.second-column
-         == presenter.answer_for(question)
-       td.third-column
-         == presenter.details_for(question)
+- if section.has_subsections?
+  - section.subsections.each do |subsection|
+    = render partial: 'summary/subsection',
+      locals: { subsection: Summary::RiskSubsectionPresenter.for(subsection, section.name, assessment),
+                section: section,
+                assessment: assessment,
+                path: path }
+- else
+  table class="#{section.name}"
+    thead
+      tr
+       th.title colspan="2"
+         = t("summary.section.titles.#{section.name}")
+       th.edit
+         = link_to 'Change', path
+    tbody
+      - section.questions.each_with_index do |question, i|
+        tr class=(%w[even odd][i%2] + ' ' + question.underscore)
+         td.first-column
+           = t("summary.section.questions.#{section.name}.#{question}")
+         td.second-column
+           == section.answer_for(question)
+         td.third-column
+           == section.details_for(question)

--- a/app/views/summary/_subsection.html.slim
+++ b/app/views/summary/_subsection.html.slim
@@ -1,12 +1,12 @@
-table class="#{section.name}"
+table class="#{subsection.name}"
   thead
     tr
      th.title colspan="2"
-       = t("summary.section.titles.#{section.name}")
+       = t("summary.section.titles.#{subsection.name}")
      th.edit
-       = link_to 'Change', path
+       = link_to 'Change', path + "##{subsection.name}_subsection"
   tbody
-    - section.questions.each_with_index do |question, i|
+    - subsection.questions.each_with_index do |question, i|
       tr class=(%w[even odd][i%2] + ' ' + question.underscore)
        td.first-column
          = t("summary.section.questions.#{section.name}.#{question}")

--- a/app/views/summary/healthcare.html.slim
+++ b/app/views/summary/healthcare.html.slim
@@ -2,7 +2,7 @@
   = render partial: 'summary/status', locals: { workflow: healthcare_workflow, title: 'Healthcare' }
 
   - HealthcareWorkflow.sections_for_summary.each do |section|
-    = render partial: 'summary/newsection',
+    = render partial: 'summary/section',
       locals: { section: Summary::HealthcarePresenter.for(section, healthcare), path: healthcare_path(detainee, section) }
 
   = render partial: 'summary/call_to_action', locals: { workflow: healthcare_workflow, confirm_path: confirm_healthcare_index_path }

--- a/app/views/summary/risk.html.slim
+++ b/app/views/summary/risk.html.slim
@@ -2,7 +2,9 @@
   = render partial: 'summary/status', locals: { workflow: risk_workflow, title: 'Risk' }
 
   - RiskWorkflow.sections.each do |section|
-    = render partial: 'summary/newsection',
-      locals: { section: Summary::RiskPresenter.for(section, risk), path: risk_path(detainee, section) }
+    = render partial: 'summary/section',
+      locals: { section: Summary::RiskPresenter.for(section, risk),
+                assessment: risk,
+                path: risk_path(detainee, section) }
 
   = render partial: 'summary/call_to_action', locals: { workflow: risk_workflow, confirm_path: confirm_risks_path }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,7 +162,7 @@ en:
           open: ACCT Open
           post_closure: ACCT Post Closure
           closed_in_last_6_months: ACCT Closed, in the last 6 months
-          not_available: None of the above
+          none: None of the above
         acct_status_details: Give details of known methods and triggers
         date_of_most_recently_closed_acct: Date of most recently closed ACCT
       security:
@@ -363,34 +363,62 @@ en:
 
   summary:
     section:
+      answers:
+        risk_to_self:
+          closed_in_last_6_months: Closed
+        security:
+          e_list_escort: E-List-Escort
+          e_list_heightened: E-List-Heightened
+          e_list_standard: E-List-Standard
       questions:
         arson:
-          arson: Arson
+          arson: Arson is a behavioural issue
           damage_to_property: Damage to property
         communication:
           hearing_speech_sight_issues: Hearing / Speech / Sight issues
           reading_writing_issues: Reading / Writing issues
+        concealed_weapons:
+          conceals_weapons: Conceals weapons
+          conceals_drugs: Conceals drugs
+          conceals_mobile_phones: Conceals mobile phones
+          conceals_sim_cards: Conceals SIM cards
+          conceals_other_items: Conceals other items
         harassments:
           harassment: Harasser
-          intimidation: Intimidator / bully
+          intimidation_to_staff: Staff
+          intimidation_to_public: Public
+          intimidation_to_other_detainees: Prisoners
+          intimidation_to_witnesses: Witnesses
+        hostage_taker:
+          staff_hostage_taker: Staff
+          prisoners_hostage_taker: Prisoners
+          public_hostage_taker: Public
         needs:
           has_medications: Medication
         sex_offences:
           sex_offence: Sex offender
-          sex_offence_adult_male_victim: Adult male victim
-          sex_offence_adult_female_victim: Adult female victim
-          sex_offence_under18_victim: Under 18 victim
+          sex_offence_adult_male_victim: Adult male
+          sex_offence_adult_female_victim: Adult female
+          sex_offence_under18_victim: Under 18
         risk_from_others:
+          csra: CSRA
+          high_profile: High public interest
           rule_45: Rule 45
-          csra: Cell Share Risk Assessment
+          victim_of_abuse: Victim of abuse in prison
         risk_to_self:
           acct_status: ACCT status
           suicide: Risk of suicide or self-harm
         security:
           category_a: Category A or Restricted status
-          current_e_risk: Current E risk
+          current_e_risk: Currently on E list
           escape_list: Escape list
+          escape_pack_completion_date: 'Completed on: '
+          escort_risk_assessment_completion_date: 'Completed on: '
           other_escape_risk_info: Other escape risk information
+          prison_escape_attempt: Prison
+          court_escape_attempt: Court
+          police_escape_attempt: Police
+          other_type_escape_attempt: Other
         substance_misuse:
           substance_supply: Risk of detainee trafficking drugs or alcohol
           trafficking_drugs: Drugs
@@ -398,32 +426,45 @@ en:
         transport:
           mpv: MPV
         violence:
-          co_defendant: Co-Defendant
+          co_defendant: Co-defendant
           escort_or_court_staff: Escort or court staff
+          gang_member: Gang member
           healthcare_staff: Healthcare staff
           homophobic: Homosexuals
           other_detainees: Other detainees
-          racist: Other races
+          other_violence_due_to_discrimination: Other
+          other_violence_to_other_detainees: Other known conflicts
+          racist: Racist
           police: Police
           prison_staff: Prison staff
           public_offence_related: Public/offence related
-          risk_to_females: Females
+          risk_to_females: Risk to females
+          violence_to_general_public: General public
+          violence_to_staff_community: Staff community
+          violence_to_staff_custody: Staff custody
       titles:
         arson: Arson and damage to property
+        category_a: Category A or Restricted status
         communication: Communication / language difficulties
-        concealed_weapons: Concealed weapons, drugs or other items
-        harassments: "Risk to others: Harasser / intimidator / bully"
-        hostage_taker: "Risk to others: Hostage taker"
+        concealed_weapons: Conceals weapons, drugs or other items
+        discrimination: "Risk to others - discrimination"
+        escape_status: Escape status/history
+        escort_details: Escort Risk Assessment/Escort Pack
+        harassment: "Risk to others: harasser and/or bully"
+        hostage_taker: "Risk to others - hostage taker"
+        intimidation: "Intimidator/bully"
         mental: Mental healthcare
         needs: Medical health needs
         physical: Physical healthcare
+        previous_escape_attempts: Made previous escape attempts
         risk_to_self: Risk to self
         risk_from_others: Risk from others
-        security: Security
-        sex_offences: "Risk to others: Sex offender"
+        sex_offences: Sex offender
         social: Social healthcare
-        substance_misuse: Risk of trafficking drugs and alcohol
-        violence: "Risk to others: discrimination"
+        substance_misuse: Risk of trafficking drugs or alcohol
+        violence_to_general_public: Violent to general public
+        violence_to_other_detainees: Violent to other detainees
+        violence_to_staff: Violent to staff
   activemodel:
     errors:
       models:

--- a/spec/features/pages/risk_summary.rb
+++ b/spec/features/pages/risk_summary.rb
@@ -86,31 +86,31 @@ module Page
 
     def check_violence_due_to_discrimination(risk)
       if risk.violence_due_to_discrimination == 'yes'
-        check_section(risk, 'violence', %w[risk_to_females homophobic racist other_violence_due_to_discrimination])
+        check_section(risk, 'discrimination', %w[risk_to_females homophobic racist other_violence_due_to_discrimination])
       else
-        check_section_is_all_no(risk, 'violence', %w[risk_to_females homophobic racist other_violence_due_to_discrimination])
+        check_section_is_all_no(risk, 'discrimination', %w[risk_to_females homophobic racist other_violence_due_to_discrimination])
       end
     end
 
     def check_violence_to_staff(risk)
       if risk.violence_to_staff == 'yes'
-        check_section(risk, 'violence', %w[violence_to_staff_custody violence_to_staff_community])
+        check_section(risk, 'violence_to_staff', %w[violence_to_staff_custody violence_to_staff_community])
       else
-        check_section_is_all_no(risk, 'violence', %w[violence_to_staff_custody violence_to_staff_community])
+        check_section_is_all_no(risk, 'violence_to_staff', %w[violence_to_staff_custody violence_to_staff_community])
       end
     end
 
     def check_violence_to_other_detainees(risk)
       if risk.violence_to_other_detainees == 'yes'
-        check_section(risk, 'violence', %w[co_defendant gang_member other_violence_to_other_detainees])
+        check_section(risk, 'violence_to_other_detainees', %w[co_defendant gang_member other_violence_to_other_detainees])
       else
-        check_section_is_all_no(risk, 'violence', %w[co_defendant gang_member other_violence_to_other_detainees])
+        check_section_is_all_no(risk, 'violence_to_other_detainees', %w[co_defendant gang_member other_violence_to_other_detainees])
       end
     end
 
     def check_violence_to_general_public(risk)
       if risk.violence_to_general_public == 'yes'
-        check_question(risk, 'violence', 'violence_to_general_public')
+        check_question(risk, 'violence_to_general_public', 'violence_to_general_public')
       end
     end
 
@@ -131,15 +131,15 @@ module Page
     def check_intimidation(risk)
       fields = %w[intimidation_to_staff intimidation_to_public intimidation_to_other_detainees intimidation_to_witnesses]
       if risk.intimidation == 'yes'
-        check_section(risk, 'harassments', fields)
+        check_section(risk, 'intimidation', fields)
       else
-        check_section_is_all_no(risk, 'harassments', fields)
+        check_section_is_all_no(risk, 'intimidation', fields)
       end
     end
 
     def check_harassment(risk)
       if risk.harassment == 'yes'
-        check_question(risk, 'harassments', 'harassment_details')
+        check_question(risk, 'harassment', 'harassment_details')
       end
     end
 
@@ -156,14 +156,14 @@ module Page
     def check_security_section(risk)
       check_current_e_risk(risk)
       check_previous_escape_attempts(risk)
-      check_question(risk, 'security', 'category_a')
-      check_question(risk, 'security', 'escort_risk_assessment')
-      check_question(risk, 'security', 'escape_pack')
+      check_question(risk, 'category_a', 'category_a')
+      check_question(risk, 'escort_details', 'escort_risk_assessment')
+      check_question(risk, 'escort_details', 'escape_pack')
     end
 
     def check_current_e_risk(risk)
       if risk.current_e_risk == 'yes'
-        check_question(risk, 'security', 'current_e_risk_details')
+        check_question(risk, 'escape_status', 'current_e_risk_details')
       end
     end
 
@@ -171,9 +171,9 @@ module Page
       fields = %w[prison_escape_attempt court_escape_attempt
                   police_escape_attempt other_type_escape_attempt]
       if risk.previous_escape_attempts == 'yes'
-        check_section(risk, 'security', fields)
+        check_section(risk, 'previous_escape_attempts', fields)
       else
-        check_section_is_all_no(risk, 'security', fields)
+        check_section_is_all_no(risk, 'previous_escape_attempts', fields)
       end
     end
 

--- a/spec/forms/risk/risk_to_self_spec.rb
+++ b/spec/forms/risk/risk_to_self_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Forms::Risk::RiskToSelf, type: :form do
   }
 
   describe '#validate' do
-    specify { is_expected.to validate_inclusion_of(:acct_status).in_array(%w(open post_closure closed_in_last_6_months not_available)) }
+    specify { is_expected.to validate_inclusion_of(:acct_status).in_array(%w(open post_closure closed_in_last_6_months none)) }
 
     context 'when ACCT status is empty' do
       specify { expect(form.validate(acct_status: nil)).to be_truthy }

--- a/spec/presenters/summary/risk_subsection_presenter_spec.rb
+++ b/spec/presenters/summary/risk_subsection_presenter_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Summary::RiskSubsectionPresenter, type: :presenter do
+  let(:answer) { true }
+  let(:conditional_answer) { 'yes' }
+  let(:model) { double(Risk) }
+  let(:section_name) { 'test_section' }
+  let(:subsection_name) { 'test_subsection' }
+  let(:section_class) {
+    Class.new(BaseSection) do
+    end
+  }
+  let(:section) { section_class.new }
+  subject(:presenter) { described_class.new(model, section: section_name, subsection: subsection_name) }
+
+  it_behaves_like 'assessment subsection presenter'
+end

--- a/spec/sections/base_section_spec.rb
+++ b/spec/sections/base_section_spec.rb
@@ -1,0 +1,131 @@
+require 'rails_helper'
+
+RSpec.describe BaseSection do
+  class TestBaseSection < BaseSection
+    def initialize(options = {})
+      @question_dependencies = options[:question_dependencies]
+      @questions_details = options[:questions_details]
+      @subsections_questions = options[:subsections_questions]
+    end
+
+    def question_dependencies
+      @question_dependencies || super
+    end
+
+    def questions_details
+      @questions_details || super
+    end
+
+    def subsections_questions
+      @subsections_questions || super
+    end
+  end
+
+  let(:section) { TestBaseSection.new(options) }
+  let(:options) { {} }
+
+  describe '#question_is_conditional?' do
+    context 'when there is no question conditions' do
+      let(:options) { {} }
+      specify { expect(section.question_is_conditional?(:some_question)).to be_falsey }
+    end
+
+    context 'when there is some question conditions' do
+      let(:options) {{ question_dependencies: { dependant: [:some_question] } }}
+      specify { expect(section.question_is_conditional?(:some_question)).to be_truthy }
+    end
+  end
+
+  describe '#question_condition' do
+    context 'when there is no question conditions' do
+      let(:options) { {} }
+      specify { expect(section.question_condition(:some_question)).to eq(nil) }
+    end
+
+    context 'when there is some question conditions' do
+      let(:options) {{ question_dependencies: { dependant: [:some_question] } }}
+      specify { expect(section.question_condition(:some_question)).to eq(:dependant) }
+    end
+  end
+
+  describe '#question_has_details?' do
+    context 'when there is no question details' do
+      let(:options) { {} }
+      specify { expect(section.question_has_details?(:some_question)).to be_falsey }
+    end
+
+    context 'when there is some question details' do
+      let(:options) {{ questions_details: { some_question: %i[detail_1 detail_2] }}}
+      specify { expect(section.question_has_details?(:some_question)).to be_truthy }
+    end
+  end
+
+  describe '#question_details' do
+    context 'when there is no question details' do
+      let(:options) { {} }
+      specify { expect(section.question_details(:some_question)).to eq(nil) }
+    end
+
+    context 'when there is some question details' do
+      let(:options) {{ questions_details: { some_question: %i[detail_1 detail_2] }}}
+      specify { expect(section.question_details(:some_question)).to match_array(%i[detail_1 detail_2]) }
+    end
+  end
+
+  describe '#subsections' do
+    context 'when there is no sub sections' do
+      let(:options) { {} }
+      specify { expect(section.subsections).to eq([]) }
+    end
+
+    context 'when there is sub sections' do
+      let(:options) {
+        {
+          subsections_questions: {
+            sub_section_1: %i[question_1 question_2],
+            sub_section_2: %i[question_3]
+          }
+        }
+      }
+      specify { expect(section.subsections).to match_array(%i[sub_section_1 sub_section_2]) }
+    end
+  end
+
+  describe '#has_subsections?' do
+    context 'when there is no sub sections' do
+      let(:options) { {} }
+      specify { expect(section.has_subsections?).to be_falsey }
+    end
+
+    context 'when there is sub sections' do
+      let(:options) {
+        {
+          subsections_questions: {
+            sub_section_1: %i[question_1 question_2],
+            sub_section_2: %i[question_3]
+          }
+        }
+      }
+      specify { expect(section.has_subsections?).to be_truthy }
+    end
+  end
+
+  describe '#questions_for_subsection' do
+    context 'when there is no sub sections' do
+      let(:options) { {} }
+      specify { expect(section.questions_for_subsection(:some_section)).to eq([]) }
+    end
+
+    context 'when there is sub sections' do
+      let(:options) {
+        {
+          subsections_questions: {
+            sub_section_1: %i[question_1 question_2],
+            sub_section_2: %i[question_3]
+          }
+        }
+      }
+      specify { expect(section.questions_for_subsection(:sub_section_1)).to match_array(%i[question_1 question_2]) }
+    end
+  end
+end

--- a/spec/support/shared_examples/assessment_subsection_presenter_shared_examples.rb
+++ b/spec/support/shared_examples/assessment_subsection_presenter_shared_examples.rb
@@ -1,0 +1,25 @@
+RSpec.shared_examples_for 'assessment subsection presenter' do
+  include_examples 'assessment section presenter'
+
+  describe '#name' do
+    specify { expect(presenter.name).to eq(subsection_name) }
+  end
+
+  describe '#questions' do
+    context 'when the subsection does not contain any questions' do
+      specify { expect(presenter.questions).to eq([]) }
+    end
+
+    context 'when the subsection contains a list of questions' do
+      let(:subsections_questions) {
+        { subsection_name.to_sym => %i[ss_question_1 ss_question_2] }
+      }
+
+      before do
+        allow(section).to receive(:subsections_questions).and_return(subsections_questions)
+      end
+
+      specify { expect(presenter.questions).to match_array(%i[ss_question_1 ss_question_2]) }
+    end
+  end
+end


### PR DESCRIPTION
[Trello #433](https://trello.com/c/l98iAMmK/433-5-as-an-osg-completing-the-risk-section-of-a-per-i-want-to-be-able-to-view-a-summary-of-all-the-questions-i-have-completed-depen)

- Display all the risk assessment questions as per design requirement
- Add the concept of subsection to deal with the display of some section
questions that have now been split in different subsections
- Section can now define subsections and which questions belong to each
of those subsections
- Support for localised answers so that for very specific cases, we can
display a different wording in the summary page for the given answer
- Add anchors for subsection to the risk assessment section pages so
that the user can jump straight to that subsection from the summary page