### PR TITLE
Update move information present in move printout

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -13,6 +13,41 @@ $is-print: true;
 @import "elements/elements-typography";
 @import "elements/layout";
 
+@media print {
+  html, body {
+    width: 210mm;
+    height: 297mm;
+  }
+
+  .grid-row {
+    display: block;
+  }
+
+  .grid-column {
+    float: left;
+  }
+
+  .header-row {
+    border-bottom: 1px dotted black;
+  }
+
+  .column-one-half {
+    width: 50%;
+  }
+
+  .column-one-quarter {
+    width: (100% / 4);
+  }
+
+  .column-one-third {
+    width: (100% / 3);
+  }
+
+  .column-one-sixth {
+    width: (100% / 6);
+  }
+}
+
 body {
   background-color: white;
 }
@@ -20,8 +55,6 @@ body {
 main {
   text-align: left;
   margin: 0;
-  height: 29.7cm;
-  width: 21cm;
   position: relative;
   @extend .font-xsmall;
 }
@@ -44,6 +77,10 @@ table {
   &.padded {
     padding-top: 10px;
     vertical-align: top;
+  }
+
+  &.padded-bottom {
+    padding-bottom: 10px;
   }
 }
 
@@ -86,6 +123,18 @@ table {
     font-weight: bold;
     @extend .font-small;
   }
+}
+
+.top-dotted {
+  border-top: 1px dotted black;
+}
+
+.min-heighted {
+  min-height: 100px;
+}
+
+.footer {
+  page-break-after: always;
 }
 
 .indicators {
@@ -248,3 +297,4 @@ table.about {
     }
   }
 }
+

--- a/app/views/moves/print/show.html.slim
+++ b/app/views/moves/print/show.html.slim
@@ -77,17 +77,18 @@ html
                 = image_tag "photo_unavailable.png", size: '128x180'
       div.grid.move
         div.grid-row.header-row.small = 'Move details'
-        div.grid-row.padded
+        div.grid-row.padded.padded-bottom
           div.grid-column.column-one-third
             div.title Date of travel
-            div.strong-text = move.date
+            div.strong-text = move.date.to_s(:humanized)
           div.grid-column.column-one-third
             div.title From
             div.strong-text = move.from
           div.grid-column.column-one-third
             div.title To
             div.strong-text = move.to
-      table.about
+        div.grid-row.top-dotted.min-heighted
+      table.about.footer
         tr
           th About this Person Escort Record
         tr

--- a/spec/features/pages/move_print.rb
+++ b/spec/features/pages/move_print.rb
@@ -16,6 +16,14 @@ module Page
       end
     end
 
+    def assert_move_details(move)
+      within('.move') do
+        assert_content(move.from)
+        assert_content(move.to)
+        assert_content(move.date.strftime('%d %b %Y'))
+      end
+    end
+
     private
 
     def assert_content(content, options = {})

--- a/spec/features/printing_spec.rb
+++ b/spec/features/printing_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature 'printing a PER', type: :feature do
     visit detainee_path(detainee)
     print_per
     move_print_page.assert_detainee_details(detainee)
+    move_print_page.assert_move_details(move)
   end
 
   def print_per


### PR DESCRIPTION
[Trello #14](https://trello.com/c/uVw8q4on/14-2-as-someone-printing-out-a-completed-per-i-want-to-see-a-summary-of-the-move-details-planned-for-the-detainee)

These changes include:
- Update information displayed in the move printout related with the
move according to new requirements.
- Add new assertions to the printing feature test to cover the new
changes in the printout

**NOTE:** It appears Chrome print preview does not respect the style
specified in the print.scss. After some investigation without much
success, I've added some specific CSS for media print which seems to
solve this issue. Even though it turns out to repeat some of the CSS
styles, I will leave it as is until a better DRY solution is found.