### PR TITLE
Adds a rake tasks to soft delete all unissued escorts past their date

### DIFF
--- a/app/models/escort.rb
+++ b/app/models/escort.rb
@@ -3,10 +3,13 @@ class Escort < ApplicationRecord
   has_one :detainee
   has_one :move
 
+  default_scope { where(deleted_at: nil) }
+
   scope :for_date, ->(date) { eager_load(move: [:move_workflow]).where(moves: { date: date }) }
   scope :with_incomplete_risk, -> { joins(move: [:risk_workflow]).merge(Workflow.not_confirmed) }
   scope :with_incomplete_healthcare, -> { joins(move: [:healthcare_workflow]).merge(Workflow.not_confirmed) }
   scope :with_incomplete_offences, -> { joins(move: [:offences_workflow]).merge(Workflow.not_confirmed) }
+  scope :active, -> { joins(:move).merge(Move.active) }
 
   delegate :risk_complete?, :healthcare_complete?, :offences_complete?, to: :move, allow_nil: true
 

--- a/app/services/escorts/delete_historic_unissued.rb
+++ b/app/services/escorts/delete_historic_unissued.rb
@@ -1,0 +1,13 @@
+module Escorts
+  module DeleteHistoricUnissued
+    def call(options = {})
+      logger = options.fetch(:logger, Rails.logger)
+      scope = Escort.active.where('date(now()) - date(date) >= 1')
+      count = scope.count
+      logger.info("Soft deleting #{count} unissued escorts past their date")
+      scope.in_batches.update_all(deleted_at: Time.now.utc)
+      logger.info("Soft deleted #{count} unissued escorts")
+    end
+    module_function :call
+  end
+end

--- a/db/migrate/20170424141759_add_deleted_at_to_escorts.rb
+++ b/db/migrate/20170424141759_add_deleted_at_to_escorts.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToEscorts < ActiveRecord::Migration[5.0]
+  def change
+    add_column :escorts, :deleted_at, :datetime
+    add_index :escorts, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170421111706) do
+ActiveRecord::Schema.define(version: 20170424141759) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,8 @@ ActiveRecord::Schema.define(version: 20170421111706) do
     t.string   "prison_number"
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
+    t.datetime "deleted_at"
+    t.index ["deleted_at"], name: "index_escorts_on_deleted_at", using: :btree
     t.index ["prison_number"], name: "index_escorts_on_prison_number", using: :btree
   end
 

--- a/lib/tasks/escorts.rake
+++ b/lib/tasks/escorts.rake
@@ -1,0 +1,8 @@
+namespace :escorts do
+  namespace :unissued do
+    desc '(soft) deletes unissued escorts past their move date'
+    task delete: :environment do
+      Escorts::DeleteHistoricUnissued.call(logger: Logger.new(STDOUT))
+    end
+  end
+end

--- a/spec/models/escort_spec.rb
+++ b/spec/models/escort_spec.rb
@@ -1,6 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe Escort do
+  describe 'default scope' do
+    it 'returns only the escorts that have not been deleted' do
+      create_list(:escort, 2)
+      create(:escort, deleted_at: 1.hour.ago)
+      expect(described_class.unscoped.count).to eq(3)
+      expect(described_class.count).to eq(2)
+    end
+  end
+
   describe '#risk' do
     context 'when there is no associated detainee' do
       let(:escort) { create(:escort) }

--- a/spec/services/escorts/delete_historic_unissued_spec.rb
+++ b/spec/services/escorts/delete_historic_unissued_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Escorts::DeleteHistoricUnissued do
+  let(:options) { { logger: Rails.logger } }
+
+  it 'soft deletes all unissued escorts past their date' do
+    create(:escort, move: create(:move, date: 3.days.ago))
+    create(:escort, move: create(:move, date: 1.day.ago))
+
+    create(:escort, move: create(:move, :issued, date: 3.days.ago))
+    create(:escort, move: create(:move, :issued, date: 1.day.ago))
+
+    create(:escort, move: create(:move, date: 1.hour.ago))
+    create(:escort, move: create(:move, :issued, date: 1.hour.ago))
+
+    expect { described_class.call(options) }.to change { Escort.count }.from(6).to(4)
+    expect(Escort.unscoped.count).to eq(6)
+    expect(Escort.unscoped.where('deleted_at is not null').count).to eq(2)
+  end
+end


### PR DESCRIPTION
Includes:
- Migration to add deleted_at field to moves
- Add default scope to moves to only return non-deleted moves by default
- Add service to delete all unissued moves past their date
- Add rake task to call the service