### PR TITLE
Add new option to display flexible toggle content for alert in move printout

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -232,7 +232,7 @@ table {
   font: 15px "Arial Narrow";
   font-weight: bold;
 
-  .alert-toggle-text {
+  .alert-toggle {
     padding-left: 5px;
     text-transform: uppercase;
     font: 15px "Arial Narrow";
@@ -262,7 +262,8 @@ table {
     float: left;
   }
 
-  .alert-toggle-text {
+  .alert-toggle {
+    border-radius: 5px;
     padding: 0 5px;
     margin-top: 3px;
     margin-right: 3px;

--- a/app/presenters/print/alert_presenter.rb
+++ b/app/presenters/print/alert_presenter.rb
@@ -7,12 +7,17 @@ module Print
       @view_context = options.fetch(:view_context)
       @status = options.fetch(:status, :off)
       @title = options[:title]
+      @toggle = options[:toggle]
       @text = options[:text]
     end
 
     def title
       return @title if @title.present?
       h.t("print.alerts.title.#{name}", default: name.to_s.humanize)
+    end
+
+    def on?
+      status == :on
     end
 
     def to_s
@@ -26,19 +31,31 @@ module Print
 
     private
 
-    attr_reader :view_context
+    attr_reader :view_context, :toggle
     alias h view_context
 
     def build_status_content
       h.content_tag(:div, class: "image #{alert_class}") do
         alert_contents = [h.content_tag(:span, title, class: 'alert-title')]
-        alert_contents << h.wicked_pdf_image_tag('ic_red_tick.png') if status == :on
+        alert_contents << toggle_content if toggle_content
         h.safe_join(alert_contents)
       end
     end
 
     def build_text_content
       h.content_tag(:span, text, class: 'alert-text')
+    end
+
+    def toggle_content
+      @toggle_content ||= build_toggle_content
+    end
+
+    def build_toggle_content
+      if toggle.present?
+        h.content_tag(:span, toggle, class: 'alert-toggle')
+      elsif on?
+        h.wicked_pdf_image_tag('ic_red_tick.png')
+      end
     end
 
     def alert_class

--- a/app/presenters/print/alert_presenter.rb
+++ b/app/presenters/print/alert_presenter.rb
@@ -16,10 +16,6 @@ module Print
       h.t("print.alerts.title.#{name}", default: name.to_s.humanize)
     end
 
-    def on?
-      status == :on
-    end
-
     def to_s
       h.content_tag(:div, class: 'alert-wrapper') do
         contents = []
@@ -34,10 +30,14 @@ module Print
     attr_reader :view_context, :toggle
     alias h view_context
 
+    def on?
+      status == :on
+    end
+
     def build_status_content
       h.content_tag(:div, class: "image #{alert_class}") do
         alert_contents = [h.content_tag(:span, title, class: 'alert-title')]
-        alert_contents << toggle_content if toggle_content
+        alert_contents << toggle_content
         h.safe_join(alert_contents)
       end
     end
@@ -59,7 +59,7 @@ module Print
     end
 
     def alert_class
-      status == :on ? 'alert-on' : 'alert-off'
+      on? ? 'alert-on' : 'alert-off'
     end
   end
 end

--- a/app/presenters/print/move_alerts_presenter.rb
+++ b/app/presenters/print/move_alerts_presenter.rb
@@ -34,7 +34,7 @@ module Print
     def csra_alert
       status = csra == 'high' ? :on : :off
       csra_text = csra == 'high' ? 'High' : 'Standard'
-      alert_for(:csra, status: status, text: csra_text)
+      alert_for(:csra, status: status, toggle: csra_text)
     end
 
     def category_a_alert

--- a/spec/features/printing_spec.rb
+++ b/spec/features/printing_spec.rb
@@ -124,8 +124,7 @@ RSpec.feature 'printing a PER', type: :feature do
     let(:alerts) {
       [
         "NOT FOR RELEASE ACCT RULE 45",
-        "E LIST CSRA CAT A MPV",
-        "Standard"
+        "E LIST CSRA STANDARD CAT A MPV"
       ]
     }
 
@@ -341,8 +340,8 @@ RSpec.feature 'printing a PER', type: :feature do
       [
         "NOT FOR RELEASE ACCT RULE 45",
         "Open",
-        "E LIST CSRA CAT A MPV",
-        "E-List-Escort High"
+        "E LIST CSRA HIGH CAT A MPV",
+        "E-List-Escort"
       ]
     }
 

--- a/spec/presenters/print/alert_presenter_spec.rb
+++ b/spec/presenters/print/alert_presenter_spec.rb
@@ -36,12 +36,33 @@ RSpec.describe Print::AlertPresenter, type: :presenter do
     end
   end
 
+  describe '#on?' do
+    context 'when alert is off' do
+      let(:status) { :off }
+      specify { expect(presenter.on?).to be_falsey }
+    end
+
+    context 'when alert is on' do
+      let(:status) { :on }
+      specify { expect(presenter.on?).to be_truthy }
+    end
+  end
+
   describe '#to_s' do
     context 'when the alert is off' do
       let(:status) { :off }
 
       it 'returns the appropriate content for when the alert is off' do
         expect(presenter.to_s).to eq('<div class="alert-wrapper"><div class="image alert-off"><span class="alert-title">Some alert</span></div></div>')
+      end
+
+      context 'and toggle content is provided' do
+        let(:toggle) { 'some toggle content' }
+        let(:options) { { status: status, toggle: toggle }.merge(default_options) }
+
+        it 'returns the appropriate content including the toggle content' do
+          expect(presenter.to_s).to eq('<div class="alert-wrapper"><div class="image alert-off"><span class="alert-title">Some alert</span><span class="alert-toggle">some toggle content</span></div></div>')
+        end
       end
     end
 
@@ -51,6 +72,15 @@ RSpec.describe Print::AlertPresenter, type: :presenter do
       it 'returns the appropriate content for when the alert is on' do
         expect(presenter.to_s).to match('<div class="image alert-on"><span class="alert-title">Some alert</span>')
         expect(presenter.to_s).to match('<img src=.* alt="Ic red tick"')
+      end
+
+      context 'and toggle content is provided' do
+        let(:toggle) { 'some toggle content' }
+        let(:options) { { status: status, toggle: toggle }.merge(default_options) }
+
+        it 'returns the appropriate content including the toggle content' do
+          expect(presenter.to_s).to eq('<div class="alert-wrapper"><div class="image alert-on"><span class="alert-title">Some alert</span><span class="alert-toggle">some toggle content</span></div></div>')
+        end
       end
     end
 

--- a/spec/presenters/print/alert_presenter_spec.rb
+++ b/spec/presenters/print/alert_presenter_spec.rb
@@ -36,18 +36,6 @@ RSpec.describe Print::AlertPresenter, type: :presenter do
     end
   end
 
-  describe '#on?' do
-    context 'when alert is off' do
-      let(:status) { :off }
-      specify { expect(presenter.on?).to be_falsey }
-    end
-
-    context 'when alert is on' do
-      let(:status) { :on }
-      specify { expect(presenter.on?).to be_truthy }
-    end
-  end
-
   describe '#to_s' do
     context 'when the alert is off' do
       let(:status) { :off }


### PR DESCRIPTION
In the alerts section for the printout is now possible to specify a new
option that enable a specifi alert to have a specific content for the
toggle alert instead of the default red tick that is displayed when the
alert is on.

Relates to: [Trello #30](https://trello.com/c/YbFEfMIj/30-as-someone-printing-out-a-completed-per-i-want-to-see-all-the-detainee-s-risk-markers)