### PR TITLE
Make prison number search case insensitive

### DIFF
--- a/app/models/forms/search.rb
+++ b/app/models/forms/search.rb
@@ -17,7 +17,13 @@ module Forms
       format: { with: PRISON_NUMBER_REGEX }
 
     def detainee
-      @_detainee ||= ::Detainee.find_by(prison_number: prison_number) if valid?
+      @_detainee ||= ::Detainee.find_by(_at[:prison_number].matches(prison_number)) if valid?
+    end
+
+    private
+
+    def _at
+      ::Detainee.arel_table
     end
   end
 end

--- a/spec/forms/search_spec.rb
+++ b/spec/forms/search_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe Forms::Search, type: :form do
           expect(subject.detainee).to be_nil
         end
       end
+
+      context 'when the provided prison name is in a different format than the one recorded for the detainee' do
+        it 'still returns the correct detainee by being case insensitive' do
+          detainee = FactoryGirl.create(:detainee, prison_number: 'A1234BC')
+          subject.validate(prison_number: 'a1234bC')
+          expect(subject.detainee).to eq(detainee)
+        end
+      end
     end
 
     context 'when the form is invalid' do


### PR DESCRIPTION
[Trello #458](https://trello.com/c/uXWRC16y/458-2-as-someone-starting-a-digital-per-i-want-to-be-able-to-search-the-moving-people-safely-application-by-inputting-a-prisoner-num)

Any permutations of a given prison number regardless of the case they're
using (as long as its a valid prison number) should be searchable and
its case ignored, so if the search value differs in case from the one
recorded in the database should not make any difference.