### PR TITLE
Display missing text on summary if unanswered

### DIFF
--- a/app/presenters/summary/assessment_section_presenter.rb
+++ b/app/presenters/summary/assessment_section_presenter.rb
@@ -56,7 +56,8 @@ module Summary
     end
 
     def question_condition_unanswered?(attribute)
-      public_send(question_condition(attribute)) == 'unknown'
+      answer_state = public_send(question_condition(attribute))
+      answer_state.nil? || answer_state == 'unknown'
     end
 
     def question_condition_answered_yes?(attribute)

--- a/spec/support/shared_examples/assessment_section_presenter_shared_examples.rb
+++ b/spec/support/shared_examples/assessment_section_presenter_shared_examples.rb
@@ -96,6 +96,16 @@ RSpec.shared_examples_for 'assessment section presenter' do
         allow(section).to receive(:question_condition).and_return(:conditional_question)
       end
 
+      context 'when the conditional is yet to be answered' do
+        let(:answer) { nil }
+        let(:conditional_answer) { nil }
+
+        it 'returns missing text as html' do
+          expect(presenter.answer_for(:question)).
+            to eq "<span class='text-error'>Missing</span>"
+        end
+      end
+
       context 'and the conditional question is answered no' do
         let(:conditional_answer) { 'no' }
 


### PR DESCRIPTION
Prior to this fix it was possible to visit a summary page and see “No”’s
for questions that do not have their top level question answered.