### PR TITLE
Profile must return changes

### DIFF
--- a/app/presenters/move_presenter.rb
+++ b/app/presenters/move_presenter.rb
@@ -1,13 +1,26 @@
 class MovePresenter < SimpleDelegator
+  include ActionView::Helpers::OutputSafetyHelper
+
   def humanized_date
     date && date.to_s(:humanized)
   end
 
   def must_return_to
-    destinations.must_return_to.map(&:establishment).join(', ')
+    format_destinations(destinations.must_return_to)
   end
 
   def must_not_return_to
-    destinations.must_not_return_to.map(&:establishment).join(', ')
+    format_destinations(destinations.must_not_return_to)
+  end
+
+  private
+
+  def format_destinations(destinations)
+    return 'None' if destinations.empty?
+    safe_join(destinations.map do |destination|
+      array = [destination.establishment]
+      array << "(#{destination.reasons})" if destination.reasons.present?
+      array.join(' ')
+    end, '<br />'.html_safe)
   end
 end

--- a/app/views/detainees/_move.html.slim
+++ b/app/views/detainees/_move.html.slim
@@ -17,11 +17,11 @@
       br
       b = move.to
   .info-tiles
-    .tile
+    .tile.must-return-to
       | Must return to
       br
       b == move.must_return_to
-    .tile
+    .tile.must-not-return-to
       | Must NOT return to
       br
       b == move.must_not_return_to

--- a/spec/features/pages/profile.rb
+++ b/spec/features/pages/profile.rb
@@ -38,8 +38,17 @@ module Page
         if destinations.present?
           must_returns = destinations.select { |d| d[:must] == :return }.pluck(:establishment)
           must_not_returns = destinations.select { |d| d[:must] == :not_return }.pluck(:establishment)
-          expect(page).to have_content(must_returns.join(', '))
-          expect(page).to have_content(must_not_returns.join(', '))
+          within('.must-return-to') do
+            must_returns.each do |must_return|
+              expect(page).to have_content(must_return)
+            end
+          end
+
+          within('.must-not-return-to') do
+            must_not_returns.each do |must_not_return|
+              expect(page).to have_content(must_not_return)
+            end
+          end
         end
       end
     end

--- a/spec/presenters/move_presenter_spec.rb
+++ b/spec/presenters/move_presenter_spec.rb
@@ -1,33 +1,95 @@
 require 'rails_helper'
 
 RSpec.describe MovePresenter, type: :presenter do
-  let(:move) { create :move }
-  subject { described_class.new move }
+  let(:move) { FactoryGirl.create(:move) }
+  subject { described_class.new(move) }
 
   describe '#humanized_date' do
-    let(:move) { build :move, date: Date.civil(2017, 6, 14) }
+    let(:move) { FactoryGirl.build(:move, date: Date.civil(2017, 6, 14)) }
     its(:humanized_date) { is_expected.to eq '14 Jun 2017' }
   end
 
   describe '#must_return_to' do
+    let(:destinations) {
+      [
+        { establishment: 'other', must_return: 'must_not_return', reasons: 'some other reason' },
+        { establishment: 'hospital', must_return: 'must_return', reasons: 'some reason' },
+        { establishment: 'court', must_return: 'must_return', reasons: 'other reason' }
+      ]
+    }
+
     before do
-      move.destinations.create(establishment: 'hospital', must_return: 'must_return')
-      move.destinations.create(establishment: 'court', must_return: 'must_return')
+      destinations.each { |destination| move.destinations.create(destination) }
     end
 
-    it 'returns comma separated string of establishments where the detainee must return to' do
-      expect(subject.must_return_to).to eq 'hospital, court'
+    it 'returns establishments the detainee must return to including its details separated by a new line' do
+      expect(subject.must_return_to).to eq 'hospital (some reason)<br />court (other reason)'
+    end
+
+    context 'when no reason was supplied' do
+      let(:destinations) {
+        [
+          { establishment: 'other', must_return: 'must_not_return', reasons: 'some other reason' },
+          { establishment: 'hospital', must_return: 'must_return', reasons: nil },
+          { establishment: 'court', must_return: 'must_return', reasons: 'other reason' }
+        ]
+      }
+
+      it 'does not display any reason content' do
+        expect(subject.must_return_to).to eq 'hospital<br />court (other reason)'
+      end
+    end
+
+    context 'when there is no establishments to return to' do
+      let(:destinations) {
+        [
+          { establishment: 'other', must_return: 'must_not_return', reasons: 'some other reason' }
+        ]
+      }
+
+      specify { expect(subject.must_return_to).to eq('None') }
     end
   end
 
   describe '#must_not_return_to' do
+    let(:destinations) {
+      [
+        { establishment: 'other', must_return: 'must_return', reasons: 'some other reason' },
+        { establishment: 'hospital', must_return: 'must_not_return', reasons: 'some reason' },
+        { establishment: 'court', must_return: 'must_not_return', reasons: 'other reason' }
+      ]
+    }
+
     before do
-      move.destinations.create(establishment: 'hospital', must_return: 'must_not_return')
-      move.destinations.create(establishment: 'court', must_return: 'must_not_return')
+      destinations.each { |destination| move.destinations.create(destination) }
     end
 
-    it 'returns comma separated string of establishments where the detainee must not return to' do
-      expect(subject.must_not_return_to).to eq 'hospital, court'
+    it 'returns establishments where the detainee must not return to including its details separated by a new line' do
+      expect(subject.must_not_return_to).to eq 'hospital (some reason)<br />court (other reason)'
+    end
+
+    context 'when no reason was supplied' do
+      let(:destinations) {
+        [
+          { establishment: 'other', must_return: 'must_return', reasons: 'some other reason' },
+          { establishment: 'hospital', must_return: 'must_not_return', reasons: nil },
+          { establishment: 'court', must_return: 'must_not_return', reasons: 'other reason' }
+        ]
+      }
+
+      it 'does not display any reason content' do
+        expect(subject.must_not_return_to).to eq 'hospital<br />court (other reason)'
+      end
+    end
+
+    context 'when there is no establishments to not return to' do
+      let(:destinations) {
+        [
+          { establishment: 'other', must_return: 'must_return', reasons: 'some other reason' }
+        ]
+      }
+
+      specify { expect(subject.must_not_return_to).to eq('None') }
     end
   end
 end


### PR DESCRIPTION
[Trello #443](https://trello.com/c/3Uax2dXo/443-1-as-someone-completing-a-digital-per-i-want-to-see-reflected-on-the-profile-screen-whether-a-detainee-must-return-to-the-prison)

Re-design display of Must (not) return move info in profile page