### PR TITLE
Enforce filling details for fields in risk from others form

### DIFF
--- a/app/models/forms/risk/risk_from_others.rb
+++ b/app/models/forms/risk/risk_from_others.rb
@@ -2,12 +2,8 @@ module Forms
   module Risk
     class RiskFromOthers < Forms::Base
       optional_field :rule_45
-      optional_field :victim_of_abuse, default: 'unknown'
-      property :victim_of_abuse_details, type: StrictString
-      reset attributes: [:victim_of_abuse_details], if_falsey: :victim_of_abuse
-      optional_field :high_profile, default: 'unknown'
-      property :high_profile_details, type: StrictString
-      reset attributes: [:high_profile_details], if_falsey: :high_profile
+      optional_details_field :victim_of_abuse, default: 'unknown'
+      optional_details_field :high_profile, default: 'unknown'
 
       concerning :CsraSection do
         included do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -158,6 +158,8 @@ en:
           unknown: Clear selection
         high_profile_choices:
           unknown: Clear selection
+        high_profile_details: Details of high public interest
+        victim_of_abuse_details: Details of a victim or possible victim of abuse in prison
       risk_to_self:
         acct_status_choices:
           open: ACCT Open

--- a/spec/forms/risk/risk_from_others_spec.rb
+++ b/spec/forms/risk/risk_from_others_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe Forms::Risk::RiskFromOthers, type: :form do
 
   describe '#validate' do
     it { is_expected.to validate_optional_field(:rule_45) }
-    it { is_expected.to validate_optional_field(:victim_of_abuse) }
-    it { is_expected.to be_configured_to_reset([:victim_of_abuse_details]).when(:victim_of_abuse).not_set_to('yes') }
-    it { is_expected.to validate_optional_field(:high_profile) }
-    it { is_expected.to be_configured_to_reset([:high_profile_details]).when(:high_profile).not_set_to('yes') }
+    it { is_expected.to validate_optional_details_field(:victim_of_abuse) }
+    it { is_expected.to be_configured_to_reset(['victim_of_abuse_details']).when(:victim_of_abuse).not_set_to('yes') }
+    it { is_expected.to validate_optional_details_field(:high_profile) }
+    it { is_expected.to be_configured_to_reset(['high_profile_details']).when(:high_profile).not_set_to('yes') }
 
     describe 'csra attribute' do
       it do


### PR DESCRIPTION
[Trello #22](https://trello.com/c/RFQP7MhI/22-2-as-an-osg-completing-the-risk-question-risk-from-others-in-the-digital-per-i-want-to-be-ensured-i-can-provide-details-of-wheth)

- Details for Detainee a victim or possible victim of abuse in prison
need to be filled in if answer for that field was Yes
- Details for Detainee of high public interest need to be filled in if
answer for that field was Yes