### PR TITLE
Re-use existing age calculator in detainee presenter

### DIFF
--- a/app/presenters/detainee_presenter.rb
+++ b/app/presenters/detainee_presenter.rb
@@ -7,12 +7,6 @@ class DetaineePresenter < SimpleDelegator
     end
   end
 
-  def age
-    today = Date.today
-    d = Date.new(today.year, date_of_birth.month, date_of_birth.day)
-    d.year - date_of_birth.year - (d > today ? 1 : 0)
-  end
-
   def humanized_date_of_birth
     date_of_birth.to_s(:humanized)
   end

--- a/spec/presenters/detainee_presenter_spec.rb
+++ b/spec/presenters/detainee_presenter_spec.rb
@@ -1,28 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe DetaineePresenter, type: :presenter do
-  let(:detainee) { build :detainee }
+  let(:detainee) { FactoryGirl.build(:detainee) }
   subject { described_class.new detainee }
 
   describe '#short_gender' do
     context 'when male' do
-      let(:detainee) { build :detainee, gender: 'male' }
+      let(:detainee) { FactoryGirl.build(:detainee, gender: 'male') }
       its(:short_gender) { is_expected.to eq 'M' }
     end
 
     context 'when female' do
-      let(:detainee) { build :detainee, gender: 'female' }
+      let(:detainee) { FactoryGirl.build(:detainee, gender: 'female') }
       its(:short_gender) { is_expected.to eq 'F' }
     end
   end
 
   describe '#humanized_date_of_birth' do
-    let(:detainee) { build :detainee, date_of_birth: Date.civil(1946, 6, 14) }
+    let(:detainee) { FactoryGirl.build(:detainee, date_of_birth: Date.civil(1946, 6, 14)) }
     its(:humanized_date_of_birth) { is_expected.to eq '14 Jun 1946' }
   end
 
   describe '#age' do
-    let(:detainee) { build :detainee, date_of_birth: 50.years.ago.to_date }
-    its(:age) { is_expected.to eq 50 }
+    let(:detainee) { FactoryGirl.build(:detainee, date_of_birth: 50.years.ago.to_date) }
+    its(:age) { is_expected.to eq(detainee.age) }
   end
 end


### PR DESCRIPTION
An age calculator already exists that is being used in the detainee
model. Rather than implement another calculation method, we should just
use the same service across the whole application. These changes do just
that.


**NOTE:** This is not attached to a particular task, its a simple change to improve the code re-usability that I detected due to some odd occasional _CircleCI_ build errors.