### PR TITLE
Fix validation bug on risk to others form

### DIFF
--- a/app/models/forms/risk/hostage_taker.rb
+++ b/app/models/forms/risk/hostage_taker.rb
@@ -28,7 +28,7 @@ module Forms
 
       validates :date_most_recent_staff_hostage_taker_incident,
         date: { not_in_the_future: true },
-        if: -> { staff_hostage_taker == true }
+        if: -> { hostage_taker == 'yes' && staff_hostage_taker == true }
 
       property :date_most_recent_prisoners_hostage_taker_incident, type: TextDate
       reset attributes: %i[date_most_recent_prisoners_hostage_taker_incident],
@@ -37,7 +37,7 @@ module Forms
 
       validates :date_most_recent_prisoners_hostage_taker_incident,
         date: { not_in_the_future: true },
-        if: -> { prisoners_hostage_taker == true }
+        if: -> { hostage_taker == 'yes' && prisoners_hostage_taker == true }
 
       property :date_most_recent_public_hostage_taker_incident, type: TextDate
       reset attributes: %i[date_most_recent_public_hostage_taker_incident],
@@ -46,7 +46,7 @@ module Forms
 
       validates :date_most_recent_public_hostage_taker_incident,
         date: { not_in_the_future: true },
-        if: -> { public_hostage_taker == true }
+        if: -> { hostage_taker == 'yes' && public_hostage_taker == true }
 
       private
 

--- a/spec/forms/risk/hostage_taker_spec.rb
+++ b/spec/forms/risk/hostage_taker_spec.rb
@@ -6,6 +6,46 @@ RSpec.describe Forms::Risk::HostageTaker, type: :form do
 
   describe '#validate' do
     context "for hostage taker" do
+      context 'when hostage taker is set to no' do
+        before { form.hostage_taker = 'no' }
+
+        context 'and staff hostage taker is set to true' do
+          before { form.staff_hostage_taker = true }
+
+          context 'but date of most recent incident is not present' do
+            before { form.date_most_recent_staff_hostage_taker_incident = nil }
+
+            it 'form is still valid' do
+              expect(form).to be_valid
+            end
+          end
+        end
+
+        context 'and prisoners hostage taker is set to true' do
+          before { form.prisoners_hostage_taker = true }
+
+          context 'but date of most recent incident is not present' do
+            before { form.date_most_recent_prisoners_hostage_taker_incident = nil }
+
+            it 'form is still valid' do
+              expect(form).to be_valid
+            end
+          end
+        end
+
+        context 'and public hostage taker is set to true' do
+          before { form.public_hostage_taker = true }
+
+          context 'but date of most recent incident is not present' do
+            before { form.date_most_recent_public_hostage_taker_incident = nil }
+
+            it 'form is still valid' do
+              expect(form).to be_valid
+            end
+          end
+        end
+      end
+
       context 'when hostage taker is set to yes' do
         before { form.hostage_taker = 'yes' }
 


### PR DESCRIPTION
[Trello #461](https://trello.com/c/SxEzvuWi/461-bug-risk-to-others-hostage-taker-selecting-no-or-clear-selection-is-not-clearing-selections-in-yes)

The bug was described as: "Question 4 of the risk section: If user has
selected 'Yes' and made selections but not inputted a date/s when they
select 'No' or 'clear selection' and then 'No' the page errors as the
selections under 'yes' are still active"

This fix ensures that the validation is only performed for the dates if
its strictly required (aka, both hostage taker and specific type of
hostage taker are set to true