### PR TITLE
Add From and To move details to profile page

### DIFF
--- a/app/views/detainees/_move.html.slim
+++ b/app/views/detainees/_move.html.slim
@@ -4,11 +4,15 @@
   h2
     ' Move information
   .info-tiles
-    .tile
+    .tile-3
       | Date of travel
       br
       b = move.humanized_date
-    .tile
+    .tile-3
+      | From
+      br
+      b = move.from
+    .tile-3
       | To
       br
       b = move.to

--- a/spec/features/detainee_profile_page_spec.rb
+++ b/spec/features/detainee_profile_page_spec.rb
@@ -331,6 +331,30 @@ RSpec.feature 'detainee profile page', type: :feature do
     end
   end
 
+  context 'move information' do
+    context 'detainee with no active move' do
+      let(:detainee) { create(:detainee, :with_completed_move) }
+
+      scenario 'does not display any move information' do
+        login
+
+        visit detainee_path(detainee)
+        expect(page).not_to have_css('.move-information')
+      end
+    end
+
+    context 'detainee with an active move' do
+      let(:detainee) { create(:detainee, :with_active_move) }
+
+      scenario 'displays all the mandatory move information' do
+        login
+
+        visit detainee_path(detainee)
+        profile.confirm_move_info(detainee.active_move)
+      end
+    end
+  end
+
   context 'offences section' do
     let(:detainee) { create(:detainee, :with_active_move, :with_no_offences) }
     let(:active_move) { detainee.active_move }

--- a/spec/features/filling_in_a_per_spec.rb
+++ b/spec/features/filling_in_a_per_spec.rb
@@ -32,9 +32,15 @@ RSpec.feature 'filling in a PER', type: :feature do
     dashboard.create_new_profile.click
 
     detainee_details.complete_form(detainee)
-    move_details.complete_form(move_data)
+    destinations = [
+      { establishment: 'Hospital', must: :return },
+      { establishment: 'Court', must: :return },
+      { establishment: 'Dentist', must: :not_return },
+      { establishment: 'Tribunal', must: :not_return }
+    ]
+    move_details.complete_form(move_data, destinations: destinations)
 
-    profile.confirm_move_info(move_data)
+    profile.confirm_move_info(move_data, destinations: destinations)
     profile.confirm_detainee_details(detainee)
     profile.click_edit_healthcare
 

--- a/spec/features/pages/move_details.rb
+++ b/spec/features/pages/move_details.rb
@@ -1,11 +1,12 @@
 module Page
   class MoveDetails < Base
-    def complete_form(move)
+    def complete_form(move, options = {})
       fill_in 'From', with: move.from
       fill_in 'To', with: move.to
       fill_in 'Date', with: move.date
       fill_in_not_for_release_details(move)
-      fill_in_destinations
+      destinations = options[:destinations]
+      fill_in_destinations(destinations) if destinations.present?
       save_and_continue
     end
 
@@ -28,19 +29,13 @@ module Page
       end
     end
 
-    def fill_in_destinations
+    def fill_in_destinations(destinations)
       choose 'move_has_destinations_yes'
-      fill_in 'move_destinations_attributes_0_establishment', with: 'Hospital'
-      choose 'move_destinations_attributes_0_must_return_must_return'
-      click_button 'Add establishment'
-      fill_in 'move_destinations_attributes_1_establishment', with: 'Court'
-      choose 'move_destinations_attributes_1_must_return_must_return'
-      click_button 'Add establishment'
-      fill_in 'move_destinations_attributes_2_establishment', with: 'Dentist'
-      choose 'move_destinations_attributes_2_must_return_must_not_return'
-      click_button 'Add establishment'
-      fill_in 'move_destinations_attributes_3_establishment', with: 'Tribunal'
-      choose 'move_destinations_attributes_3_must_return_must_not_return'
+      destinations.each_with_index do |destination, index|
+        fill_in "move_destinations_attributes_#{index}_establishment", with: destination[:establishment]
+        choose "move_destinations_attributes_#{index}_must_return_must_#{destination[:must]}"
+        click_button 'Add establishment' unless index == destinations.size - 1
+      end
     end
   end
 end

--- a/spec/features/pages/profile.rb
+++ b/spec/features/pages/profile.rb
@@ -29,12 +29,18 @@ module Page
       end
     end
 
-    def confirm_move_info(move)
+    def confirm_move_info(move, options = {})
       within('.move-information') do
+        expect(page).to have_content move.from
         expect(page).to have_content move.to
         expect(page).to have_content move.date.strftime('%d %b %Y')
-        expect(page).to have_content('Hospital, Court')
-        expect(page).to have_content('Dentist, Tribunal')
+        destinations = options[:destinations]
+        if destinations.present?
+          must_returns = destinations.select { |d| d[:must] == :return }.pluck(:establishment)
+          must_not_returns = destinations.select { |d| d[:must] == :not_return }.pluck(:establishment)
+          expect(page).to have_content(must_returns.join(', '))
+          expect(page).to have_content(must_not_returns.join(', '))
+        end
       end
     end
 


### PR DESCRIPTION
[Trello #447](https://trello.com/c/fcxG6KjS/447-1-as-someone-reviewing-the-move-information-on-a-profile-i-want-to-see-where-a-detainee-is-travelling-from-and-to)

Nothing else to add. Small change, just refactored the associated specs
so they're not assuming content, but they make assertions base on the
actual provided content.