### PR TITLE
Printout alerts

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -54,6 +54,16 @@ $is-print: true;
   .section-sub-table {
     page-break-inside: avoid;
   }
+
+  .alert-on {
+    border: 2px solid $mellow-red;
+    position: relative;
+    display: inline-block;
+
+    .alert-title {
+      color: $mellow-red !important;
+    }
+  }
 }
 
 body {
@@ -174,6 +184,11 @@ table {
   }
 }
 
+.top-border {
+  border-top: 2px solid black;
+  padding-top: 5px;
+}
+
 .top-dotted {
   border-top: 1px dotted black;
 }
@@ -203,8 +218,59 @@ table {
 
 .indicators {
   padding: 10px 0;
-  border-bottom: 1px dotted black;
+}
+
+.alert-off {
+  display: inline-block;
+  border: 2px solid $secondary-text-colour;
+  background-color: white;
+  text-transform: uppercase;
+  padding: 0.2em 0.5em;
+  color: $secondary-text-colour;
+  font: 19px "Arial Narrow";
   font-weight: bold;
+
+  .alert-toggle-text {
+    padding-left: 5px;
+    text-transform: uppercase;
+    font: 19px "Arial Narrow";
+    font-weight: bold;
+  }
+}
+
+.alert-on {
+  border: 2px solid $mellow-red;
+  background-color: $mellow-red !important;
+  position: relative;
+  display: inline-block;
+
+  .alert-title {
+    text-transform: uppercase;
+    padding: 0.2em 0.5em;
+    color: white;
+    font: 19px "Arial Narrow";
+    font-weight: bold;
+    position: relative;
+    float: left;
+  }
+
+  .alert-toggle-text {
+    padding: 0 5px;
+    margin-top: 3px;
+    margin-right: 3px;
+    background-color: white;
+    color: $mellow-red;
+    text-transform: uppercase;
+    font: 19px "Arial Narrow";
+    font-weight: bold;
+    position: relative;
+    float: left;
+  }
+}
+
+.alert-text {
+  display: block;
+  padding-top: 5px;
 }
 
 table.vehicles {

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -54,16 +54,6 @@ $is-print: true;
   .section-sub-table {
     page-break-inside: avoid;
   }
-
-  .alert-on {
-    border: 2px solid $mellow-red;
-    position: relative;
-    display: inline-block;
-
-    .alert-title {
-      color: $mellow-red !important;
-    }
-  }
 }
 
 body {
@@ -227,32 +217,34 @@ table {
   text-transform: uppercase;
   padding: 0.2em 0.5em;
   color: $secondary-text-colour;
-  font: 19px "Arial Narrow";
+  font: 15px "Arial Narrow";
   font-weight: bold;
 
   .alert-toggle-text {
     padding-left: 5px;
     text-transform: uppercase;
-    font: 19px "Arial Narrow";
+    font: 15px "Arial Narrow";
     font-weight: bold;
   }
 }
 
 .alert-on {
-  border: 2px solid $mellow-red;
+  //border: 2px solid $mellow-red;
   background-color: $mellow-red !important;
   position: relative;
   display: inline-block;
 
   .alert-title {
     text-transform: uppercase;
-    padding: 0.2em 0.5em;
+    padding: 0.5em 0.5em;
     color: white;
-    font: 19px "Arial Narrow";
+    font: 15px "Arial Narrow";
     font-weight: bold;
     position: relative;
     float: left;
   }
+
+  img {  }
 
   .alert-toggle-text {
     padding: 0 5px;
@@ -261,7 +253,7 @@ table {
     background-color: white;
     color: $mellow-red;
     text-transform: uppercase;
-    font: 19px "Arial Narrow";
+    font: 15px "Arial Narrow";
     font-weight: bold;
     position: relative;
     float: left;

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -19,10 +19,6 @@ $is-print: true;
     height: 297mm;
   }
 
-  .inner-page-header {
-    display: table-header-group;
-  }
-
   .grid-row {
     display: block;
   }
@@ -143,6 +139,14 @@ table {
 .section-table {
   border-top: 2px solid black;
   border-collapse: collapse;
+
+  thead {
+    display: table-header-group;
+  }
+
+  tr {
+    page-break-inside: avoid;
+  }
 
   td {
     font-weight: lighter;

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -211,6 +211,7 @@ table {
 }
 
 .alert-off {
+  border-radius: 5px;
   display: inline-block;
   border: 2px solid $secondary-text-colour;
   background-color: white;
@@ -229,14 +230,15 @@ table {
 }
 
 .alert-on {
-  //border: 2px solid $mellow-red;
+  border-radius: 5px;
+  border: 2px solid $mellow-red;
   background-color: $mellow-red !important;
   position: relative;
   display: inline-block;
 
   .alert-title {
     text-transform: uppercase;
-    padding: 0.5em 0.5em;
+    padding: 0.2em 0.5em;
     color: white;
     font: 15px "Arial Narrow";
     font-weight: bold;
@@ -244,7 +246,10 @@ table {
     float: left;
   }
 
-  img {  }
+  img {
+    width: 25px;
+    float: left;
+  }
 
   .alert-toggle-text {
     padding: 0 5px;

--- a/app/presenters/print/alert_presenter.rb
+++ b/app/presenters/print/alert_presenter.rb
@@ -32,7 +32,7 @@ module Print
     def build_status_content
       h.content_tag(:div, class: "image #{alert_class}") do
         alert_contents = [h.content_tag(:span, title, class: 'alert-title')]
-        alert_contents << h.image_tag('ic_red_tick.png') if status == :on
+        alert_contents << h.wicked_pdf_image_tag('ic_red_tick.png') if status == :on
         h.safe_join(alert_contents)
       end
     end

--- a/app/presenters/print/alert_presenter.rb
+++ b/app/presenters/print/alert_presenter.rb
@@ -1,0 +1,48 @@
+module Print
+  class AlertPresenter
+    attr_reader :name, :status, :text
+
+    def initialize(name, options)
+      @name = name
+      @view_context = options.fetch(:view_context)
+      @status = options.fetch(:status, :off)
+      @title = options[:title]
+      @text = options[:text]
+    end
+
+    def title
+      return @title if @title.present?
+      h.t("print.alerts.title.#{name}", default: name.to_s.humanize)
+    end
+
+    def to_s
+      h.content_tag(:div, class: 'alert-wrapper') do
+        contents = []
+        contents << build_status_content
+        contents << build_text_content if text.present?
+        h.safe_join(contents)
+      end
+    end
+
+    private
+
+    attr_reader :view_context
+    alias h view_context
+
+    def build_status_content
+      h.content_tag(:div, class: "image #{alert_class}") do
+        alert_contents = [h.content_tag(:span, title, class: 'alert-title')]
+        alert_contents << h.image_tag('ic_red_tick.png') if status == :on
+        h.safe_join(alert_contents)
+      end
+    end
+
+    def build_text_content
+      h.content_tag(:span, text, class: 'alert-text')
+    end
+
+    def alert_class
+      status == :on ? 'alert-on' : 'alert-off'
+    end
+  end
+end

--- a/app/presenters/print/move_alerts_presenter.rb
+++ b/app/presenters/print/move_alerts_presenter.rb
@@ -1,0 +1,109 @@
+module Print
+  class MoveAlertsPresenter < SimpleDelegator
+    def initialize(object, view_context)
+      super(object)
+      @view_context = view_context
+    end
+
+    RISK_ATTRIBUTES = %i[
+      acct_status date_of_most_recently_closed_acct rule_45
+      current_e_risk current_e_risk_details csra category_a
+    ].freeze
+    delegate(:detainee, to: :model)
+    delegate(:risk, :healthcare, to: :detainee)
+    delegate(*RISK_ATTRIBUTES, to: :risk, allow_nil: true)
+    delegate(:mpv, to: :healthcare, allow_nil: true)
+
+    def not_for_release_alert
+      status = not_for_release == 'yes' ? :on : :off
+      alert_for(:not_for_release, status: status, text: not_for_release_text)
+    end
+
+    def not_for_release_text
+      return unless not_for_release == 'yes'
+      text = localised_attr_value(:not_for_release_reason)
+      text << " (#{not_for_release_reason_details})" if not_for_release_reason == 'other'
+      text
+    end
+
+    def acct_status_alert
+      alert_for(:acct_status, status: acct_status_status, text: acct_status_text)
+    end
+
+    def acct_status_status
+      return :on if %w[open post_closure].include?(acct_status)
+      :off
+    end
+
+    def acct_status_text
+      return unless acct_status.present?
+      case acct_status
+      when 'closed_in_last_6_months'
+        [
+          localised_attr_value(:acct_status),
+          date_of_most_recently_closed_acct
+        ].join(' ')
+      else
+        localised_attr_value(:acct_status)
+      end
+    end
+
+    def rule_45_alert
+      status = rule_45 == 'yes' ? :on : :off
+      alert_for(:rule_45, status: status)
+    end
+
+    def current_e_risk_alert
+      alert_for(:current_e_risk, status: current_e_risk_status, text: current_e_risk_text)
+    end
+
+    def current_e_risk_status
+      return :off if current_e_risk != 'yes'
+      return :on if %w[e_list_standard e_list_escort e_list_heightened].include?(current_e_risk_details)
+      :off
+    end
+
+    def current_e_risk_text
+      return unless current_e_risk == 'yes'
+      return unless current_e_risk_details.present?
+      localised_attr_value(:current_e_risk_details)
+    end
+
+    def csra_alert
+      status = csra == 'high' ? :on : :off
+      alert_for(:csra, status: status, text: csra_text)
+    end
+
+    def csra_text
+      csra == 'high' ? 'High' : 'Standard'
+    end
+
+    def category_a_alert
+      status = category_a == 'yes' ? :on : :off
+      alert_for(:category_a, status: status)
+    end
+
+    def mpv_alert
+      status = mpv == 'yes' ? :on : :off
+      alert_for(:mpv, status: status)
+    end
+
+    private
+
+    attr_reader :view_context
+    alias h view_context
+
+    def alert_for(attr, options)
+      Print::AlertPresenter.new(attr, options.merge(view_context: view_context)).to_s
+    end
+
+    def localised_attr_value(attr)
+      value = public_send(attr)
+      h.t("print.alerts.#{attr}.#{value}", default: value.humanize)
+    end
+
+    def model
+      __getobj__
+    end
+  end
+end

--- a/app/presenters/print/move_alerts_presenter.rb
+++ b/app/presenters/print/move_alerts_presenter.rb
@@ -15,8 +15,7 @@ module Print
     delegate(:mpv, to: :healthcare, allow_nil: true)
 
     def not_for_release_alert
-      status = not_for_release == 'yes' ? :on : :off
-      alert_for(:not_for_release, status: status, text: not_for_release_text)
+      alert_for(:not_for_release, status: status_for(not_for_release), text: not_for_release_text)
     end
 
     def not_for_release_text
@@ -49,8 +48,7 @@ module Print
     end
 
     def rule_45_alert
-      status = rule_45 == 'yes' ? :on : :off
-      alert_for(:rule_45, status: status)
+      alert_for(:rule_45, status: status_for(rule_45))
     end
 
     def current_e_risk_alert
@@ -64,34 +62,32 @@ module Print
     end
 
     def current_e_risk_text
-      return unless current_e_risk == 'yes'
-      return unless current_e_risk_details.present?
+      return unless current_e_risk == 'yes' || current_e_risk_details.present?
       localised_attr_value(:current_e_risk_details)
     end
 
     def csra_alert
       status = csra == 'high' ? :on : :off
+      csra_text = csra == 'high' ? 'High' : 'Standard'
       alert_for(:csra, status: status, text: csra_text)
     end
 
-    def csra_text
-      csra == 'high' ? 'High' : 'Standard'
-    end
-
     def category_a_alert
-      status = category_a == 'yes' ? :on : :off
-      alert_for(:category_a, status: status)
+      alert_for(:category_a, status: status_for(category_a))
     end
 
     def mpv_alert
-      status = mpv == 'yes' ? :on : :off
-      alert_for(:mpv, status: status)
+      alert_for(:mpv, status: status_for(mpv))
     end
 
     private
 
     attr_reader :view_context
     alias h view_context
+
+    def status_for(attribute)
+      attribute == 'yes' ? :on : :off
+    end
 
     def alert_for(attr, options)
       Print::AlertPresenter.new(attr, options.merge(view_context: view_context)).to_s

--- a/app/presenters/print/move_alerts_presenter.rb
+++ b/app/presenters/print/move_alerts_presenter.rb
@@ -9,6 +9,7 @@ module Print
       acct_status date_of_most_recently_closed_acct rule_45
       current_e_risk current_e_risk_details csra category_a
     ].freeze
+
     delegate(:detainee, to: :model)
     delegate(:risk, :healthcare, to: :detainee)
     delegate(*RISK_ATTRIBUTES, to: :risk, allow_nil: true)
@@ -18,33 +19,8 @@ module Print
       alert_for(:not_for_release, status: status_for(not_for_release), text: not_for_release_text)
     end
 
-    def not_for_release_text
-      return unless not_for_release == 'yes'
-      text = localised_attr_value(:not_for_release_reason)
-      text << " (#{not_for_release_reason_details})" if not_for_release_reason == 'other'
-      text
-    end
-
     def acct_status_alert
       alert_for(:acct_status, status: acct_status_status, text: acct_status_text)
-    end
-
-    def acct_status_status
-      return :on if %w[open post_closure].include?(acct_status)
-      :off
-    end
-
-    def acct_status_text
-      return unless acct_status.present?
-      case acct_status
-      when 'closed_in_last_6_months'
-        [
-          localised_attr_value(:acct_status),
-          date_of_most_recently_closed_acct
-        ].join(' ')
-      else
-        localised_attr_value(:acct_status)
-      end
     end
 
     def rule_45_alert
@@ -53,17 +29,6 @@ module Print
 
     def current_e_risk_alert
       alert_for(:current_e_risk, status: current_e_risk_status, text: current_e_risk_text)
-    end
-
-    def current_e_risk_status
-      return :off if current_e_risk != 'yes'
-      return :on if %w[e_list_standard e_list_escort e_list_heightened].include?(current_e_risk_details)
-      :off
-    end
-
-    def current_e_risk_text
-      return unless current_e_risk == 'yes' || current_e_risk_details.present?
-      localised_attr_value(:current_e_risk_details)
     end
 
     def csra_alert
@@ -84,6 +49,42 @@ module Print
 
     attr_reader :view_context
     alias h view_context
+
+    def not_for_release_text
+      return unless not_for_release == 'yes'
+      text = localised_attr_value(:not_for_release_reason)
+      text << " (#{not_for_release_reason_details})" if not_for_release_reason == 'other'
+      text
+    end
+
+    def acct_status_status
+      return :on if %w[open post_closure].include?(acct_status)
+      :off
+    end
+
+    def acct_status_text
+      return unless acct_status.present?
+      case acct_status
+      when 'closed_in_last_6_months'
+        [
+          localised_attr_value(:acct_status),
+          date_of_most_recently_closed_acct
+        ].join(' ')
+      else
+        localised_attr_value(:acct_status)
+      end
+    end
+
+    def current_e_risk_status
+      return :off if current_e_risk != 'yes'
+      return :on if %w[e_list_standard e_list_escort e_list_heightened].include?(current_e_risk_details)
+      :off
+    end
+
+    def current_e_risk_text
+      return unless current_e_risk == 'yes' || current_e_risk_details.present?
+      localised_attr_value(:current_e_risk_details)
+    end
 
     def status_for(attribute)
       attribute == 'yes' ? :on : :off

--- a/app/services/pdf_generator.rb
+++ b/app/services/pdf_generator.rb
@@ -12,7 +12,8 @@ class PdfGenerator
         move: move_presenter,
         risk: risk,
         healthcare: healthcare,
-        offences: offences_presenter
+        offences: offences_presenter,
+        alerts: alerts_presenter
       }
     )
   end
@@ -33,6 +34,10 @@ class PdfGenerator
 
   def offences_presenter
     @offences_presenter ||= Print::OffencesPresenter.new(offences)
+  end
+
+  def alerts_presenter
+    @alerts_presenter ||= Print::MoveAlertsPresenter.new(move, view_context)
   end
 
   attr_reader :move

--- a/app/services/pdf_generator.rb
+++ b/app/services/pdf_generator.rb
@@ -4,7 +4,7 @@ class PdfGenerator
   end
 
   def call
-    ActionController::Base.new.render_to_string(
+    controller.render_to_string(
       pdf: filename,
       template: 'moves/print/show',
       locals: {
@@ -37,7 +37,11 @@ class PdfGenerator
   end
 
   def alerts_presenter
-    @alerts_presenter ||= Print::MoveAlertsPresenter.new(move, view_context)
+    @alerts_presenter ||= Print::MoveAlertsPresenter.new(move, controller.view_context)
+  end
+
+  def controller
+    @controller ||= ActionController::Base.new
   end
 
   attr_reader :move

--- a/app/views/moves/print/show.html.slim
+++ b/app/views/moves/print/show.html.slim
@@ -100,12 +100,10 @@ html
     br
     main.inner-page
       table
-        thead.inner-page-header
-          tr
-            td
-              div.grid-row.top-border
-                span#detainee-identifier.strong-text => detainee.identifier
-                = detainee.forenames
+        thead
+          div.grid-row.top-border
+            span#detainee-identifier.strong-text => detainee.identifier
+            = detainee.forenames
         tbody
           tr
             td

--- a/app/views/moves/print/show.html.slim
+++ b/app/views/moves/print/show.html.slim
@@ -106,6 +106,9 @@ html
               div.grid-row.top-border
                 span#detainee-identifier.strong-text => detainee.identifier
                 = detainee.forenames
+        tbody
+          tr
+            td
               div.grid-row.indicators.top-dotted
                 #not_for_release_alert.grid-column.column-one-third
                   = alerts.not_for_release_alert
@@ -122,7 +125,6 @@ html
                   = alerts.category_a_alert
                 #mpv_alert.grid-column.column-one-quarter
                   = alerts.mpv_alert
-        tbody
           tr
             td
               div#risk-section.section

--- a/app/views/moves/print/show.html.slim
+++ b/app/views/moves/print/show.html.slim
@@ -32,9 +32,13 @@ html
             span#detainee-identifier.strong-text => detainee.identifier
             = detainee.forenames
         div.grid-row.indicators
-          div.grid-column.column-one-half E-list
-          div.grid-column.column-one-half MPV
-        div.grid-row.padded
+          #not_for_release_alert.grid-column.column-one-third
+            = alerts.not_for_release_alert
+          #e_list_alert.grid-column.column-one-third
+            = alerts.current_e_risk_alert
+          #mpv_alert.grid-column.column-one-third
+            = alerts.mpv_alert
+        div.grid-row.padded.top-dotted
           div.grid-column.column-one-half
             div.grid-row
               div.grid-column.column-one-third
@@ -99,8 +103,25 @@ html
         thead.inner-page-header
           tr
             td
-              span#detainee-identifier.strong-text => detainee.identifier
-              = detainee.forenames
+              div.grid-row.top-border
+                span#detainee-identifier.strong-text => detainee.identifier
+                = detainee.forenames
+              div.grid-row.indicators.top-dotted
+                #not_for_release_alert.grid-column.column-one-third
+                  = alerts.not_for_release_alert
+                #acct_status_alert.grid-column.column-one-third
+                  = alerts.acct_status_alert
+                #rule_45_alert.grid-column.column-one-third
+                  = alerts.rule_45_alert
+              div.grid-row.indicators
+                #e_list_alert.grid-column.column-one-quarter
+                  = alerts.current_e_risk_alert
+                #csra_alert.grid-column.column-one-quarter
+                  = alerts.csra_alert
+                #category_a_alert.grid-column.column-one-quarter
+                  = alerts.category_a_alert
+                #mpv_alert.grid-column.column-one-quarter
+                  = alerts.mpv_alert
         tbody
           tr
             td

--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -1,0 +1,3 @@
+WickedPdf.config = {
+  exe_path: Gem.bin_path('wkhtmltopdf-binary')
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -503,16 +503,7 @@ en:
         violence_to_general_public: Violent to general public
         violence_to_other_detainees: Violent to other detainees
         violence_to_staff: Violent to staff
-  print:
-    <<: *summary
-    label:
-      move:
-        must_return_to: Must return to
-        must_not_return_to: Must NOT return to
-      offences:
-        current_offences: Current offences
-        past_offences: Significant past offences
-  profile:
+  profile: &profile
     alerts:
       acct_status:
         closed_in_last_6_months: 'Closed:'
@@ -525,6 +516,24 @@ en:
         e_list_heightened: E-List-Heightened
         e_list_standard: E-List-Standard
         unknown: ''
+      title:
+        acct_status: ACCT
+        category_a: Cat A
+        csra: CSRA
+        current_e_risk: E list
+        mpv: MPV
+        not_for_release: Not for release
+        rule_45: Rule 45
+  print:
+    <<: *summary
+    <<: *profile
+    label:
+      move:
+        must_return_to: Must return to
+        must_not_return_to: Must NOT return to
+      offences:
+        current_offences: Current offences
+        past_offences: Significant past offences
   activemodel:
     errors:
       models:

--- a/spec/features/printing_spec.rb
+++ b/spec/features/printing_spec.rb
@@ -25,8 +25,6 @@ RSpec.feature 'printing a PER', type: :feature do
 
   let(:detainee_details) {
     [
-      detainee_info_line,
-      "E-list MPV",
       "Prison number CRO number PNC number Aliases",
       "#{detainee.prison_number} #{detainee.cro_number} #{detainee.pnc_number} #{detainee.aliases}",
       "Date of birth Age GenderNationality",
@@ -56,9 +54,12 @@ RSpec.feature 'printing a PER', type: :feature do
     [
       outbound_vehicle_details,
       return_vehicle_details,
+      detainee_info_line,
+      front_cover_alerts,
       detainee_details,
       move_details,
       person_escort_record_info_panel,
+      alerts,
       risk_details,
       healthcare_details,
       offences_details,
@@ -114,6 +115,20 @@ RSpec.feature 'printing a PER', type: :feature do
       })
     }
 
+    let(:front_cover_alerts){
+      [
+        "NOT FOR RELEASE E LIST MPV"
+      ]
+    }
+
+    let(:alerts) {
+      [
+        "NOT FOR RELEASE ACCT RULE 45",
+        "E LIST CSRA CAT A MPV",
+        "Standard"
+      ]
+    }
+
     let(:risk_details) {
       [
         "Risk to self No",
@@ -152,11 +167,11 @@ RSpec.feature 'printing a PER', type: :feature do
         "Social healthcare No",
         "Allergies No",
         "Medical health needs No",
-        "Transport No",
-        "Communication / language No",
+        "Transport NoCommunication / language No",
         "difficulties",
         "Medical contact Yes",
-        "Healthcare professional John doctor doe#{detainee_info_line} 1-131-999-0232",
+        "Healthcare professional John doctor doe",
+        "Contact number 1-131-999-0232",
       ]
     }
 
@@ -313,6 +328,22 @@ RSpec.feature 'printing a PER', type: :feature do
       })
     }
 
+    let(:front_cover_alerts){
+      [
+        "NOT FOR RELEASE E LIST MPV",
+        "E-List-Escort"
+      ]
+    }
+
+    let(:alerts) {
+      [
+        "NOT FOR RELEASE ACCT RULE 45",
+        "Open",
+        "E LIST CSRA CAT A MPV",
+        "E-List-Escort High"
+      ]
+    }
+
     let(:risk_details) {
       [
         "Risk to self Yes",
@@ -342,14 +373,13 @@ RSpec.feature 'printing a PER', type: :feature do
         "taker",
         "Staff Yes 12/03/2010",
         "Prisoners Yes 24/05/2012",
-        "Public Yes 02/09/2007",
-        "Risk to others: harasser Yes",
+        "Public Yes 02/09/2007Risk to others: harasser Yes",
         "and/or bully",
         "Harasser Yes harassment details",
         "Intimidator/bully Yes",
         "Staff Yes intimidation to staff details",
         "Public Yes intimidation to public details",
-        "Prisoners Yes intimidation to other detainees details#{detainee_info_line}",
+        "Prisoners Yes intimidation to other detainees details",
         "Witnesses Yes intimidation to witnesses details",
         "Sex offender Yes",
         "Adult male Yes",
@@ -379,8 +409,7 @@ RSpec.feature 'printing a PER', type: :feature do
         "Conceals weapons Yes conceals weapons details",
         "Conceals drugs Yes conceals drugs details",
         "Conceals mobile phones Yes",
-        "Conceals SIM cards Yes",
-        "Conceals other items Yes conceals other items details",
+        "Conceals SIM cards Yes Conceals other items Yes conceals other items details",
         "Arson and damage to Yes",
         "property",
         "Arson is a behavioural Yes",
@@ -391,7 +420,8 @@ RSpec.feature 'printing a PER', type: :feature do
 
     let(:healthcare_details) {
       [
-        "Physical healthcare Yes#{detainee_info_line}s Yes physical issues details",
+        "Physical healthcare Yes",
+        "Physical health needs Yes physical issues details",
         "Mental healthcare Yes",
         "Mental health issues Yes mental illness details",
         "Phobias Yes phobias details",

--- a/spec/features/printing_spec.rb
+++ b/spec/features/printing_spec.rb
@@ -194,8 +194,10 @@ RSpec.feature 'printing a PER', type: :feature do
       visit detainee_path(detainee)
       profile.click_print
 
-      expect(transform_pdf_to_lines_of_text(page.body)).
-        to match_array expected_lines
+      pdf_text = transform_pdf_to_lines_of_text(page.body).join
+      expected_text = expected_lines.join
+
+      expect(pdf_text).to eql expected_text
     end
   end
 
@@ -456,8 +458,8 @@ RSpec.feature 'printing a PER', type: :feature do
 
     let(:must_return_must_not_return_move_details) {
       [
-        "Must NOT return to HMP Clive House: Its too cold.",
-        "Must return to HMP Brixton: Its a lovely place."
+        "Must return to HMP Brixton: Its a lovely place.",
+        "Must NOT return to HMP Clive House: Its too cold."
       ]
     }
 
@@ -466,8 +468,10 @@ RSpec.feature 'printing a PER', type: :feature do
       visit detainee_path(detainee)
       profile.click_print
 
-      expect(transform_pdf_to_lines_of_text(page.body)).
-        to match_array expected_lines
+      pdf_text = transform_pdf_to_lines_of_text(page.body).join
+      expected_text = expected_lines.join
+
+      expect(pdf_text).to eql expected_text
     end
   end
 

--- a/spec/presenters/print/alert_presenter_spec.rb
+++ b/spec/presenters/print/alert_presenter_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe Print::AlertPresenter, type: :presenter do
+  let(:name) { :some_alert }
+  let(:status) { :off }
+  let(:default_options) { { view_context: view } }
+  let(:options) { { status: status }.merge(default_options) }
+
+  subject(:presenter) { described_class.new(name, options) }
+
+  describe '#title' do
+    context 'when the title is provided' do
+      let(:options) { { status: status, title: 'Provided title' }.merge(default_options) }
+
+      it 'returns the provided title' do
+        expect(presenter.title).to eq('Provided title')
+      end
+    end
+
+    context 'when there is no locale for the alert title' do
+      it 'returns the humanized version of the alert' do
+        expect(presenter.title).to eq('Some alert')
+      end
+    end
+
+    context 'when there is a locale for the alert title' do
+      let(:name) { :some_localised_alert }
+
+      before do
+        localize_key("print.alerts.title.#{name}", 'Localised alert name')
+      end
+
+      it 'returns the locale version of the alert' do
+        expect(presenter.title).to eq('Localised alert name')
+      end
+    end
+  end
+
+  describe '#to_s' do
+    context 'when the alert is off' do
+      let(:status) { :off }
+
+      it 'returns the appropriate content for when the alert is off' do
+        expect(presenter.to_s).to eq('<div class="alert-wrapper"><div class="image alert-off"><span class="alert-title">Some alert</span></div></div>')
+      end
+    end
+
+    context 'when the alert is on' do
+      let(:status) { :on }
+
+      it 'returns the appropriate content for when the alert is on' do
+        expect(presenter.to_s).to match('<div class="image alert-on"><span class="alert-title">Some alert</span>')
+        expect(presenter.to_s).to match('<img src=.* alt="Ic red tick"')
+      end
+    end
+
+    context 'when the alert has no additional text' do
+      it 'returs the appropriate content without any additional text' do
+        expect(presenter.to_s).not_to match('<span class="alert-text">')
+      end
+    end
+
+    context 'when the alert has additional text' do
+      let(:text) { 'some additional text' }
+      let(:options) { { status: status, text: text }.merge(default_options) }
+
+      it 'returs the appropriate content without any additional text' do
+        expect(presenter.to_s).to match('<span class="alert-text">')
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello #30](https://trello.com/c/YbFEfMIj/30-as-someone-printing-out-a-completed-per-i-want-to-see-all-the-detainee-s-risk-markers)

- Change print layout to contain the sections related with the move
alerts
- Adds a presenter for the move alerts and a presenter for a specific
alert.

<img width="652" alt="screen shot 2017-03-13 at 16 24 21" src="https://cloud.githubusercontent.com/assets/1006365/23864202/af1b38bc-0809-11e7-8875-dc324981505b.png">
