### PR TITLE
Move form date picker

### DIFF
--- a/app/assets/javascripts/no-script.js
+++ b/app/assets/javascripts/no-script.js
@@ -1,10 +1,14 @@
 'use-strict';
 
-$(function () {
-  $('.no-script').each(function() {
-    $(this).removeClass('no-script');
-    $(this).find('input:disabled').each(function() {
-      $(this).prop('disabled', false);
+$(function() {
+  $.fn.removeNoScriptRestrictions = function() {
+    $('.no-script').each(function() {
+      $(this).removeClass('no-script');
+      $(this).find('input:disabled').each(function() {
+        $(this).prop('disabled', false);
+      });
     });
-  });
+  };
+
+  $.fn.removeNoScriptRestrictions();
 });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,6 +34,7 @@
 @import "moving_people_safely/authentication";
 @import "moving_people_safely/buttons";
 @import "moving_people_safely/forms";
+@import "moving_people_safely/date_picker";
 @import "moving_people_safely/home";
 @import "moving_people_safely/labels";
 @import "moving_people_safely/profile";

--- a/app/assets/stylesheets/moving_people_safely/_date_picker.scss
+++ b/app/assets/stylesheets/moving_people_safely/_date_picker.scss
@@ -1,0 +1,69 @@
+.date-picker-wrapper {
+  line-height: 45px;
+
+  span.date-picker-field {
+    position: relative;
+    display: table;
+    border-collapse: separate;
+    float: left;
+
+    input.date-field {
+      position: relative;
+      float: left;
+      display: table-cell;
+      height: 45px;
+      width: 100%;
+      z-index: 2;
+      vertical-align: middle;
+      display: inline-block;
+      margin-bottom: 0;
+      border-right: 0;
+
+      &.no-script {
+        border-right: 2px solid #6f777b;
+      }
+    }
+
+    span.calendar-icon {
+
+      &.no-script {
+        display:none;
+      }
+
+      cursor: pointer;
+      display: table-cell;
+      z-index: 999;
+      border-width: 2px 2px 2px 0;
+      border-style: solid;
+      border-color: #6f777b;
+      vertical-align: middle;
+      width: 45px;
+      background-image: image-url('ic_calendar.png');
+      background-position: center center;
+      background-repeat: no-repeat;
+      background-color: transparent;
+      &:hover {
+        background-color: transparent;
+      }
+    }
+  }
+
+  &.error {
+    span.date-picker-field {
+      input.date-field {
+        &.no-script {
+          border-right: 4px solid #b10e1e;
+        }
+      }
+
+      span.calendar-icon {
+        border-width: 4px 4px 4px 0;
+        border-color: #b10e1e;
+      }
+    }
+  }
+}
+
+.date-radios {
+  margin-top: -25px;
+}

--- a/app/form_builders/mps_form_builder.rb
+++ b/app/form_builders/mps_form_builder.rb
@@ -85,6 +85,26 @@ class MpsFormBuilder < GovukElementsFormBuilder::FormBuilder
     end
   end
 
+  def date_picker_text_field(attribute, options = {})
+    content_tag :div,
+      class: form_group_classes(attribute.to_sym) + ' date-picker-wrapper',
+      id: form_group_id(attribute) do
+        set_field_classes! options
+
+        label_tag = label(attribute, class: 'form-label')
+        add_hint :label, label_tag, attribute
+
+        date_picker_tag = content_tag :span,
+          class: 'date-picker-field input-group date',
+          data: { provide: 'datepicker' } do
+            date_text_field_tag = custom_text_field(attribute, class: 'no-script form-control date-field')
+            calendar_icon_tag = content_tag :span, nil, class: 'no-script calendar-icon input-group-addon'
+            (date_text_field_tag + calendar_icon_tag).html_safe
+          end
+        (label_tag + date_picker_tag).html_safe
+      end
+  end
+
   def search_text_field(attribute, options = {})
     ActionView::Helpers::Tags::TextField.new(
       object.class.name, attribute, self,
@@ -147,6 +167,13 @@ class MpsFormBuilder < GovukElementsFormBuilder::FormBuilder
   end
 
   private
+
+  def custom_text_field(attribute, options = {})
+    ActionView::Helpers::Tags::TextField.new(
+      object.class.name, attribute, self,
+      { value: object.public_send(attribute), class: 'form-control' }.merge(options)
+    ).render
+  end
 
   def style_for_radio_block(attribute, options = {})
     style = 'optional-section-wrapper'

--- a/app/views/moves/_form.html.slim
+++ b/app/views/moves/_form.html.slim
@@ -8,7 +8,17 @@
   = form_for form, url: submit_path, method: method do |f|
     = f.text_field :from
     = f.text_field :to
-    = f.text_field :date
+    = f.date_picker_text_field :date
+    .no-script
+      .form-group.date-radios
+        fieldset.inline
+          = label_tag "move_date_#{Date.today}", 'Today', class: 'block-label' do
+            = radio_button_tag 'move[date]', Date.today.strftime('%d/%m/%Y'), (form.date == Date.today), class: 'radio-date-selector', disabled: true
+            == 'Today'
+          = label_tag "move_date_#{Date.tomorrow}", 'Tomorrow', class: 'block-label' do
+            = radio_button_tag 'move[date]', Date.tomorrow.strftime('%d/%m/%Y'), (form.date == Date.tomorrow), class: 'radio-date-selector', disabled: true
+            == 'Tomorrow'
+
     = f.radio_toggle :not_for_release do
       = f.radio_toggle_with_textarea :not_for_release_reason,
         legend: false,

--- a/spec/javascripts/fixtures/no_script.html
+++ b/spec/javascripts/fixtures/no_script.html
@@ -1,0 +1,24 @@
+<div class="form-group date-picker-wrapper">
+  <label class="form-label" for="move_date">
+    Date of travel
+    <span class="form-hint">DD/MM/YYYY</span>
+  </label>
+  <span class="date-picker-field input-group date" data-provide="datepicker">
+    <input value="08/02/2017" class="no-script form-control no-script-field" type="text" name="move[date]" id="move_date" />
+    <span class="no-script calendar-icon input-group-addon"></span>
+  </span>
+</div>
+<div class="no-script">
+  <div class="form-group wrapped-content">
+    <fieldset class="inline">
+      <label class="block-label" for="move_date_07_02_2017">
+        <input type="radio" name="move[date]" id="move_date_07_02_2017" value="07/02/2017" class="no-script-disabled" disabled="disabled" />
+        Today
+      </label>
+      <label class="block-label" for="move_date_08_02_2017">
+        <input type="radio" name="move[date]" id="move_date_08_02_2017" value="08/02/2017" class="no-script-disabled" disabled="disabled" checked="checked" />
+        Tomorrow
+      </label>
+    </fieldset>
+  </div>
+</div>

--- a/spec/javascripts/no_script_spec.js
+++ b/spec/javascripts/no_script_spec.js
@@ -1,0 +1,35 @@
+describe("No script", function() {
+  beforeEach(function(){
+    loadFixtures("no_script.html");
+  });
+
+  it("hides any content wrapped under a no-script class", function(){
+    expect($('.wrapped-content').is(':visible')).toBe(false);
+  });
+
+  it("does not remove the no-script class from the elements containing it", function(){
+    expect($('.no-script').size()).toBeGreaterThan(0);
+  });
+
+  it("does not enable any disabled elements wrapped under the no-script class", function(){
+    expect($('.no-script-disabled').is(':disabled')).toBe(true);
+  });
+
+  describe("when no script restrictions are removed", function() {
+    beforeEach(function(){
+      $.fn.removeNoScriptRestrictions();
+    });
+
+    it("shows any content wrapped under a no-script class", function(){
+      expect($('.wrapped-content').is(':visible')).toBe(true);
+    });
+
+    it("removes the no-script class from all elements containing it", function(){
+      expect($('.no-script').size()).toBe(0);
+    });
+
+    it("enables any disabled elements wrapped under the no-script class", function(){
+      expect($('.no-script-disabled').is(':disabled')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
[Trello #446](https://trello.com/c/0lB8ZbcC/446-3-as-someone-in-omu-completing-a-digital-per-i-want-to-be-able-to-select-whether-a-detainee-is-moving-today-or-tomorrow)

These changes re-use the work done in the homepage where a date picker and
a radio today/tomorrow were added (it is designed to work with and without javascript).

- Extend MPS form builder to support date picker field. The current
implementation of the text_field in the UK Gov Form Builder is too
restrictive and does not allow to customise the way the fields are
displayed, specially if there's extra DOM elements required to be
displayed. For this reason, I have extended the MPS form builder to
provided that support. The downside of it, is that in case of an upgrade
of the UK Gov Form Builder, the MPS forms might no longer work
appropriately (that being said, that already happened ever since the MPS
form builder was created). So, in summary, any upgrades to the UK Gov
Form Builder might require an update on the MPS form builder.
- Add CSS to the date picker to be used across all forms that follow
the UK Gov default display style.