### PR TITLE
Changes to the healthcare summary page

### DIFF
--- a/app/assets/stylesheets/moving_people_safely/_summary.scss
+++ b/app/assets/stylesheets/moving_people_safely/_summary.scss
@@ -40,6 +40,7 @@
 
     td {
       padding: 0.6em;
+      vertical-align: top;
     }
 
     b {

--- a/app/models/healthcare_workflow.rb
+++ b/app/models/healthcare_workflow.rb
@@ -3,12 +3,8 @@ class HealthcareWorkflow < Workflow
     %i[physical mental social allergies needs transport communication contact]
   end
 
-  def self.sections_for_summary
-    %i[physical mental social allergies needs transport communication]
-  end
-
   def self.mandatory_questions
-    sections_for_summary.map do |section_name|
+    sections.map do |section_name|
       HealthcareAssessment.section_for(section_name).mandatory_questions
     end.flatten
   end

--- a/app/models/sections/base_section.rb
+++ b/app/models/sections/base_section.rb
@@ -27,6 +27,14 @@ class BaseSection
     subsections_questions.fetch(subsection.to_sym, [])
   end
 
+  def relevant_answer?(question, answer)
+    answers = relevant_answers[question.to_sym]
+    if answers && answer.present?
+      return true if answers == :all
+      answers.include?(answer.downcase)
+    end
+  end
+
   private
 
   def question_dependencies
@@ -34,6 +42,10 @@ class BaseSection
   end
 
   def questions_details
+    {}
+  end
+
+  def relevant_answers
     {}
   end
 

--- a/app/models/sections/healthcare_assessment/contact_section.rb
+++ b/app/models/sections/healthcare_assessment/contact_section.rb
@@ -1,0 +1,12 @@
+module HealthcareAssessment
+  class ContactSection < BaseSection
+    def name
+      'contact'
+    end
+
+    def questions
+      %w[healthcare_professional contact_number]
+    end
+    alias mandatory_questions questions
+  end
+end

--- a/app/models/sections/healthcare_assessment/needs_section.rb
+++ b/app/models/sections/healthcare_assessment/needs_section.rb
@@ -8,5 +8,19 @@ module HealthcareAssessment
       %w[dependencies has_medications]
     end
     alias mandatory_questions questions
+
+    private
+
+    def questions_details
+      {
+        has_medications:
+        [
+          {
+            collection: :medications,
+            fields: %i[description administration carrier]
+          }
+        ]
+      }
+    end
   end
 end

--- a/app/models/sections/risk_assessment/risk_from_others_section.rb
+++ b/app/models/sections/risk_assessment/risk_from_others_section.rb
@@ -8,5 +8,13 @@ module RiskAssessment
       %w[rule_45 csra victim_of_abuse high_profile]
     end
     alias mandatory_questions questions
+
+    private
+
+    def relevant_answers
+      {
+        csra: %w[high]
+      }
+    end
   end
 end

--- a/app/models/sections/risk_assessment/risk_to_self_section.rb
+++ b/app/models/sections/risk_assessment/risk_to_self_section.rb
@@ -14,5 +14,11 @@ module RiskAssessment
         acct_status: %i[date_of_most_recently_closed_acct acct_status_details]
       }
     end
+
+    def relevant_answers
+      {
+        acct_status: :all
+      }
+    end
   end
 end

--- a/app/presenters/summary/assessment_section_presenter.rb
+++ b/app/presenters/summary/assessment_section_presenter.rb
@@ -5,6 +5,7 @@ module Summary
     delegate :question_is_conditional?, :question_condition, to: :section
     delegate :question_has_details?, :question_details, to: :section
     delegate :subsections, :has_subsections?, :questions_for_subsection, to: :section
+    delegate :relevant_answer?, to: :section
 
     def self.for(section, assessment)
       new(assessment, section: section)
@@ -46,12 +47,11 @@ module Summary
         "<span class='text-error'>Missing</span>"
       when 'no', false
         'No'
-      when true
-        '<b>Yes</b>'
-      when 'standard'
-        'Standard'
+      when 'yes', true
+        highlight('Yes')
       else
-        "<b>#{answer_value(value)}</b>"
+        answer = answer_value(value)
+        relevant_answer?(attribute, value) ? highlight(answer) : answer
       end
     end
 
@@ -91,6 +91,10 @@ module Summary
     def answer_value(value)
       default_value = value.respond_to?(:humanize) ? value.humanize : value
       I18n.t(value, scope: [:summary, :section, :answers, section_name], default: default_value)
