### PR TITLE
Add new move must/must not return destinations section to printout

### DIFF
--- a/app/assets/stylesheets/print-ie8.scss
+++ b/app/assets/stylesheets/print-ie8.scss
@@ -6,3 +6,8 @@ $ie-version: 8;
 th {
   text-align: left !important;
 }
+
+.watermark {
+  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
+  font-size: 48px;
+}

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -19,6 +19,10 @@ $is-print: true;
     height: 297mm;
   }
 
+  .inner-page-header {
+    display: table-header-group;
+  }
+
   .grid-row {
     display: block;
   }
@@ -46,6 +50,10 @@ $is-print: true;
   .column-one-sixth {
     width: (100% / 6);
   }
+
+  .section-table {
+    page-break-inside: avoid;
+  }
 }
 
 body {
@@ -65,6 +73,10 @@ table {
 
 .strong-text {
   font-weight: bold;
+}
+
+.title {
+  font-weight: lighter;
 }
 
 .grid {
@@ -87,10 +99,6 @@ table {
 .grid-column {
   padding: 0;
 
-  .title {
-    font-weight: lighter;
-  }
-
   .image {
     text-align: right;
 
@@ -111,6 +119,29 @@ table {
   width: (100% / 6);
 }
 
+.column-30-percent {
+  width: 30%;
+}
+
+.column-70-percent {
+  width: 70%;
+}
+
+.section {
+  position: relative;
+  min-height: 50px;
+}
+
+.section-table {
+  border-top: 2px solid black;
+  border-collapse: collapse;
+
+  td {
+    font-weight: lighter;
+    padding: 0.3em 0;
+  }
+}
+
 .header-row {
   border-top: 2px solid black;
   border-bottom: 1px dotted black;
@@ -129,8 +160,23 @@ table {
   border-top: 1px dotted black;
 }
 
+.top-dotted {
+  border-bottom: 1px dotted black;
+}
+
 .min-heighted {
   min-height: 100px;
+}
+
+.watermark {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  opacity: 0.5;
+  z-index: 99;
+  color: grey;
+  @extend .font-xlarge;
+  font-weight: bold;
 }
 
 .footer {

--- a/app/controllers/moves/print_controller.rb
+++ b/app/controllers/moves/print_controller.rb
@@ -5,7 +5,7 @@ module Moves
     def show
       error_redirect && return unless printable_move?
       move.move_workflow.issued! unless move.issued?
-      render :show, locals: { detainee: Print::DetaineePresenter.new(detainee), move: move }
+      render :show, locals: { detainee: detainee_presenter, move: move_presenter }
     end
 
     private
@@ -24,6 +24,14 @@ module Moves
 
     def error_redirect
       redirect_back(fallback_location: root_path, alert: t('alerts.move.print.unauthorized'))
+    end
+
+    def detainee_presenter
+      @detainee_presenter ||= Print::DetaineePresenter.new(detainee)
+    end
+
+    def move_presenter
+      @move_presenter ||= Print::MovePresenter.new(move)
     end
   end
 end

--- a/app/presenters/print/move_presenter.rb
+++ b/app/presenters/print/move_presenter.rb
@@ -1,0 +1,55 @@
+module Print
+  class MovePresenter < SimpleDelegator
+    include ActionView::Helpers::TagHelper
+    include ActionView::Helpers::TranslationHelper
+
+    def date
+      model.date.to_s(:humanized)
+    end
+
+    def must_return_to_label
+      label_for_destinations(:must_return_to, destinations.must_return_to)
+    end
+
+    def must_not_return_to_label
+      label_for_destinations(:must_not_return_to, destinations.must_not_return_to)
+    end
+
+    def must_return_to
+      format_destinations(destinations.must_return_to)
+    end
+
+    def must_not_return_to
+      format_destinations(destinations.must_not_return_to)
+    end
+
+    private
+
+    def label_for_destinations(attr, destinations)
+      label = t(attr, scope: [:print, :label, :move])
+      return title_label(label) if destinations.empty?
+      strong_title_label(label)
+    end
+
+    def strong_title_label(label)
+      content_tag(:div, label, class: 'strong-text')
+    end
+
+    def title_label(label)
+      content_tag(:div, label, class: 'title')
+    end
+
+    def format_destinations(destinations)
+      return 'None' if destinations.empty?
+      safe_join(destinations.map do |destination|
+        array = [destination.establishment]
+        array << ": #{destination.reasons}" if destination.reasons.present?
+        strong_title_label(array.join(''))
+      end)
+    end
+
+    def model
+      __getobj__
+    end
+  end
+end

--- a/app/views/moves/print/show.html.slim
+++ b/app/views/moves/print/show.html.slim
@@ -80,7 +80,7 @@ html
         div.grid-row.padded.padded-bottom
           div.grid-column.column-one-third
             div.title Date of travel
-            div.strong-text = move.date.to_s(:humanized)
+            div.strong-text = move.date
           div.grid-column.column-one-third
             div.title From
             div.strong-text = move.from
@@ -96,4 +96,48 @@ html
             div.first This person escort record was printed from the Moving People Safely web site.
             div To find out more about the Person Escort Record go to exmaple.com
             div If you have feedback or suggestions please email feedback@example.com
-
+    br
+    main.inner-page
+      table
+        thead.inner-page-header
+          tr
+            td
+              span#detainee-identifier.strong-text => detainee.identifier
+              = detainee.forenames
+        tbody
+          tr
+            td
+              div#risk-section.section
+                span.watermark = 'Risk'
+                table#risk-table.section-table
+                  tr
+                    td
+          tr
+            td
+              div#healthcare-section.section
+                span.watermark = 'Healthcare'
+                table#healthcare-table.section-table
+                  tr
+                    td
+          tr
+            td
+              div#offences-section.section
+                span.watermark = 'Offences'
+                table#offences-table.section-table
+                  tr
+                    td
+          tr
+            td
+              div#move-returns-section.section
+                span.watermark = 'Move'
+                table#move-returns-table.section-table
+                  tr#move-must-return-to-destinations
+                    td.column-30-percent
+                      = move.must_return_to_label
+                    td.column-70-percent
+                      = move.must_return_to
+                  tr#move-must-not-return-to-destinations.top-dotted.bottom-dotted
+                    td.column-30-percent
+                      = move.must_not_return_to_label
+                    td.column-70-percent
+                      = move.must_not_return_to

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -491,6 +491,11 @@ en:
         violence_to_general_public: Violent to general public
         violence_to_other_detainees: Violent to other detainees
         violence_to_staff: Violent to staff
+  print:
+    label:
+      move:
+        must_return_to: Must return to
+        must_not_return_to: Must NOT return to
   profile:
     alerts:
       acct_status:

--- a/spec/factories/destination_factory.rb
+++ b/spec/factories/destination_factory.rb
@@ -5,5 +5,13 @@ FactoryGirl.define do
     establishment { FixtureData.prison }
     must_return { %w[ must_return must_not_return ].sample }
     reasons { Faker::Lorem.paragraph }
+
+    trait :must_return do
+      must_return 'must_return'
+    end
+
+    trait :must_not_return do
+      must_return 'must_not_return'
+    end
   end
 end

--- a/spec/features/pages/move_print.rb
+++ b/spec/features/pages/move_print.rb
@@ -22,9 +22,38 @@ module Page
         assert_content(move.to)
         assert_content(move.date.strftime('%d %b %Y'))
       end
+
+      within('#move-returns-section') do
+        assert_must_return_to_destinations(move)
+        assert_must_not_return_to_destinations(move)
+      end
     end
 
     private
+
+    def assert_must_return_to_destinations(move)
+      destinations = move.destinations.must_return_to
+      within('#move-must-return-to-destinations') do
+        assert_destinations(destinations)
+      end
+    end
+
+    def assert_must_not_return_to_destinations(move)
+      destinations = move.destinations.must_not_return_to
+      within('#move-must-not-return-to-destinations') do
+        assert_destinations(destinations)
+      end
+    end
+
+    def assert_destinations(destinations)
+      if destinations.empty?
+        assert_content('None')
+      else
+        destinations.each do |destination|
+          assert_content(destination.establishment)
+        end
+      end
+    end
 
     def assert_content(content, options = {})
       within_container = options[:within]

--- a/spec/features/printing_spec.rb
+++ b/spec/features/printing_spec.rb
@@ -3,7 +3,7 @@ require 'feature_helper'
 RSpec.feature 'printing a PER', type: :feature do
   scenario 'user prints a completed PER' do
     detainee = FactoryGirl.create(:detainee)
-    move = FactoryGirl.create(:move, :confirmed, detainee: detainee)
+    move = FactoryGirl.create(:move, :confirmed, :with_destinations, detainee: detainee)
 
     login
     visit detainee_path(detainee)

--- a/spec/presenters/print/move_presenter_spec.rb
+++ b/spec/presenters/print/move_presenter_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+RSpec.describe Print::MovePresenter, type: :presenter do
+  let(:options) { {} }
+  let(:move) { create(:move, options) }
+
+  subject(:presenter) { described_class.new(move) }
+
+  describe '#date' do
+    let(:date) { 3.days.from_now }
+    let(:options) { { date: date } }
+
+    it 'returns the humanized version of the date' do
+      expect(presenter.date).to eq(date.strftime('%d %b %Y'))
+    end
+  end
+
+  describe '#must_return_to_label' do
+    context 'when the move has no destinations the detainee must return to' do
+      let(:options) { { destinations: [] } }
+
+      it 'returns a non-hightlighted version of the label' do
+        expect(presenter.must_return_to_label).to eq('<div class="title">Must return to</div>')
+      end
+    end
+
+    context 'when the move has destinations the detainee must return to' do
+      let(:must_return_to_destinations) { build_list(:destination, 2, :must_return) }
+      let(:options) { { destinations: must_return_to_destinations } }
+
+      it 'returns an hightlighted version of the label' do
+        expect(presenter.must_return_to_label).to eq('<div class="strong-text">Must return to</div>')
+      end
+    end
+  end
+
+  describe '#must_not_return_to_label' do
+    context 'when the move has no destinations the detainee must return to' do
+      let(:options) { { destinations: [] } }
+
+      it 'returns a non-hightlighted version of the label' do
+        expect(presenter.must_not_return_to_label).to eq('<div class="title">Must NOT return to</div>')
+      end
+    end
+
+    context 'when the move has destinations the detainee must return to' do
+      let(:must_not_return_to_destinations) { build_list(:destination, 2, :must_not_return) }
+      let(:options) { { destinations: must_not_return_to_destinations } }
+
+      it 'returns an hightlighted version of the label' do
+        expect(presenter.must_not_return_to_label).to eq('<div class="strong-text">Must NOT return to</div>')
+      end
+    end
+  end
+
+  describe '#must_return_to' do
+    context 'when the move has no destinations the detainee must return to' do
+      let(:options) { { destinations: [] } }
+
+      it 'returns None' do
+        expect(presenter.must_return_to).to eq('None')
+      end
+    end
+
+    context 'when the move has destinations the detainee must return to' do
+      let(:must_return_to_destinations) { build_list(:destination, 2, :must_return) }
+      let(:options) { { destinations: must_return_to_destinations } }
+
+      it 'returns the list of destinations' do
+        must_return_to_destinations.each do |destination|
+          expect(presenter.must_return_to).to include(%[<div class="strong-text">#{destination.establishment}: #{destination.reasons}</div>])
+        end
+      end
+    end
+  end
+
+  describe '#must_not_return_to' do
+    context 'when the move has no destinations the detainee must return to' do
+      let(:options) { { destinations: [] } }
+
+      it 'returns None' do
+        expect(presenter.must_not_return_to).to eq('None')
+      end
+    end
+
+    context 'when the move has destinations the detainee must return to' do
+      let(:must_not_return_to_destinations) { build_list(:destination, 2, :must_not_return) }
+      let(:options) { { destinations: must_not_return_to_destinations } }
+
+      it 'returns the list of destinations' do
+        must_not_return_to_destinations.each do |destination|
+          expect(presenter.must_not_return_to).to include(%[<div class="strong-text">#{destination.establishment}: #{destination.reasons}</div>])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello #28](https://trello.com/c/1K4Rtqsz/28-2-as-someone-printing-out-a-digital-per-i-want-to-see-whether-a-detainee-must-return-to-the-prison-or-must-not-return-to-the-pri)

Also, includes the following improvements:

- Adds a new move presenter to encapsulate all the presentation logic
for the move in the print layout
- Moves some of the wording in the print layout to the locales file
- Add test coverage for the new components of the print layout