### PR TITLE
Print out risk section

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -51,7 +51,7 @@ $is-print: true;
     width: (100% / 6);
   }
 
-  .section-table {
+  .section-sub-table {
     page-break-inside: avoid;
   }
 }
@@ -119,8 +119,16 @@ table {
   width: (100% / 6);
 }
 
+.column-20-percent {
+  width: 20%;
+}
+
 .column-30-percent {
   width: 30%;
+}
+
+.column-50-percent {
+  width: 50%;
 }
 
 .column-70-percent {
@@ -139,7 +147,17 @@ table {
   td {
     font-weight: lighter;
     padding: 0.3em 0;
+    vertical-align: top;
+    text-align: left;
   }
+
+  td.indented {
+    padding-left: 5px;
+  }
+}
+
+.section-sub-table {
+  border-collapse: collapse;
 }
 
 .header-row {
@@ -160,7 +178,7 @@ table {
   border-top: 1px dotted black;
 }
 
-.top-dotted {
+.bottom-dotted {
   border-bottom: 1px dotted black;
 }
 

--- a/app/models/sections/base_section.rb
+++ b/app/models/sections/base_section.rb
@@ -1,4 +1,10 @@
 class BaseSection
+  MethodNotImplementedError = Class.new(StandardError)
+
+  def name
+    raise MethodNotImplementedError
+  end
+
   def question_is_conditional?(question)
     !question_condition(question).nil?
   end

--- a/app/models/sections/risk_assessment/risk_to_self_section.rb
+++ b/app/models/sections/risk_assessment/risk_to_self_section.rb
@@ -17,7 +17,7 @@ module RiskAssessment
 
     def relevant_answers
       {
-        acct_status: :all
+        acct_status: %w[open post_closure closed_in_last_6_months]
       }
     end
   end

--- a/app/presenters/print/assessment_question_presenter.rb
+++ b/app/presenters/print/assessment_question_presenter.rb
@@ -1,0 +1,122 @@
+module Print
+  class AssessmentQuestionPresenter < SimpleDelegator
+    include Print::Helpers
+
+    delegate :question_is_conditional?, :question_condition, to: :section
+    delegate :question_has_details?, :question_details, to: :section
+    delegate :relevant_answer?, to: :section
+
+    attr_reader :name
+
+    def initialize(question, assessment, section)
+      super(assessment)
+      @name = question
+      @section = section
+    end
+
+    def label
+      content = t("summary.section.questions.#{section_name}.#{name}")
+      if answer_is_relevant?
+        strong_title_label(content)
+      else
+        title_label(content)
+      end
+    end
+
+    def answer_is_relevant?
+      return default_relevance unless question_is_conditional?(name)
+      question_condition_answered_yes? && checkbox_checked?
+    end
+
+    def answer
+      return default_answer unless question_is_conditional?(name)
+      if question_condition_answered_yes? && checkbox_checked?
+        highlighted_content('Yes')
+      else
+        'No'
+      end
+    end
+
+    def details
+      return default_details unless question_has_details?(name)
+      question_details(name).each_with_object([]) do |detail_attr, details|
+        if detail_attr.is_a?(Hash)
+          details << complex_detail_context(detail_attr)
+        elsif public_send(detail_attr).present?
+          details << detail_content(detail_attr)
+        end
+      end.join('. ')
+    end
+
+    private
+
+    attr_reader :section
+
+    def default_relevance
+      value = public_send(name)
+      case value
+      when 'no', false
+        false
+      when 'yes', true
+        true
+      else
+        relevant_answer?(name, value)
+      end
+    end
+
+    def default_answer
+      value = public_send(name)
+      case value
+      when 'no', false
+        'No'
+      when 'yes', true
+        highlighted_content('Yes')
+      else
+        answer = answer_value(value)
+        relevant_answer?(name, value) ? highlighted_content(answer) : answer
+      end
+    end
+
+    def default_details
+      public_send("#{name}_details") if respond_to?("#{name}_details")
+    end
+
+    def question_condition_answered_yes?
+      public_send(question_condition(name)) == 'yes'
+    end
+
+    def checkbox_checked?
+      public_send(name) == true
+    end
+
+    def detail_content(attribute)
+      [detail_label(attribute), answer_value(public_send(attribute))].join('')
+    end
+
+    def complex_detail_context(hash)
+      public_send(hash[:collection]).each_with_object([]) do |item, details|
+        details << hash[:fields].map do |field|
+          [
+            detail_label("#{hash[:collection]}_collection.#{field}"),
+            answer_value(item.send(field))
+          ].join(' ')
+        end.join(' | ')
+      end.join('</br>')
+    end
+
+    def detail_label(attribute)
+      I18n.t!(attribute, scope: [:summary, :section, :questions, section_name])
+    rescue
+      nil
+    end
+
+    def answer_value(value)
+      default_value = value.respond_to?(:humanize) ? value.humanize : value
+      I18n.t(value, scope: [:summary, :section, :answers, section_name], default: default_value)
+    end
+
+    def section_name
+      section.name
+    end
+  end
+end

--- a/app/presenters/print/assessment_section_presenter.rb
+++ b/app/presenters/print/assessment_section_presenter.rb
@@ -1,0 +1,43 @@
+module Print
+  class AssessmentSectionPresenter < SimpleDelegator
+    include Print::Helpers
+
+    attr_reader :section_name
+    delegate :name, to: :section
+    delegate :subsections, :has_subsections?, :questions_for_subsection, to: :section
+
+    def self.for(section, assessment)
+      new(assessment, section: section)
+    end
+
+    def initialize(object, options = {})
+      super(object)
+      @section_name = options.fetch(:section)
+    end
+
+    def questions
+      @questions ||= section.questions.map do |question|
+        Print::AssessmentQuestionPresenter.new(question, assessment, section)
+      end
+    end
+
+    def relevant
+      relevant? ? highlighted_content('Yes') : 'No'
+    end
+
+    def label
+      content = t("summary.section.titles.#{name}")
+      relevant? ? highlighted_content(content) : content
+    end
+
+    private
+
+    def relevant?
+      questions.any?(&:answer_is_relevant?)
+    end
+
+    def assessment
+      __getobj__
+    end
+  end
+end

--- a/app/presenters/print/assessment_subsection_presenter.rb
+++ b/app/presenters/print/assessment_subsection_presenter.rb
@@ -1,0 +1,22 @@
+module Print
+  class AssessmentSubsectionPresenter < AssessmentSectionPresenter
+    attr_reader :section_name, :subsection_name
+    alias name subsection_name
+
+    def self.for(subsection, section, assessment)
+      new(assessment, section: section, subsection: subsection)
+    end
+
+    def initialize(object, options = {})
+      super(object, section: options.fetch(:section))
+      @section_name = options.fetch(:section)
+      @subsection_name = options.fetch(:subsection)
+    end
+
+    def questions
+      @questions ||= questions_for_subsection(subsection_name).map do |question|
+        Print::AssessmentQuestionPresenter.new(question, assessment, section)
+      end
+    end
+  end
+end

--- a/app/presenters/print/helpers.rb
+++ b/app/presenters/print/helpers.rb
@@ -1,0 +1,15 @@
+module Print
+  module Helpers
+    include ActionView::Helpers::TagHelper
+    include ActionView::Helpers::TranslationHelper
+
+    def highlighted_content(content)
+      content_tag(:div, content, class: 'strong-text')
+    end
+    alias strong_title_label highlighted_content
+
+    def title_label(label)
+      content_tag(:div, label, class: 'title')
+    end
+  end
+end

--- a/app/presenters/print/move_presenter.rb
+++ b/app/presenters/print/move_presenter.rb
@@ -1,7 +1,6 @@
 module Print
   class MovePresenter < SimpleDelegator
-    include ActionView::Helpers::TagHelper
-    include ActionView::Helpers::TranslationHelper
+    include Print::Helpers
 
     def date
       model.date.to_s(:humanized)
@@ -29,14 +28,6 @@ module Print
       label = t(attr, scope: [:print, :label, :move])
       return title_label(label) if destinations.empty?
       strong_title_label(label)
-    end
-
-    def strong_title_label(label)
-      content_tag(:div, label, class: 'strong-text')
-    end
-
-    def title_label(label)
-      content_tag(:div, label, class: 'title')
     end
 
     def format_destinations(destinations)

--- a/app/presenters/print/risk_presenter.rb
+++ b/app/presenters/print/risk_presenter.rb
@@ -1,0 +1,9 @@
+module Print
+  class RiskPresenter < AssessmentSectionPresenter
+    private
+
+    def section
+      @section ||= RiskAssessment.section_for(section_name)
+    end
+  end
+end

--- a/app/presenters/print/risk_subsection_presenter.rb
+++ b/app/presenters/print/risk_subsection_presenter.rb
@@ -1,0 +1,9 @@
+module Print
+  class RiskSubsectionPresenter < AssessmentSubsectionPresenter
+    private
+
+    def section
+      @section ||= RiskAssessment.section_for(section_name)
+    end
+  end
+end

--- a/app/views/moves/print/_section.html.slim
+++ b/app/views/moves/print/_section.html.slim
@@ -1,0 +1,23 @@
+- if section.has_subsections?
+  - section.subsections.each do |subsection|
+    = render partial: 'moves/print/subsection',
+      locals: { subsection: Print::RiskSubsectionPresenter.for(subsection, section.name, assessment),
+                section: section,
+                assessment: assessment }
+- else
+  tr.top-dotted
+   td.column-30-percent
+     == section.label
+   td.column-20-percent
+     == section.relevant
+   td.column-50-percent
+     == "&nbsp;".html_safe
+  - section.questions.each do |question|
+    - if question.answer_is_relevant?
+      tr.top-dotted
+       td.indented.column-30-percent
+         == question.label
+       td.column-20-percent
+         == question.answer
+       td.column-50-percent
+         == question.details

--- a/app/views/moves/print/_subsection.html.slim
+++ b/app/views/moves/print/_subsection.html.slim
@@ -1,0 +1,16 @@
+tr.top-dotted
+ td.column-30-percent
+   == subsection.label
+ td.column-20-percent
+   == subsection.relevant
+ td.column-50-percent
+   == "&nbsp;".html_safe
+- subsection.questions.each do |question|
+  - if question.answer_is_relevant?
+    tr.top-dotted
+     td.indented.column-30-percent
+       == question.label
+     td.column-20-percent
+       == question.answer
+     td.column-50-percent
+       == question.details

--- a/app/views/moves/print/show.html.slim
+++ b/app/views/moves/print/show.html.slim
@@ -110,8 +110,10 @@ html
               div#risk-section.section
                 span.watermark = 'Risk'
                 table#risk-table.section-table
-                  tr
-                    td
+                  - RiskWorkflow.sections.each do |section|
+                    = render partial: 'moves/print/section',
+                      locals: { section: Print::RiskPresenter.for(section, risk),
+                                assessment: risk }
           tr
             td
               div#healthcare-section.section

--- a/spec/features/printing_spec.rb
+++ b/spec/features/printing_spec.rb
@@ -1,8 +1,34 @@
 require 'feature_helper'
 
 RSpec.feature 'printing a PER', type: :feature do
-  scenario 'user prints a completed PER' do
-    detainee = FactoryGirl.create(:detainee)
+  scenario 'user prints a completed PER with all answers as no' do
+    risk = create(:risk, {
+      acct_status: 'none',
+      rule_45: 'no',
+      csra: 'standard',
+      victim_of_abuse: 'no',
+      high_profile: 'no',
+      violence_due_to_discrimination: 'no',
+      violence_to_staff: 'no',
+      violence_to_other_detainees: 'no',
+      violence_to_general_public: 'no',
+      harassment: 'no',
+      hostage_taker: 'no',
+      intimidation: 'no',
+      sex_offence: 'no',
+      current_e_risk: 'no',
+      previous_escape_attempts: 'no',
+      category_a: 'no',
+      escape_pack: 'no',
+      escort_risk_assessment: 'no',
+      substance_supply: 'no',
+      conceals_weapons: 'no',
+      conceals_drugs: 'no',
+      conceals_mobile_phone_or_other_items: 'no',
+      arson: 'no',
+      damage_to_property: 'no'
+    })
+    detainee = FactoryGirl.create(:detainee, risk: risk)
     move = FactoryGirl.create(:move, :confirmed, :with_destinations, detainee: detainee)
 
     login
@@ -10,6 +36,190 @@ RSpec.feature 'printing a PER', type: :feature do
     print_per
     move_print_page.assert_detainee_details(detainee)
     move_print_page.assert_move_details(move)
+
+    within('#risk-table') do
+      expect(page).to have_text('Risk to selfNo').
+        and have_text("Risk from othersNo").
+        and have_text("Risk to others - discriminationNo").
+        and have_text("Violent to staffNo").
+        and have_text("Violent to other detaineesNo").
+        and have_text("Violent to general publicNo").
+        and have_text("Risk to others - hostage takerNo").
+        and have_text("Risk to others: harasser and/or bullyNo").
+        and have_text("Intimidator/bullyNo").
+        and have_text("Sex offenderNo").
+        and have_text("Escape status/historyNo").
+        and have_text("Made previous escape attemptsNo").
+        and have_text("Category A or Restricted statusNo").
+        and have_text("Escort Risk Assessment/Escort PackNo").
+        and have_text("Risk of trafficking drugs or alcoholNo").
+        and have_text("Conceals weapons, drugs or other itemsNo").
+        and have_text("Arson and damage to propertyNo")
+
+      # asserting the number of rows containing the risk answers
+      # with full detailed answers you get more rows than when
+      # all answers are no
+      expect(page.all('tr').size).to eq(17)
+    end
+  end
+
+  scenario 'user prints a completed PER with the most fully detailed answers' do
+    risk = create(:risk, {
+      acct_status: 'open',
+      rule_45: 'yes',
+      csra: 'high',
+      victim_of_abuse: 'yes',
+      victim_of_abuse_details: 'abuse details',
+      high_profile: 'yes',
+      high_profile_details: 'high profile details',
+      violence_due_to_discrimination: 'yes',
+      risk_to_females: true,
+      homophobic: true,
+      racist: true,
+      racist_details: 'violence racist details',
+      other_violence_due_to_discrimination: true,
+      other_violence_due_to_discrimination_details: 'other violence due to discrimination details',
+      violence_to_staff: 'yes',
+      violence_to_staff_custody: true,
+      violence_to_staff_community: true,
+      violence_to_other_detainees: 'yes',
+      co_defendant: true,
+      co_defendant_details: 'violente co-defendant details',
+      gang_member: true,
+      gang_member_details: 'violence gang member details',
+      other_violence_to_other_detainees: true,
+      other_violence_to_other_detainees_details: 'other violence to other detainees details',
+      violence_to_general_public: 'yes',
+      violence_to_general_public_details: 'violence to general public details',
+      hostage_taker: 'yes',
+      staff_hostage_taker: true,
+      date_most_recent_staff_hostage_taker_incident: '12/03/2010',
+      prisoners_hostage_taker: true,
+      date_most_recent_prisoners_hostage_taker_incident: '24/05/2012',
+      public_hostage_taker: true,
+      date_most_recent_public_hostage_taker_incident: '02/09/2007',
+      harassment: 'yes',
+      harassment_details: 'harassment details',
+      intimidation: 'yes',
+      intimidation_to_staff: true,
+      intimidation_to_staff_details: 'intimidation to staff details',
+      intimidation_to_public: true,
+      intimidation_to_public_details: 'intimidation to public details',
+      intimidation_to_other_detainees: true,
+      intimidation_to_other_detainees_details: 'intimidation to other detainees details',
+      intimidation_to_witnesses: true,
+      intimidation_to_witnesses_details: 'intimidation to witnesses details',
+      sex_offence: 'yes',
+      sex_offence_adult_male_victim: true,
+      sex_offence_adult_female_victim: true,
+      sex_offence_under18_victim: true,
+      sex_offence_under18_victim_details: 'under 18 sex offence victim details',
+      current_e_risk: 'yes',
+      current_e_risk_details: 'e_list_escort',
+      previous_escape_attempts: 'yes',
+      prison_escape_attempt: true,
+      prison_escape_attempt_details: 'prison escape attempt details',
+      court_escape_attempt: true,
+      court_escape_attempt_details: 'court escape attempt details',
+      police_escape_attempt: true,
+      police_escape_attempt_details: 'police escape attempt details',
+      other_type_escape_attempt: true,
+      other_type_escape_attempt_details: 'other type of escape attempt details',
+      category_a: 'yes',
+      escort_risk_assessment: 'yes',
+      escort_risk_assessment_completion_date: '26/11/2016',
+      escape_pack: 'yes',
+      escape_pack_completion_date: '13/12/2016',
+      substance_supply: 'yes',
+      trafficking_drugs: true,
+      trafficking_alcohol: true,
+      conceals_weapons: 'yes',
+      conceals_weapons_details: 'conceals weapons details',
+      conceals_drugs: 'yes',
+      conceals_drugs_details: 'conceals drugs details',
+      conceals_mobile_phone_or_other_items: 'yes',
+      conceals_mobile_phones: true,
+      conceals_sim_cards: true,
+      conceals_other_items: true,
+      conceals_other_items_details: 'conceals other items details',
+      arson: 'yes',
+      damage_to_property: 'yes'
+    })
+    detainee = create(:detainee, risk: risk)
+    move = create(:move, :confirmed, :with_destinations, detainee: detainee)
+
+    login
+    visit detainee_path(detainee)
+    print_per
+    move_print_page.assert_detainee_details(detainee)
+    move_print_page.assert_move_details(move)
+
+    within('#risk-table') do
+      expect(page).to have_text('Risk to selfYes').
+        and have_text("ACCT statusOpen").
+        and have_text("Risk from othersYes").
+        and have_text("Rule 45Yes").
+        and have_text("CSRAHigh").
+        and have_text("Victim of abuse in prisonYesabuse details").
+        and have_text("High public interestYeshigh profile details").
+        and have_text("Risk to others - discriminationYes").
+        and have_text("Risk to femalesYes").
+        and have_text("HomosexualsYes").
+        and have_text("RacistYesviolence racist details").
+        and have_text("OtherYesother violence due to discrimination details").
+        and have_text("Violent to staffYes").
+        and have_text("Staff custodyYes").
+        and have_text("Staff communityYes").
+        and have_text("Violent to other detaineesYes").
+        and have_text("Co-defendantYesviolente co-defendant details").
+        and have_text("Gang memberYesviolence gang member details").
+        and have_text("Other known conflictsYesother violence to other detainees details").
+        and have_text("Violent to general publicYes").
+        and have_text("General publicYes").
+        and have_text("Risk to others - hostage takerYes").
+        and have_text("StaffYes12/03/2010").
+        and have_text("PrisonersYes24/05/2012").
+        and have_text("PublicYes02/09/2007").
+        and have_text("Risk to others: harasser and/or bullyYes").
+        and have_text("HarasserYesharassment details").
+        and have_text("Intimidator/bullyYes").
+        and have_text("StaffYesintimidation to staff details").
+        and have_text("PublicYesintimidation to public details").
+        and have_text("PrisonersYesintimidation to other detainees details").
+        and have_text("WitnessesYesintimidation to witnesses details").
+        and have_text("Sex offenderYes").
+        and have_text("Adult maleYes").
+        and have_text("Adult femaleYes").
+        and have_text("Under 18Yesunder 18 sex offence victim details").
+        and have_text("Escape status/historyYes").
+        and have_text("Currently on E listYesE-List-Escort").
+        and have_text("Made previous escape attemptsYes").
+        and have_text("PrisonYesprison escape attempt details").
+        and have_text("CourtYescourt escape attempt details").
+        and have_text("PoliceYespolice escape attempt details").
+        and have_text("OtherYesother type of escape attempt details").
+        and have_text("Category A or Restricted statusYes").
+        and have_text("Escort Risk Assessment/Escort PackYes").
+        and have_text("Escort Risk AssessmentYesCompleted on: 26/11/2016").
+        and have_text("Escape PackYesCompleted on: 13/12/2016").
+        and have_text("Risk of trafficking drugs or alcoholYes").
+        and have_text("DrugsYes").
+        and have_text("AlcoholYes").
+        and have_text("Conceals weapons, drugs or other itemsYes").
+        and have_text("Conceals weaponsYesconceals weapons details").
+        and have_text("Conceals drugsYesconceals drugs details").
+        and have_text("Conceals mobile phonesYes").
+        and have_text("Conceals SIM cardsYes").
+        and have_text("Conceals other itemsYesconceals other items details").
+        and have_text("Arson and damage to propertyYes").
+        and have_text("Arson is a behavioural issueYes").
+        and have_text("Damage to propertyYes")
+
+      # asserting the number of rows containing the risk answers
+      # with full detailed answers you get more rows than when
+      # all answers are no
+      expect(page.all('tr').size).to eq(60)
+    end
   end
 
   def print_per

--- a/spec/presenters/print/assessment_question_presenter_spec.rb
+++ b/spec/presenters/print/assessment_question_presenter_spec.rb
@@ -1,0 +1,289 @@
+require 'rails_helper'
+
+RSpec.describe Print::AssessmentQuestionPresenter do
+  let(:question) { 'some_question' }
+  let(:answer) { 'some_answer' }
+  let(:section_name) { 'some_section' }
+  let(:section_klass) {
+    Class.new(BaseSection) do
+      def initialize(section_name)
+        @section_name = section_name
+      end
+
+      def name
+        @section_name
+      end
+    end
+  }
+  let(:section) { section_klass.new(section_name) }
+  let(:assessment) { double(:assessment) }
+
+  subject(:presenter) { described_class.new(question, assessment, section) }
+
+  before do
+    allow(assessment).to receive(question).and_return(answer)
+  end
+
+  describe '#label' do
+    before do
+      localize_key("summary.section.questions.#{section_name}.#{question}", 'Localised question')
+    end
+
+    context 'when the answer is relevant' do
+      before do
+        allow(presenter).to receive(:answer_is_relevant?).and_return(true)
+      end
+
+      it 'returns the highlighted label' do
+        expect(presenter.label).to eq('<div class="strong-text">Localised question</div>')
+      end
+    end
+
+    it 'returns the normal non-highlighted label' do
+      expect(presenter.label).to eq('<div class="title">Localised question</div>')
+    end
+  end
+
+  describe '#answer' do
+    context 'when the question is not conditional' do
+      before do
+        allow(section).to receive(:question_is_conditional?).and_return(false)
+      end
+
+      context 'and the question is answered no' do
+        let(:answer) { 'no' }
+
+        it 'returns the No content' do
+          expect(presenter.answer).to eq 'No'
+        end
+      end
+
+      context 'and the question is answered false' do
+        let(:answer) { false }
+
+        it 'returns the No content' do
+          expect(presenter.answer).to eq 'No'
+        end
+      end
+
+      context 'and the question is answered yes' do
+        let(:answer) { 'yes' }
+
+        it 'returns the Yes content' do
+          expect(presenter.answer).to eq '<div class="strong-text">Yes</div>'
+        end
+      end
+
+      context 'and the question is answered true' do
+        let(:answer) { true }
+
+        it 'returns the Yes content' do
+          expect(presenter.answer).to eq '<div class="strong-text">Yes</div>'
+        end
+      end
+
+      context 'and the question is answered with some other value' do
+        let(:answer) { 'some_other_value' }
+
+        context 'and the answer has a locale for the summary page' do
+          let(:answer) { 'some_localised_value' }
+
+          before do
+            localize_key("summary.section.answers.#{section_name}.some_localised_value", 'Localised some other value')
+          end
+
+          it 'returns the localised version of the answer' do
+            expect(presenter.answer).to eq('Localised some other value')
+          end
+        end
+
+        context 'and the answer has no locale for the summary page' do
+          it 'returns the humanized version of it' do
+            expect(presenter.answer).to eq 'Some other value'
+          end
+        end
+
+        context 'and the answer is considered relevant' do
+          before do
+            allow(section).to receive(:relevant_answer?).with(question, answer).and_return(true)
+          end
+
+          it 'returns the answer highlighted' do
+            expect(presenter.answer).to eq '<div class="strong-text">Some other value</div>'
+          end
+        end
+      end
+    end
+
+    context 'when the question is conditional' do
+      before do
+        allow(assessment).to receive(:conditional_question).and_return(conditional_answer)
+        allow(section).to receive(:question_is_conditional?).and_return(true)
+        allow(section).to receive(:question_condition).and_return(:conditional_question)
+      end
+
+      context 'and the conditional question is answered no' do
+        let(:conditional_answer) { 'no' }
+
+        it 'returns no text' do
+          expect(presenter.answer).to eq 'No'
+        end
+      end
+
+      context 'and the conditional question is answered yes' do
+        let(:conditional_answer) { 'yes' }
+
+        context 'and the attribute checkbox is checked' do
+          let(:answer) { true }
+
+          it 'returns yes text highlighted' do
+            expect(presenter.answer).to eq '<div class="strong-text">Yes</div>'
+          end
+        end
+
+        context 'and the attribute checkbox is unchecked' do
+          let(:answer) { nil }
+
+          it 'returns no text' do
+            expect(presenter.answer).to eq 'No'
+          end
+        end
+      end
+    end
+  end
+
+  describe '#answer_is_relevant?' do
+    context 'when the question is not conditional' do
+      before do
+        allow(section).to receive(:question_is_conditional?).and_return(false)
+      end
+
+      context 'and the question is answered no' do
+        let(:answer) { 'no' }
+
+        specify { expect(presenter.answer_is_relevant?).to be_falsey }
+      end
+
+      context 'and the question is answered false' do
+        let(:answer) { false }
+
+        specify { expect(presenter.answer_is_relevant?).to be_falsey }
+      end
+
+      context 'and the question is answered yes' do
+        let(:answer) { 'yes' }
+
+        specify { expect(presenter.answer_is_relevant?).to be_truthy }
+      end
+
+      context 'and the question is answered true' do
+        let(:answer) { true }
+
+        specify { expect(presenter.answer_is_relevant?).to be_truthy }
+      end
+
+      context 'and the question is answered with some other value' do
+        let(:answer) { 'some_other_value' }
+
+        specify { expect(presenter.answer_is_relevant?).to be_falsey }
+
+        context 'and the answer is considered relevant' do
+          before do
+            allow(section).to receive(:relevant_answer?).with(question, answer).and_return(true)
+          end
+
+          specify { expect(presenter.answer_is_relevant?).to be_truthy }
+        end
+      end
+    end
+
+    context 'when the question is conditional' do
+      before do
+        allow(assessment).to receive(:conditional_question).and_return(conditional_answer)
+        allow(section).to receive(:question_is_conditional?).and_return(true)
+        allow(section).to receive(:question_condition).and_return(:conditional_question)
+      end
+
+      context 'and the conditional question is answered no' do
+        let(:conditional_answer) { 'no' }
+
+         specify { expect(presenter.answer_is_relevant?).to be_falsey }
+      end
+
+      context 'and the conditional question is answered yes' do
+        let(:conditional_answer) { 'yes' }
+
+        context 'and the attribute checkbox is checked' do
+          let(:answer) { true }
+
+          specify { expect(presenter.answer_is_relevant?).to be_truthy }
+        end
+
+        context 'and the attribute checkbox is unchecked' do
+          let(:answer) { nil }
+
+          specify { expect(presenter.answer_is_relevant?).to be_falsey }
+        end
+      end
+    end
+  end
+
+  describe '#details' do
+    let(:answer_detail_1) { 'foo' }
+    let(:answer_detail_2) { 'bar' }
+
+    before do
+      allow(assessment).to receive(:question_detail_1).and_return(answer_detail_1)
+      allow(assessment).to receive(:question_detail_2).and_return(answer_detail_2)
+    end
+
+    context 'when the question has no defined details' do
+      before do
+        allow(section).to receive(:question_has_details?).and_return(false)
+      end
+    end
+
+    context 'when the question has defined details' do
+      before do
+        allow(section).to receive(:question_has_details?).and_return(true)
+        allow(section).to receive(:question_details).and_return(%i[question_detail_1 question_detail_2])
+      end
+
+      it 'returns a string with the combined details for the question' do
+        expect(presenter.details).to eq('Foo. Bar')
+      end
+
+      context 'when one of the details is empty' do
+        let(:answer_detail_1) { nil }
+
+        it 'returns a string only with the details that are present' do
+          expect(presenter.details).to eq('Bar')
+        end
+      end
+
+      context 'when one of the details has a locale for its label in the summary page' do
+        before do
+          allow(section).to receive(:question_details).and_return(%i[localised_question_detail_1 question_detail_2])
+          allow(assessment).to receive(:localised_question_detail_1).and_return(answer_detail_1)
+          localize_key("summary.section.questions.#{section_name}.localised_question_detail_1", 'Localised question detail 1: ')
+        end
+
+        it 'prepends the localised label for the specified detail in the returned string' do
+          expect(presenter.details).to eq('Localised question detail 1: Foo. Bar')
+        end
+      end
+
+      context 'when one of the details has a localised version for the summary page' do
+        let(:answer_detail_2) { 'localised_answer_detail_2' }
+
+        before do
+          localize_key("summary.section.answers.#{section_name}.localised_answer_detail_2", 'Localised answer detail 2')
+        end
+
+        it 'prepends the localised label for the specified detail in the returned string' do
+          expect(presenter.details).to eq('Foo. Localised answer detail 2')
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/print/risk_presenter_spec.rb
+++ b/spec/presenters/print/risk_presenter_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Print::RiskPresenter, type: :presenter do
+  let(:answer) { true }
+  let(:conditional_answer) { 'yes' }
+  let(:model) { double(Risk) }
+  let(:section_name) { 'test_section' }
+  let(:section_class) {
+    Class.new(BaseSection) do
+      def name
+        'test_section'
+      end
+
+      def questions
+        %w[question_1 question_2]
+      end
+    end
+  }
+  let(:section) { section_class.new }
+  subject(:presenter) { described_class.new(model, section: section_name) }
+
+  it { is_expected.to be_a Print::AssessmentSectionPresenter }
+  it_behaves_like 'print assessment section presenter'
+end

--- a/spec/presenters/print/risk_subsection_presenter_spec.rb
+++ b/spec/presenters/print/risk_subsection_presenter_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Print::RiskSubsectionPresenter, type: :presenter do
+  let(:answer) { true }
+  let(:conditional_answer) { 'yes' }
+  let(:model) { double(Risk) }
+  let(:section_name) { 'test_section' }
+  let(:subsection_name) { 'test_subsection' }
+  let(:section_class) {
+    Class.new(BaseSection) do
+      def name
+        'test_section'
+      end
+
+      def questions
+        %w[question_1 question_2]
+      end
+    end
+  }
+  let(:section) { section_class.new }
+  subject(:presenter) { described_class.new(model, section: section_name, subsection: subsection_name) }
+
+  it_behaves_like 'print assessment subsection presenter'
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -57,6 +57,7 @@ RSpec.configure do |config|
   config.include(OffendersApiHelpers)
   config.include(NomisApiHelpers)
   config.include(ActionView::TestCase::Behavior, type: :presenter)
+  config.include(LocalizerHelpers)
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/support/localizer_helpers.rb
+++ b/spec/support/localizer_helpers.rb
@@ -1,0 +1,7 @@
+module LocalizerHelpers
+  def localize_key(key, value, options = {})
+    locale = options.fetch(:locale, :en)
+    hash = key.split('.').reverse.inject(value) { |a, n| { n => a } }
+    I18n.backend.store_translations(locale, hash)
+  end
+end

--- a/spec/support/shared_examples/assessment_section_presenter_shared_examples.rb
+++ b/spec/support/shared_examples/assessment_section_presenter_shared_examples.rb
@@ -64,17 +64,7 @@ RSpec.shared_examples_for 'assessment section presenter' do
           let(:answer) { 'some_localised_value' }
 
           before do
-            I18n.backend.store_translations(:en, {
-              summary: {
-                section: {
-                  answers: {
-                    section_name => {
-                      'some_localised_value' => 'Localised some other value'
-                    }
-                  }
-                }
-              }
-            })
+            localize_key("summary.section.answers.#{section_name}.some_localised_value", 'Localised some other value')
           end
 
           it 'returns the localised version of the answer' do
@@ -173,17 +163,7 @@ RSpec.shared_examples_for 'assessment section presenter' do
         before do
           allow(section).to receive(:question_details).and_return(%i[localised_question_detail_1 question_detail_2])
           allow(model).to receive(:localised_question_detail_1).and_return(answer_detail_1)
-          I18n.backend.store_translations(:en, {
-            summary: {
-              section: {
-                questions: {
-                  section_name => {
-                    'localised_question_detail_1' => 'Localised question detail 1: '
-                  }
-                }
-              }
-            }
-          })
+          localize_key("summary.section.questions.#{section_name}.localised_question_detail_1", 'Localised question detail 1: ')
         end
 
         it 'prepends the localised label for the specified detail in the returned string' do
@@ -195,17 +175,7 @@ RSpec.shared_examples_for 'assessment section presenter' do
         let(:answer_detail_2) { 'localised_answer_detail_2' }
 
         before do
-          I18n.backend.store_translations(:en, {
-            summary: {
-              section: {
-                answers: {
-                  section_name => {
-                    'localised_answer_detail_2' => 'Localised answer detail 2'
-                  }
-                }
-              }
-            }
-          })
+          localize_key("summary.section.answers.#{section_name}.localised_answer_detail_2", 'Localised answer detail 2')
         end
 
         it 'prepends the localised label for the specified detail in the returned string' do

--- a/spec/support/shared_examples/print_assessment_section_presenter_shared_examples.rb
+++ b/spec/support/shared_examples/print_assessment_section_presenter_shared_examples.rb
@@ -1,0 +1,66 @@
+RSpec.shared_examples_for 'print assessment section presenter' do
+  before do
+    allow(presenter).to receive(:section).and_return(section)
+    allow(model).to receive(:question).and_return(answer)
+    allow(model).to receive(:conditional_question).and_return(conditional_answer)
+  end
+
+  describe '#questions' do
+    it 'returns a list of question presenters for the section questions' do
+      expect(presenter.questions).to be_a(Array)
+      expect(presenter.questions.size).to eq(section.questions.size)
+      presenter.questions.each do |question|
+        expect(question).to be_kind_of(Print::AssessmentQuestionPresenter)
+      end
+      expect(presenter.questions.map(&:name)).to match_array(section.questions)
+    end
+  end
+
+  describe '#relevant' do
+    context 'when there are no relevant answers' do
+      before do
+        allow_any_instance_of(Print::AssessmentQuestionPresenter).to receive(:answer_is_relevant?).and_return(false)
+      end
+
+      it 'returns No' do
+        expect(presenter.relevant).to eq('No')
+      end
+    end
+
+    context 'when there is at least one relevant answer' do
+      before do
+        allow_any_instance_of(Print::AssessmentQuestionPresenter).to receive(:answer_is_relevant?).and_return(true)
+      end
+
+      it 'returns highlighted Yes' do
+        expect(presenter.relevant).to eq('<div class="strong-text">Yes</div>')
+      end
+    end
+  end
+
+  describe '#label' do
+    before do
+      localize_key("summary.section.titles.#{section_name}", 'Localised section name')
+    end
+
+    context 'when section is NOT relevant' do
+      before do
+        allow(presenter).to receive(:relevant?).and_return(false)
+      end
+
+      it 'returns the non highlighted label' do
+        expect(presenter.label).to eq('Localised section name')
+      end
+    end
+
+    context 'when section is relevant' do
+      before do
+        allow(presenter).to receive(:relevant?).and_return(true)
+      end
+
+      it 'returns the highlighted label' do
+        expect(presenter.label).to eq('<div class="strong-text">Localised section name</div>')
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/print_assessment_subsection_presenter_shared_examples.rb
+++ b/spec/support/shared_examples/print_assessment_subsection_presenter_shared_examples.rb
@@ -1,0 +1,94 @@
+RSpec.shared_examples_for 'print assessment subsection presenter' do
+  before do
+    allow(presenter).to receive(:section).and_return(section)
+    allow(model).to receive(:question).and_return(answer)
+    allow(model).to receive(:conditional_question).and_return(conditional_answer)
+  end
+
+  describe '#name' do
+    specify { expect(presenter.name).to eq(subsection_name) }
+  end
+
+  describe '#questions' do
+    context 'when the subsection does not contain any questions' do
+      specify { expect(presenter.questions).to eq([]) }
+    end
+
+    context 'when the subsection contains a list of questions' do
+      let(:questions) { %i[ss_question_1 ss_question_2] }
+      let(:subsections_questions) {
+        { subsection_name.to_sym => questions }
+      }
+
+      before do
+        allow(section).to receive(:subsections_questions).and_return(subsections_questions)
+      end
+
+      it 'returns a list of question presenters for the subsection questions' do
+        expect(presenter.questions).to be_a(Array)
+        expect(presenter.questions.size).to eq(questions.size)
+        presenter.questions.each do |question|
+          expect(question).to be_kind_of(Print::AssessmentQuestionPresenter)
+        end
+        expect(presenter.questions.map(&:name)).to match_array(questions)
+      end
+    end
+  end
+
+  describe '#relevant' do
+    let(:questions) { %i[ss_question_1 ss_question_2] }
+    let(:subsections_questions) {
+      { subsection_name.to_sym => questions }
+    }
+
+    before do
+      allow(section).to receive(:subsections_questions).and_return(subsections_questions)
+    end
+
+    context 'when there are no relevant answers' do
+      before do
+        allow_any_instance_of(Print::AssessmentQuestionPresenter).to receive(:answer_is_relevant?).and_return(false)
+      end
+
+      it 'returns No' do
+        expect(presenter.relevant).to eq('No')
+      end
+    end
+
+    context 'when there is at least one relevant answer' do
+      before do
+        allow_any_instance_of(Print::AssessmentQuestionPresenter).to receive(:answer_is_relevant?).and_return(true)
+      end
+
+      it 'returns highlighted Yes' do
+        expect(presenter.relevant).to eq('<div class="strong-text">Yes</div>')
+      end
+    end
+  end
+
+  describe '#label' do
+    before do
+      localize_key("summary.section.titles.#{subsection_name}", 'Localised subsection name')
+    end
+
+    context 'when section is NOT relevant' do
+      before do
+        allow(presenter).to receive(:relevant?).and_return(false)
+      end
+
+      it 'returns the non highlighted label' do
+        expect(presenter.label).to eq('Localised subsection name')
+      end
+    end
+
+    context 'when section is relevant' do
+      before do
+        allow(presenter).to receive(:relevant?).and_return(true)
+      end
+
+      it 'returns the highlighted label' do
+        expect(presenter.label).to eq('<div class="strong-text">Localised subsection name</div>')
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello #31](https://trello.com/c/j1XIqWpc/31-5-as-someone-printing-out-a-completed-per-i-want-to-see-a-summary-of-all-the-detainee-s-risk-information)

Add risk assessment content to the move printout.

Also:
- Add new print presenters for risk sections and subsections
- Add new print presenter for an assessment question
- Tweak the way pages break in the print media