### PR TITLE
Enforce filling not for release and establishments fields in move form

### DIFF
--- a/app/models/forms/base.rb
+++ b/app/models/forms/base.rb
@@ -7,6 +7,7 @@ module Forms
     TOGGLE_YES = 'yes'
     TOGGLE_NO = 'no'
     DEFAULT_CHOICE = 'unknown'
+    TOGGLE_STRICT_CHOICES = [TOGGLE_YES, TOGGLE_NO].freeze
     TOGGLE_CHOICES = [TOGGLE_YES, TOGGLE_NO, DEFAULT_CHOICE].freeze
 
     StrictString = Forms::StrictString
@@ -186,6 +187,10 @@ module Forms
 
     def toggle_choices
       TOGGLE_CHOICES
+    end
+
+    def toggle_strict_choices
+      TOGGLE_STRICT_CHOICES
     end
 
     def toggle_field

--- a/app/views/moves/_form.html.slim
+++ b/app/views/moves/_form.html.slim
@@ -19,7 +19,8 @@
             = radio_button_tag 'move[date]', Date.tomorrow.strftime('%d/%m/%Y'), (form.date == Date.tomorrow), class: 'radio-date-selector', disabled: true
             == 'Tomorrow'
 
-    = f.radio_toggle :not_for_release do
+    = f.radio_toggle :not_for_release,
+      choices: f.object.toggle_strict_choices do
       = f.radio_toggle_with_textarea :not_for_release_reason,
         legend: false,
         choices: f.object.not_for_release_reasons,
@@ -27,7 +28,8 @@
         data: { 'toggle-field' => f.object.not_for_release_reason_with_details }
 
     .multiple
-      = f.radio_toggle :has_destinations do
+      = f.radio_toggle :has_destinations,
+        choices: f.object.toggle_strict_choices do
         - if f.object.has_destinations_on?
           #establishments
           #error_move_destinations

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,6 +122,7 @@ en:
         from: From
         to: To
         date: Date of travel
+        has_destinations: Are there establishments the detainee must or must not be sent
         has_destinations_choices:
           unknown: Clear selection
         destinations:
@@ -511,6 +512,8 @@ en:
             has_past_offences:
               inclusion: 'Past offences: You must select an option'
   errors:
+    messages:
+      minimum_collection_size: At least one item needs to be provided
     attributes:
       base:
         minimum_current_offence: 'At least one current offence needs to be provided'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -507,6 +507,12 @@ en:
   activemodel:
     errors:
       models:
+        move:
+          attributes:
+            has_destinations:
+              inclusion: question must be answered
+            not_for_release:
+              inclusion: question must be answered
         offences:
           attributes:
             has_past_offences:

--- a/spec/factories/move_factory.rb
+++ b/spec/factories/move_factory.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
     from { FixtureData.prison }
     to { FixtureData.county_court }
     date { Date.today }
+    not_for_release 'no'
     has_destinations 'no'
 
     association :move_workflow, :incomplete, strategy: :build

--- a/spec/forms/move_spec.rb
+++ b/spec/forms/move_spec.rb
@@ -66,6 +66,14 @@ RSpec.describe Forms::Move, type: :form do
     context "for not for release" do
       it { is_expected.to validate_optional_field(:not_for_release, inclusion: { in: %w(yes no) }) }
 
+      shared_examples_for 'validation error on not for release value' do
+        it 'returns an inclusion validation error' do
+          expect(form).not_to be_valid
+          expect(form.errors.keys).to include(:not_for_release)
+          expect(form.errors[:not_for_release]).to match_array(['question must be answered'])
+        end
+      end
+
       shared_examples_for 'no validation on not for release reason' do
         it 'does not validate the reason (and details) for release' do
           form.valid?
@@ -81,6 +89,7 @@ RSpec.describe Forms::Move, type: :form do
           form.not_for_release_reason_details = nil
         end
 
+        include_examples 'validation error on not for release value'
         include_examples 'no validation on not for release reason'
 
         context 'and not for release reason is set to other' do
@@ -88,6 +97,7 @@ RSpec.describe Forms::Move, type: :form do
             form.not_for_release_reason = 'other'
           end
 
