### PR TITLE
Fix validation bug in sex offenders risk form

### DIFF
--- a/app/models/forms/risk/sex_offences.rb
+++ b/app/models/forms/risk/sex_offences.rb
@@ -16,7 +16,7 @@ module Forms
 
       optional_checkbox :sex_offence_adult_male_victim
       optional_checkbox :sex_offence_adult_female_victim
-      optional_checkbox_with_details :sex_offence_under18_victim
+      optional_checkbox_with_details :sex_offence_under18_victim, :sex_offence
 
       reset attributes: %i[sex_offence_adult_male_victim sex_offence_adult_female_victim
                            sex_offence_under18_victim sex_offence_under18_victim_details],

--- a/spec/forms/risk/sex_offences_spec.rb
+++ b/spec/forms/risk/sex_offences_spec.rb
@@ -8,6 +8,15 @@ RSpec.describe Forms::Risk::SexOffences, type: :form do
     describe "sex_offence" do
       it { is_expected.to validate_optional_field(:sex_offence) }
 
+      context 'when sex_offence is set to no' do
+        before { form.sex_offence = 'no' }
+
+        context 'when under 18 is set to true' do
+          before { subject.sex_offence_under18_victim = true }
+          specify { expect(form).to be_valid }
+        end
+      end
+
       context 'when sex_offence is set to yes' do
         before { form.sex_offence = 'yes' }
 


### PR DESCRIPTION
[Trello #462](https://trello.com/c/lOVZLLD1/462-bug-sex-offender-selecting-no-or-clear-selection-is-not-clearing-selections-in-yes)

**BUG** - 'Sex offender' - selecting 'no' or 'clear selection is not clearing selections in 'Yes'

Question 6 of the risk section: If user has selected 'Yes' and selected 'under 18' but not inputted data when they select 'No' or 'clear selection' and then 'No' the page errors as the selections under 'yes' are still active