+    end
+
+    def highlight(text)
+      "<b>#{text}</b>"
     end
   end
 end

--- a/app/presenters/summary/assessment_section_presenter.rb
+++ b/app/presenters/summary/assessment_section_presenter.rb
@@ -29,7 +29,11 @@ module Summary
     def details_for(attribute)
       return super(attribute) unless question_has_details?(attribute)
       question_details(attribute).each_with_object([]) do |detail_attr, details|
-        details << detail_content(detail_attr) if public_send(detail_attr).present?
+        if detail_attr.is_a?(Hash)
+          details << complex_detail_context(detail_attr)
+        elsif public_send(detail_attr).present?
+          details << detail_content(detail_attr)
+        end
       end.join('. ')
     end
 
@@ -65,6 +69,17 @@ module Summary
 
     def detail_content(attribute)
       [detail_label(attribute), answer_value(public_send(attribute))].join('')
+    end
+
+    def complex_detail_context(hash)
+      public_send(hash[:collection]).each_with_object([]) do |item, details|
+        details << hash[:fields].map do |field|
+          [
+            detail_label("#{hash[:collection]}_collection.#{field}"),
+            answer_value(item.send(field))
+          ].join(' ')
+        end.join(' | ')
+      end.join('</br>')
     end
 
     def detail_label(attribute)

--- a/app/views/summary/healthcare.html.slim
+++ b/app/views/summary/healthcare.html.slim
@@ -1,7 +1,7 @@
 .summary
   = render partial: 'summary/status', locals: { workflow: healthcare_workflow, title: 'Healthcare' }
 
-  - HealthcareWorkflow.sections_for_summary.each do |section|
+  - HealthcareWorkflow.sections.each do |section|
     = render partial: 'summary/section',
       locals: { section: Summary::HealthcarePresenter.for(section, healthcare), path: healthcare_path(detainee, section) }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -375,14 +375,17 @@ en:
           arson: Arson is a behavioural issue
           damage_to_property: Damage to property
         communication:
-          hearing_speech_sight_issues: Hearing / Speech / Sight issues
-          reading_writing_issues: Reading / Writing issues
+          hearing_speech_sight_issues: Hearing / speech / sight issues
+          reading_writing_issues: Reading / writing issues
         concealed_weapons:
           conceals_weapons: Conceals weapons
           conceals_drugs: Conceals drugs
           conceals_mobile_phones: Conceals mobile phones
           conceals_sim_cards: Conceals SIM cards
           conceals_other_items: Conceals other items
+        contact:
+          contact_number: Contact number
+          healthcare_professional: Healthcare professional
         harassments:
           harassment: Harasser
           intimidation_to_staff: Staff
@@ -393,8 +396,13 @@ en:
           staff_hostage_taker: Staff
           prisoners_hostage_taker: Prisoners
           public_hostage_taker: Public
+        mental:
+          mental_illness: Mental health issues
         needs:
-          has_medications: Medication
+          dependencies: Dependencies / misuse
+          has_medications: Regular Medication
+          medications_collection:
+            carrier: 'Carried by '
         sex_offences:
           sex_offence: Sex offender
           sex_offence_adult_male_victim: Adult male
@@ -419,12 +427,15 @@ en:
           court_escape_attempt: Court
           police_escape_attempt: Police
           other_type_escape_attempt: Other
+        social:
+          personal_care: Personal care issues
+          personal_hygiene: Personal hygiene issues
         substance_misuse:
           substance_supply: Risk of detainee trafficking drugs or alcohol
           trafficking_drugs: Drugs
           trafficking_alcohol: Alcohol
         transport:
-          mpv: MPV
+          mpv: MPV required
         violence:
           co_defendant: Co-defendant
           escort_or_court_staff: Escort or court staff
@@ -447,6 +458,7 @@ en:
         category_a: Category A or Restricted status
         communication: Communication / language difficulties
         concealed_weapons: Conceals weapons, drugs or other items
+        contact: Medical contact
         discrimination: "Risk to others - discrimination"
         escape_status: Escape status/history
         escort_details: Escort Risk Assessment/Escort Pack

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -400,9 +400,11 @@ en:
           mental_illness: Mental health issues
         needs:
           dependencies: Dependencies / misuse
-          has_medications: Regular Medication
+          has_medications: Regular medication
           medications_collection:
             carrier: 'Carried by '
+        physical:
+          physical_issues: Physical health needs
         sex_offences:
           sex_offence: Sex offender
           sex_offence_adult_male_victim: Adult male