+          include_examples 'validation error on not for release value'
           include_examples 'no validation on not for release reason'
         end
       end
@@ -219,7 +229,7 @@ RSpec.describe Forms::Move, type: :form do
         specify {
           expect(form).not_to be_valid
           expect(form.errors.keys).to include(:has_destinations)
-          expect(form.errors[:has_destinations]).to match_array([I18n.t(:inclusion, scope: 'errors.messages')])
+          expect(form.errors[:has_destinations]).to match_array(['question must be answered'])
         }
 
       end

--- a/spec/forms/move_spec.rb
+++ b/spec/forms/move_spec.rb
@@ -31,13 +31,9 @@ RSpec.describe Forms::Move, type: :form do
 
   describe 'defaults' do
     its(:from) { is_expected.to eq 'HMP Bedford' }
-    its(:has_destinations) { is_expected.to eq 'unknown' }
   end
 
   describe '#validate' do
-    it { is_expected.to validate_prepopulated_collection(:destinations, subform_class: Forms::Moves::Destination) }
-    it { is_expected.to validate_optional_field(:has_destinations) }
-
     describe 'nilifies empty strings' do
       %w[from to].each do |attribute|
         it { is_expected.to validate_strict_string(attribute) }
@@ -68,7 +64,7 @@ RSpec.describe Forms::Move, type: :form do
     end
 
     context "for not for release" do
-      it { is_expected.to validate_optional_field(:not_for_release) }
+      it { is_expected.to validate_optional_field(:not_for_release, inclusion: { in: %w(yes no) }) }
 
       shared_examples_for 'no validation on not for release reason' do
         it 'does not validate the reason (and details) for release' do
@@ -206,7 +202,59 @@ RSpec.describe Forms::Move, type: :form do
         it 'sets a descriptive error on date' do
           params[:date] = '01/01/2015'
           form.validate(params)
-          expect(form.errors[:date]).to include 'must not be in the past.'
+          expect(form.errors[:date]).to include 'must not be in the past'
+        end
+      end
+    end
+
+    context 'has destinations' do
+      it { is_expected.to validate_prepopulated_collection(:destinations, subform_class: Forms::Moves::Destination) }
+      it { is_expected.to validate_optional_field(:has_destinations, inclusion: { in: %w(yes no) }) }
+
+      context 'when has destinations is blank' do
+        before do
+          form.has_destinations = ''
+        end
+
+        specify {
+          expect(form).not_to be_valid
+          expect(form.errors.keys).to include(:has_destinations)
+          expect(form.errors[:has_destinations]).to match_array([I18n.t(:inclusion, scope: 'errors.messages')])
+        }
+
+      end
+
+      shared_examples_for 'no inclusion validation error' do
+        specify {
+          form.valid?
+          expect(form.errors.keys).not_to include(:has_destinations)
+        }
+      end
+
+      context 'when has destinations is set to "no"' do
+        before { form.has_destinations = 'no' }
+        include_examples 'no inclusion validation error'
+
+        context 'and no destinations are provided' do
+          before { form.destinations = [] }
+
+          it 'does not require to validate destinations' do
+            expect(form.errors.keys).not_to include(:destinations)
+          end
+        end
+      end
+
+      context 'when has destinations is set to "yes"' do
+        before { form.has_destinations = 'yes' }
+        include_examples 'no inclusion validation error'
+
+        context 'and no destinations are provided' do
+          before { form.destinations = [] }
+          specify {
+            expect(form).not_to be_valid
+            expect(form.errors.keys).to include(:destinations)
+            expect(form.errors[:destinations]).to match_array([I18n.t(:minimum_collection_size, scope: 'errors.messages')])
+          }
         end
       end
     end


### PR DESCRIPTION
[Trello #23](https://trello.com/c/uomczpTE/23-2-as-someone-in-omu-completing-a-digital-per-i-want-to-be-able-to-ensure-i-have-captured-and-saved-all-the-relevant-information-)

- Answers for 'Not for release' and 'Are there establishments the
detainee must or must not be sent' are not optional, so they need to be
provided, otherwise the form will display an error.
- Minor improvements of the date validator for the 'date' field