### PR TITLE
Add offences info to printout

### DIFF
--- a/app/presenters/print/offences_presenter.rb
+++ b/app/presenters/print/offences_presenter.rb
@@ -1,0 +1,56 @@
+module Print
+  class OffencesPresenter < SimpleDelegator
+    include Print::Helpers
+
+    def current_offences_label
+      content = t('print.label.offences.current_offences')
+      label_for(model.current_offences, content)
+    end
+
+    def current_offences_relevant
+      relevance_for(model.current_offences)
+    end
+
+    def current_offences
+      format_list(model.current_offences)
+    end
+
+    def past_offences_label
+      content = t('print.label.offences.past_offences')
+      label_for(model.past_offences, content)
+    end
+
+    def past_offences_relevant
+      relevance_for(model.past_offences)
+    end
+
+    def past_offences
+      format_list(model.past_offences)
+    end
+
+    private
+
+    def label_for(list, content)
+      list.present? ? highlighted_content(content) : content
+    end
+
+    def relevance_for(list)
+      list.present? ? highlighted_content('Yes') : 'None'
+    end
+
+    def format_list(list)
+      return if list.empty?
+      safe_join(list.map do |item|
+        array = [item.offence]
+        if item.respond_to?(:case_reference) && item.case_reference.present?
+          array << "(#{item.case_reference})"
+        end
+        array.join(' ')
+      end, ' | ')
+    end
+
+    def model
+      __getobj__
+    end
+  end
+end

--- a/app/services/pdf_generator.rb
+++ b/app/services/pdf_generator.rb
@@ -7,7 +7,13 @@ class PdfGenerator
     ActionController::Base.new.render_to_string(
       pdf: filename,
       template: 'moves/print/show',
-      locals: { detainee: detainee_presenter, move: move_presenter, risk: risk, healthcare: healthcare }
+      locals: {
+        detainee: detainee_presenter,
+        move: move_presenter,
+        risk: risk,
+        healthcare: healthcare,
+        offences: offences_presenter
+      }
     )
   end
 
@@ -25,11 +31,15 @@ class PdfGenerator
     @detainee_presenter ||= Print::DetaineePresenter.new(detainee)
   end
 
+  def offences_presenter
+    @offences_presenter ||= Print::OffencesPresenter.new(offences)
+  end
+
   attr_reader :move
 
   def detainee
     move.detainee
   end
 
-  private(*delegate(:risk, :healthcare, to: :detainee))
+  private(*delegate(:risk, :healthcare, :offences, to: :detainee))
 end

--- a/app/views/moves/print/show.html.slim
+++ b/app/views/moves/print/show.html.slim
@@ -126,7 +126,20 @@ html
                 span.watermark = 'Offences'
                 table#offences-table.section-table
                   tr
-                    td
+                    td.column-30-percent
+                      = offences.current_offences_label
+                    td.column-20-percent.indented
+                      = offences.current_offences_relevant
+                    td.column-50-percent
+                      = offences.current_offences
+                  tr.top-dotted
+                    td.column-30-percent
+                      = offences.past_offences_label
+                    td.column-20-percent.indented
+                      = offences.past_offences_relevant
+                    td.column-50-percent
+                      = offences.past_offences
+
           tr
             td
               div#move-returns-section.section

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -509,6 +509,9 @@ en:
       move:
         must_return_to: Must return to
         must_not_return_to: Must NOT return to
+      offences:
+        current_offences: Current offences
+        past_offences: Significant past offences
   profile:
     alerts:
       acct_status:

--- a/spec/factories/offences_factory.rb
+++ b/spec/factories/offences_factory.rb
@@ -14,5 +14,10 @@ FactoryGirl.define do
     trait :with_no_current_offences do
       current_offences { [] }
     end
+
+    trait :with_no_past_offences do
+      has_past_offences 'no'
+      past_offences { [] }
+    end
   end
 end

--- a/spec/features/printing_spec.rb
+++ b/spec/features/printing_spec.rb
@@ -2,7 +2,8 @@ require 'feature_helper'
 
 RSpec.feature 'printing a PER', type: :feature do
   let!(:move) { create(:move, :confirmed, destinations: destinations, detainee: detainee) }
-  let(:detainee) { create(:detainee, forenames: 'Testy', surname: 'McTest', risk: risk, healthcare: healthcare) }
+  let(:offences) { create(:offences, :with_no_current_offences, :with_no_past_offences) }
+  let(:detainee) { create(:detainee, forenames: 'Testy', surname: 'McTest', risk: risk, healthcare: healthcare, offences: offences) }
 
   let(:outbound_vehicle_details) {
     [
@@ -60,6 +61,7 @@ RSpec.feature 'printing a PER', type: :feature do
       person_escort_record_info_panel,
       risk_details,
       healthcare_details,
+      offences_details,
       must_return_must_not_return_move_details
     ].flatten
   }
@@ -158,6 +160,13 @@ RSpec.feature 'printing a PER', type: :feature do
       ]
     }
 
