### PR TITLE
Ensure prison number is always upcased

### DIFF
--- a/app/models/forms/detainee.rb
+++ b/app/models/forms/detainee.rb
@@ -26,6 +26,10 @@ module Forms
       errors.add(:date_of_birth) unless date_of_birth.is_a? Date
     end
 
+    def prison_number=(value)
+      value && super(value.upcase)
+    end
+
     def genders
       GENDERS
     end

--- a/app/models/forms/search.rb
+++ b/app/models/forms/search.rb
@@ -16,6 +16,10 @@ module Forms
       presence: true,
       format: { with: PRISON_NUMBER_REGEX }
 
+    def prison_number=(value)
+      value && super(value.upcase)
+    end
+
     def detainee
       @_detainee ||= ::Detainee.find_by(_at[:prison_number].matches(prison_number)) if valid?
     end

--- a/app/services/detainees/fetcher.rb
+++ b/app/services/detainees/fetcher.rb
@@ -1,7 +1,7 @@
 module Detainees
   class Fetcher
     def initialize(prison_number, options = {})
-      @prison_number = prison_number
+      @prison_number = prison_number.upcase
       @options = options
       @errors = []
     end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature 'searching for a prisoner', type: :feature do
   end
 
   def expect_error_message
-    expect(page).to have_content("The prison number 'invalid-prison-number' is not valid")
+    expect(page).to have_content("The prison number 'INVALID-PRISON-NUMBER' is not valid")
   end
 
   def expect_result_with_move(move)

--- a/spec/forms/detainee_spec.rb
+++ b/spec/forms/detainee_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Forms::Detainee, type: :form do
   let(:model) { Detainee.new }
   subject { described_class.new(model) }
 
+  let(:prison_number) { 'A1234Ab' }
   let(:params) {
     {
       forenames: 'Jimmy',
@@ -14,7 +15,7 @@ RSpec.describe Forms::Detainee, type: :form do
       cro_number: 'SOMECRO',
       pnc_number: 'SOMEPNC',
       aliases: 'The Nailfile, Crocodile Shoes',
-      prison_number: 'A1234AB',
+      prison_number: prison_number,
       image_filename: ''
     }.with_indifferent_access
   }
@@ -29,7 +30,7 @@ RSpec.describe Forms::Detainee, type: :form do
 
     it 'coerces params' do
       subject.validate(params)
-      coerced_params = params.merge(date_of_birth: Date.civil(1946, 12, 30))
+      coerced_params = params.merge(prison_number: prison_number.upcase, date_of_birth: Date.civil(1946, 12, 30))
       expect(subject.to_nested_hash).to eq coerced_params
     end
 

--- a/spec/forms/search_spec.rb
+++ b/spec/forms/search_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe Forms::Search, type: :form do
     end
   end
 
+  describe "#prison_number" do
+    it "returns an upcased string" do
+      subject.prison_number = "a1234bc"
+      expect(subject.prison_number).to eq "A1234BC"
+    end
+  end
+
   describe '#detainee' do
     context 'when the form is valid' do
       context 'when an detainee exists for a given prison number' do


### PR DESCRIPTION
The prison number should be upcased for querying the NOMIS API and
storing in the DB. A user doesn’t always input the prison number in
its upcased form which can result in failed search results on the
NOMIS API.