### PR TITLE
Remove duplicate aliases retrieved from NOMS API

### DIFF
--- a/app/services/detainees/details_mapper.rb
+++ b/app/services/detainees/details_mapper.rb
@@ -70,10 +70,17 @@ module Detainees
 
     def mapped_aliases
       return if aliases.empty?
-      aliases.map do |a|
+      mapped = aliases.map do |a|
         names = [a['given_name'], a['middle_names'], a['surname']]
         mapped_names(names)
-      end.join(', ')
+      end
+      unique_aliases(mapped).join(', ')
+    end
+
+    def unique_aliases(list)
+      list.each_with_object([]) do |item, mem|
+        mem << item.titleize unless mem.include?(item.titleize)
+      end
     end
   end
 end

--- a/app/services/detainees/details_mapper.rb
+++ b/app/services/detainees/details_mapper.rb
@@ -11,7 +11,7 @@ module Detainees
       {
         prison_number: prison_number,
         forenames: mapped_forenames,
-        surname: details[:surname],
+        surname: surname,
         date_of_birth: mapped_dob,
         gender: mapped_gender,
         nationalities: details[:nationalities],
@@ -46,6 +46,10 @@ module Detainees
       [given_name, middle_names]
     end
 
+    def surname
+      mapped_names([details[:surname]])
+    end
+
     def mapped_forenames
       mapped_names(forenames)
     end
@@ -53,7 +57,7 @@ module Detainees
     def mapped_names(names)
       present_names = names.select(&:present?)
       return if present_names.empty?
-      present_names.join(' ')
+      present_names.join(' ').upcase
     end
 
     def gender
@@ -70,17 +74,10 @@ module Detainees
 
     def mapped_aliases
       return if aliases.empty?
-      mapped = aliases.map do |a|
+      aliases.map do |a|
         names = [a['given_name'], a['middle_names'], a['surname']]
         mapped_names(names)
-      end
-      unique_aliases(mapped).join(', ')
-    end
-
-    def unique_aliases(list)
-      list.each_with_object([]) do |item, mem|
-        mem << item.titleize unless mem.include?(item.titleize)
-      end
+      end.uniq.join(', ')
     end
   end
 end

--- a/spec/features/detainee_creation_spec.rb
+++ b/spec/features/detainee_creation_spec.rb
@@ -42,8 +42,8 @@ RSpec.feature 'Detainee creation', type: :feature do
     }
     let(:expected_field_values) {
       {
-        surname: 'Doe',
-        forenames: 'John C.',
+        surname: 'DOE',
+        forenames: 'JOHN C.',
         date_of_birth: '11/09/1975',
         nationalities: 'British',
         gender: 'male',

--- a/spec/services/detainees/details_fetcher_spec.rb
+++ b/spec/services/detainees/details_fetcher_spec.rb
@@ -130,8 +130,8 @@ RSpec.describe Detainees::DetailsFetcher do
     it 'returns a mapped hash for the detainee data retrieved' do
       expected_response = {
         prison_number: prison_number,
-        forenames: 'John C.',
-        surname: 'Doe',
+        forenames: 'JOHN C.',
+        surname: 'DOE',
         date_of_birth: '23/01/1969',
         gender: 'male',
         nationalities: 'American',

--- a/spec/services/detainees/details_mapper_spec.rb
+++ b/spec/services/detainees/details_mapper_spec.rb
@@ -33,14 +33,14 @@ RSpec.describe Detainees::DetailsMapper do
   let(:expected_result) {
     {
       prison_number: prison_number,
-      forenames: 'John C.',
-      surname: 'Doe',
+      forenames: 'JOHN C.',
+      surname: 'DOE',
       date_of_birth: '23/01/1969',
       gender: 'male',
       nationalities: 'French',
       pnc_number: '12344',
       cro_number: '54321',
-      aliases: 'James Bond, Tom Ford'
+      aliases: 'JAMES BOND, TOM FORD'
     }.with_indifferent_access
   }
 
@@ -50,14 +50,14 @@ RSpec.describe Detainees::DetailsMapper do
     result = mapper.call
     expected_result = {
       prison_number: prison_number,
-      forenames: 'John C.',
-      surname: 'Doe',
+      forenames: 'JOHN C.',
+      surname: 'DOE',
       date_of_birth: '23/01/1969',
       gender: 'male',
       nationalities: 'French',
       pnc_number: '12344',
       cro_number: '54321',
-      aliases: 'James Bond, Tom Ford'
+      aliases: 'JAMES BOND, TOM FORD'
     }.with_indifferent_access
     expect(result).to eq(expected_result)
   end
@@ -74,7 +74,7 @@ RSpec.describe Detainees::DetailsMapper do
     let(:middle_names) { '' }
 
     it 'returns the forenames containing only the given name' do
-      expect(mapper.call).to eq(expected_result.merge('forenames' => 'John'))
+      expect(mapper.call).to eq(expected_result.merge('forenames' => 'JOHN'))
     end
   end
 
@@ -84,6 +84,15 @@ RSpec.describe Detainees::DetailsMapper do
 
     it 'returns the forenames as nil' do
       expect(mapper.call).to eq(expected_result.merge('forenames' => nil))
+    end
+  end
+
+  context 'when retrieved given name or middle names are not normalised' do
+    let(:given_name) { 'McDonald' }
+    let(:middle_names) { 'C.' }
+
+    it 'returns the normalised forenames' do
+      expect(mapper.call).to eq(expected_result.merge('forenames' => 'MCDONALD C.'))
     end
   end
 
@@ -179,7 +188,7 @@ RSpec.describe Detainees::DetailsMapper do
     let(:aliases) { [{ 'given_name' => 'James', 'middle_names' => 'C. Reilly', 'date_of_birth' => '1969-01-24' }] }
 
     it 'returns the remain names for that aliases' do
-      expect(mapper.call).to eq(expected_result.merge('aliases' => 'James C. Reilly'))
+      expect(mapper.call).to eq(expected_result.merge('aliases' => 'JAMES C. REILLY'))
     end
   end
 
@@ -187,7 +196,7 @@ RSpec.describe Detainees::DetailsMapper do
     let(:aliases) { [{ 'given_name' => 'James', 'surname' => 'Lovett', 'date_of_birth' => '1969-01-24' }] }
 
     it 'returns the remain names for that aliases' do
-      expect(mapper.call).to eq(expected_result.merge('aliases' => 'James Lovett'))
+      expect(mapper.call).to eq(expected_result.merge('aliases' => 'JAMES LOVETT'))
     end
   end
 
@@ -195,7 +204,7 @@ RSpec.describe Detainees::DetailsMapper do
     let(:aliases) { [{ 'middle_names' => 'C. Reilly', 'surname' => 'Lovett', 'date_of_birth' => '1969-01-24' }] }
 
     it 'returns the remain names for that aliases' do
-      expect(mapper.call).to eq(expected_result.merge('aliases' => 'C. Reilly Lovett'))
+      expect(mapper.call).to eq(expected_result.merge('aliases' => 'C. REILLY LOVETT'))
     end
   end
 
@@ -209,7 +218,7 @@ RSpec.describe Detainees::DetailsMapper do
     }
 
     it 'returns a list of the unique aliases' do
-      expect(mapper.call).to eq(expected_result.merge('aliases' => 'John Unique, Tom Duplicate'))
+      expect(mapper.call).to eq(expected_result.merge('aliases' => 'JOHN UNIQUE, TOM DUPLICATE'))
     end
   end
 end

--- a/spec/services/detainees/details_mapper_spec.rb
+++ b/spec/services/detainees/details_mapper_spec.rb
@@ -198,4 +198,18 @@ RSpec.describe Detainees::DetailsMapper do
       expect(mapper.call).to eq(expected_result.merge('aliases' => 'C. Reilly Lovett'))
     end
   end
+
+  context 'when detainee has duplicate aliases' do
+    let(:aliases) {
+      [
+        { 'given_name' => 'John', 'surname' => 'Unique' },
+        { 'given_name' => 'Tom', 'surname' => 'Duplicate' },
+        { 'given_name' => 'TOM', 'surname' => 'DUPLICATE' }
+      ]
+    }
+
+    it 'returns a list of the unique aliases' do
+      expect(mapper.call).to eq(expected_result.merge('aliases' => 'John Unique, Tom Duplicate'))
+    end
+  end
 end


### PR DESCRIPTION
[Trello #80](https://trello.com/c/QYVVujMh/80-as-a-receiver-of-the-per-i-only-want-to-see-aliases-that-are-alternatives-to-the-current-name-by-which-they-are-known-i-don-t-wa)

Note: The data the NOMS API doesn't seem to be normalised, so there's a
lot of information that we retrieve that is not well formatted or
contains duplicate information. The detainee aliases is one of these
examples where we get a lot of duplicates.

The API should be really taking care of this issues, but until that
happens we need to handle this at the client level.