+    let(:offences_details) {
+      [
+        "Current offences None",
+        "Significant past offences None"
+      ]
+    }
+
     let(:must_return_must_not_return_move_details) {
       [
         "Must return to None",
@@ -176,6 +185,19 @@ RSpec.feature 'printing a PER', type: :feature do
   end
 
   context 'when a PER has detailed answers' do
+    let(:current_offences) {
+      [
+      create(:current_offence, offence: 'Burglary', case_reference: 'LXAHTGNJQF'),
+      create(:current_offence, offence: 'Sex offence', case_reference: 'QDPREIBMSF')
+      ]
+    }
+    let(:past_offences) {
+      [
+      create(:past_offence, offence: 'Past Offence 1'),
+      create(:past_offence, offence: 'Past Offence 2')
+      ]
+    }
+    let(:offences) { create(:offences, current_offences: current_offences, past_offences: past_offences) }
     let(:must_return_destination) { create(:destination, :must_return, establishment: 'HMP Brixton', reasons: 'Its a lovely place.') }
     let(:must_not_return_destination) { create(:destination, :must_not_return, establishment: 'HMP Clive House', reasons: 'Its too cold.') }
     let(:destinations) { [must_return_destination, must_not_return_destination] }
@@ -391,6 +413,14 @@ RSpec.feature 'printing a PER', type: :feature do
         "Medical contact Yes",
         "Healthcare professional John doctor doe",
         "Contact number 1-131-999-0232",
+      ]
+    }
+
+    let(:offences_details) {
+      [
+        "Current offences Yes Burglary (LXAHTGNJQF) | Sex offence",
+        "(QDPREIBMSF)",
+        "Significant past offences Yes Past Offence 1 | Past Offence 2"
       ]
     }
 

--- a/spec/presenters/print/offences_presenter_spec.rb
+++ b/spec/presenters/print/offences_presenter_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+
+RSpec.describe Print::OffencesPresenter do
+  subject(:presenter) { described_class.new(offences) }
+
+  describe '#current_offences_label' do
+    context 'when there are no current offences' do
+      let(:offences) { FactoryGirl.build(:offences, :with_no_current_offences) }
+
+      it 'returns a non-highlighed label' do
+        expect(presenter.current_offences_label).to eq('Current offences')
+      end
+    end
+
+    context 'when there are current offences' do
+      let(:current_offences) { build_list(:current_offence, 2) }
+      let(:offences) { FactoryGirl.build(:offences, current_offences: current_offences) }
+
+      it 'returns an highlighed label' do
+        expect(presenter.current_offences_label).to eq('<div class="strong-text">Current offences</div>')
+      end
+    end
+  end
+
+  describe '#current_offences_relevant' do
+    context 'when there are no current offences' do
+      let(:offences) { FactoryGirl.build(:offences, :with_no_current_offences) }
+
+      it 'returns a non-highlighed None' do
+        expect(presenter.current_offences_relevant).to eq('None')
+      end
+    end
+
+    context 'when there are current offences' do
+      let(:current_offences) { build_list(:current_offence, 2) }
+      let(:offences) { FactoryGirl.build(:offences, current_offences: current_offences) }
+
+      it 'returns an highlighed Yes' do
+        expect(presenter.current_offences_relevant).to eq('<div class="strong-text">Yes</div>')
+      end
+    end
+  end
+
+  describe '#current_offences' do
+    context 'when there are no current offences' do
+      let(:offences) { FactoryGirl.build(:offences, :with_no_current_offences) }
+
+      it 'returns nil' do
+        expect(presenter.current_offences).to be_nil
+      end
+    end
+
+    context 'when there are current offences' do
+      let(:current_offences) { build_list(:current_offence, 2) }
+      let(:offences) { FactoryGirl.build(:offences, current_offences: current_offences) }
+
+      it 'returns the list of current offences' do
+        current_offences.each do |offence|
+          expect(presenter.current_offences).to include(%[#{offence.offence} (#{offence.case_reference})])
+        end
+      end
+    end
+  end
+
+  describe '#past_offences_label' do
+    context 'when there are no past offences' do
+      let(:offences) { FactoryGirl.build(:offences, :with_no_past_offences) }
+
+      it 'returns an highlighed label' do
+        expect(presenter.past_offences_label).to eq('Significant past offences')
+      end
+    end
+
+    context 'when there are past offences' do
+      let(:past_offences) { build_list(:past_offence, 2) }
+      let(:offences) { FactoryGirl.build(:offences, past_offences: past_offences) }
+
+      it 'returns an highlighed label' do
+        expect(presenter.past_offences_label).to eq('<div class="strong-text">Significant past offences</div>')
+      end
+    end
+  end
+
+  describe '#past_offences_relevant' do
+    context 'when there are no current offences' do
+      let(:offences) { FactoryGirl.build(:offences, :with_no_past_offences) }
+
+      it 'returns a non-highlighed None' do
+        expect(presenter.past_offences_relevant).to eq('None')
+      end
+    end
+
+    context 'when there are current offences' do
+      let(:past_offences) { build_list(:past_offence, 2) }
+      let(:offences) { FactoryGirl.build(:offences, past_offences: past_offences) }
+
+      it 'returns an highlighed Yes' do
+        expect(presenter.past_offences_relevant).to eq('<div class="strong-text">Yes</div>')
+      end
+    end
+  end
+
+  describe '#past_offences' do
+    context 'when there are no past offences' do
+      let(:offences) { FactoryGirl.build(:offences, :with_no_past_offences) }
+
+      it 'returns nil' do
+        expect(presenter.past_offences).to be_nil
+      end
+    end
+
+    context 'when there are past offences' do
+      let(:past_offences) { build_list(:past_offence, 2) }
+      let(:offences) { FactoryGirl.build(:offences, past_offences: past_offences) }
+
+      it 'returns the list of past offences' do
+        past_offences.each do |offence|
+          expect(presenter.past_offences).to include(offence.offence)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello #29](https://trello.com/c/2cHWamJ3/29-2-as-someone-printing-out-a-completed-digital-per-i-want-to-see-a-summary-of-the-detainee-s-offences)

Also:
- Adds a presenter to manage the logic to display the correct info for
current offences and past offences