--- a/spec/models/healthcare_workflow_spec.rb
+++ b/spec/models/healthcare_workflow_spec.rb
@@ -12,19 +12,13 @@ RSpec.describe HealthcareWorkflow do
     }
   end
 
-  describe '.sections_for_summary' do
-    specify {
-      expect(described_class.sections_for_summary)
-        .to match_array(%i[physical mental social allergies needs transport communication])
-    }
-  end
-
   describe '.mandatory_questions' do
     it 'returns the appropriate list of mandatory questions' do
       expect(described_class.mandatory_questions).to match_array(
           %w[physical_issues mental_illness phobias personal_hygiene
              personal_care allergies dependencies has_medications
-             hearing_speech_sight_issues reading_writing_issues mpv])
+             hearing_speech_sight_issues reading_writing_issues mpv
+             healthcare_professional contact_number])
     end
   end
 end

--- a/spec/sections/base_section_spec.rb
+++ b/spec/sections/base_section_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe BaseSection do
       @question_dependencies = options[:question_dependencies]
       @questions_details = options[:questions_details]
       @subsections_questions = options[:subsections_questions]
+      @relevant_answers = options[:relevant_answers]
     end
 
     def question_dependencies
@@ -18,6 +19,10 @@ RSpec.describe BaseSection do
 
     def subsections_questions
       @subsections_questions || super
+    end
+
+    def relevant_answers
+      @relevant_answers || super
     end
   end
 
@@ -126,6 +131,57 @@ RSpec.describe BaseSection do
         }
       }
       specify { expect(section.questions_for_subsection(:sub_section_1)).to match_array(%i[question_1 question_2]) }
+    end
+  end
+
+  describe '#relevant_answer?' do
+    context 'when there is no relevant answers' do
+      let(:options) { {} }
+      specify { expect(section.relevant_answer?(:question, 'answer')).to be_falsey }
+    end
+
+    context 'when the answer is blank' do
+      let(:options) {
+        {
+          relevant_answers: {
+            question: %w(answer)
+          }
+        }
+      }
+      specify { expect(section.relevant_answer?(:question, '')).to be_falsey }
+    end
+
+    context 'when the answer is not relevant' do
+      let(:options) {
+        {
+          relevant_answers: {
+            question: %w(answer)
+          }
+        }
+      }
+      specify { expect(section.relevant_answer?(:question, 'other_answer')).to be_falsey }
+    end
+
+    context 'when the answer is relevant' do
+      let(:options) {
+        {
+          relevant_answers: {
+            question: %w(answer)
+          }
+        }
+      }
+      specify { expect(section.relevant_answer?(:question, 'answer')).to be_truthy }
+    end
+
+    context 'when all the answers are relevant' do
+      let(:options) {
+        {
+          relevant_answers: {
+            question: :all
+          }
+        }
+      }
+      specify { expect(section.relevant_answer?(:question, 'random answer')).to be_truthy }
     end
   end
 end

--- a/spec/support/shared_examples/assessment_section_presenter_shared_examples.rb
+++ b/spec/support/shared_examples/assessment_section_presenter_shared_examples.rb
@@ -78,12 +78,22 @@ RSpec.shared_examples_for 'assessment section presenter' do
           end
 
           it 'returns the localised version of the answer' do
-            expect(presenter.answer_for(:question)).to eq('<b>Localised some other value</b>')
+            expect(presenter.answer_for(:question)).to eq('Localised some other value')
           end
         end
 
         context 'and the answer has no locale for the summary page' do
           it 'returns the humanized version of it' do
+            expect(presenter.answer_for(:question)).to eq 'Some other value'
+          end
+        end
+
+        context 'and the answer is considered relevant' do
+          before do
+            allow(section).to receive(:relevant_answer?).with(:question, answer).and_return(true)
+          end
+
+          it 'returns the answer highlighted' do
             expect(presenter.answer_for(:question)).to eq '<b>Some other value</b>'
           end
         end


### PR DESCRIPTION
[Trello #442](https://trello.com/c/WCrDqngO/442-2-as-a-member-of-nhs-healthcare-staff-completing-the-health-section-of-the-digital-per-i-want-to-be-able-to-view-a-summary-of-al)

- Wording changes according to the most recent design requirements
- Add support to the assessment presenters to display details for
information that is stored in a related collection (e.g. healthcare
assessment can have multiples of medications). Presents the collection
by decorating the items described in the section details.