### PR TITLE
Nomis offences

### DIFF
--- a/app/controllers/offences_controller.rb
+++ b/app/controllers/offences_controller.rb
@@ -44,6 +44,13 @@ class OffencesController < DetaineeController
   end
 
   def fetch_offences
-    Detainees::OffencesFetcher.new(detainee.prison_number).call.data.map(&:attributes)
+    result = Detainees::OffencesFetcher.new(detainee.prison_number).call
+    flash_fetcher_error(result.error) if result.error.present?
+    result.data.map(&:attributes)
+  end
+
+  def flash_fetcher_error(error)
+    flash.now[:warning] ||= []
+    flash.now[:warning] << t("alerts.offences.#{error}")
   end
 end

--- a/app/controllers/offences_controller.rb
+++ b/app/controllers/offences_controller.rb
@@ -2,6 +2,7 @@ class OffencesController < DetaineeController
   before_action :add_offence, only: [:update]
 
   def show
+    prepopulate_current_offences
     form.validate(flash[:form_data]) if flash[:form_data]
     form.prepopulate!
     render locals: { form: form }
@@ -34,5 +35,15 @@ class OffencesController < DetaineeController
 
   def form
     @_form ||= Forms::Offences.new(offences)
+  end
+
+  private(*delegate(:current_offences, to: :offences))
+
+  def prepopulate_current_offences
+    current_offences.blank? && current_offences.build(fetch_offences)
+  end
+
+  def fetch_offences
+    Detainees::OffencesFetcher.new(detainee.prison_number).call.data.map(&:attributes)
   end
 end

--- a/app/services/detainees/base_fetcher.rb
+++ b/app/services/detainees/base_fetcher.rb
@@ -29,6 +29,20 @@ module Detainees
       }[http_status] || 'api_error'
     end
 
+    def with_error_handling(&_blk)
+      yield
+    rescue Nomis::HttpError => e
+      log_api_error(e.inspect)
+      error_code = error_code_for_http_status(e.response.status)
+      error_response(error_code)
+    rescue Nomis::ApiError => e
+      log_api_error(e.inspect)
+      error_response('api_error')
+    rescue => e
+      log_error("Internal error: #{e.inspect}")
+      error_response('internal_error')
+    end
+
     def log(message, options = {})
       severity = options.fetch(:severity, :info)
       prefix = options[:prefix]

--- a/app/services/detainees/base_fetcher.rb
+++ b/app/services/detainees/base_fetcher.rb
@@ -22,6 +22,10 @@ module Detainees
       FetcherResponse.new({}, error: error_code)
     end
 
+    def empty_response
+      FetcherResponse.new({})
+    end
+
     def error_code_for_http_status(http_status)
       {
         404 => 'not_found',

--- a/app/services/detainees/details_fetcher.rb
+++ b/app/services/detainees/details_fetcher.rb
@@ -2,7 +2,7 @@ module Detainees
   class DetailsFetcher < BaseFetcher
     def call
       with_error_handling do
-        return FetcherResponse.new({}) unless prison_number.present?
+        return empty_response unless prison_number.present?
         fetch_details
         successful_response(detainee_attrs)
       end

--- a/app/services/detainees/details_fetcher.rb
+++ b/app/services/detainees/details_fetcher.rb
@@ -1,19 +1,11 @@
 module Detainees
   class DetailsFetcher < BaseFetcher
     def call
-      return FetcherResponse.new({}) unless prison_number.present?
-      fetch_details
-      successful_response(detainee_attrs)
-    rescue Nomis::HttpError => e
-      log_api_error(e.inspect)
-      error_code = error_code_for_http_status(e.response.status)
-      error_response(error_code)
-    rescue Nomis::ApiError => e
-      log_api_error(e.inspect)
-      error_response('api_error')
-    rescue => e
-      log_error("Internal error: #{e.inspect}")
-      error_response('internal_error')
+      with_error_handling do
+        return FetcherResponse.new({}) unless prison_number.present?
+        fetch_details
+        successful_response(detainee_attrs)
+      end
     end
 
     private

--- a/app/services/detainees/fetcher_response.rb
+++ b/app/services/detainees/fetcher_response.rb
@@ -10,6 +10,7 @@ module Detainees
     def to_h
       hash
     end
+    alias data to_h
 
     private
 

--- a/app/services/detainees/image_fetcher.rb
+++ b/app/services/detainees/image_fetcher.rb
@@ -2,7 +2,7 @@ module Detainees
   class ImageFetcher < BaseFetcher
     def call
       with_error_handling do
-        return FetcherResponse.new({}) unless prison_number.present?
+        return empty_response unless prison_number.present?
         fetch_image
         image_response
       end

--- a/app/services/detainees/image_fetcher.rb
+++ b/app/services/detainees/image_fetcher.rb
@@ -1,19 +1,11 @@
 module Detainees
   class ImageFetcher < BaseFetcher
     def call
-      return FetcherResponse.new({}) unless prison_number.present?
-      fetch_image
-      image_response
-    rescue Nomis::HttpError => e
-      log_api_error(e.inspect)
-      error_code = error_code_for_http_status(e.response.status)
-      error_response(error_code)
-    rescue Nomis::ApiError => e
-      log_api_error(e.inspect)
-      error_response('api_error')
-    rescue => e
-      log_error("Internal error: #{e.inspect}")
-      error_response('internal_error')
+      with_error_handling do
+        return FetcherResponse.new({}) unless prison_number.present?
+        fetch_image
+        image_response
+      end
     end
 
     private

--- a/app/services/detainees/offences_fetcher.rb
+++ b/app/services/detainees/offences_fetcher.rb
@@ -1,0 +1,21 @@
+module Detainees
+  class OffencesFetcher < BaseFetcher
+    def call
+      with_error_handling do
+        fetch_offences
+        successful_response(mapped_offences)
+      end
+    end
+
+    private
+
+    def fetch_offences
+      log_api_request "Requesting offences for offender with NOMS id #{prison_number}"
+      @response = api_client.get("/offenders/#{prison_number}/charges")
+    end
+
+    def mapped_offences
+      OffencesMapper.new(response).call
+    end
+  end
+end

--- a/app/services/detainees/offences_mapper.rb
+++ b/app/services/detainees/offences_mapper.rb
@@ -1,0 +1,52 @@
+module Detainees
+  class OffencesMapper
+    module BookingsList
+      class Offence
+        include Virtus.value_object
+        attribute :offence, String
+        attribute :case_reference, String
+      end
+
+      refine Array do
+        def active_cases_grouped_by_case_reference
+          find { |b| b['booking_active'] }.
+            fetch('legal_cases').
+            select { |lc| lc['case_active'] }.
+            group_by { |lc| lc['case_info_number'] }
+        end
+
+        def value_objects
+          map { |attributes| Offence.new(attributes) }
+        end
+      end
+
+      refine Hash do
+        def extract_offences_with_normalised_keys_and_case_reference
+          flat_map do |(case_ref, cases)|
+            cases.
+              flat_map  { |c| c['charges'] }.
+              map       do |c|
+                offence = c['offence']
+                offence['offence'] = offence.delete('desc')
+                offence.merge('case_reference' => case_ref)
+              end
+          end
+        end
+      end
+    end
+    private_constant :BookingsList
+
+    using BookingsList
+
+    def initialize(offences)
+      @offences = offences
+    end
+
+    def call
+      @offences['bookings'].
+        active_cases_grouped_by_case_reference.
+        extract_offences_with_normalised_keys_and_case_reference.
+        value_objects
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -555,6 +555,8 @@ en:
         unavailable: "Image Look-Up function is not currently available. Please try again later"
         not_found: "Look-Up function for photograph returned no image. Either try again later or attach photograph manually to print out"
         invalid_input: The provided prison number is not valid, please try again with a valid prison number
+    offences:
+      api_error: Offences aren't available right now, please try again or fill in the offences below
     move:
       print:
         unauthorized: "Move is not in a status that can be printed"

--- a/spec/features/adding_offences_to_a_move_spec.rb
+++ b/spec/features/adding_offences_to_a_move_spec.rb
@@ -1,0 +1,61 @@
+require 'feature_helper'
+
+RSpec.feature 'Adding offences to a move', type: :feature do
+  let(:detainee) { create(:detainee, :with_active_move, :with_no_offences) }
+  let(:fixture_json_file_path) { Rails.root.join('spec', 'support', 'fixtures', 'valid-nomis-charges.json') }
+  let(:valid_json) { File.read(fixture_json_file_path) }
+  
+  let(:expected_offences) {
+    [
+      { name: "Attempt burglary dwelling with intent to inflict grievous bodily harm (CR: T20117495)" },
+      { name: "Abstract / use without authority electricity (CR: T20117495)" }
+    ]
+  }
+  
+  before do
+    login
+    visit detainee_path(detainee)
+  end
+
+  scenario 'saving pre populated offences' do
+    stub_nomis_api_request(:get, "/offenders/#{detainee.prison_number}/charges", body: valid_json)
+
+    profile.click_edit_offences
+    offences.save_and_continue
+    profile.confirm_current_offences(expected_offences)
+  end
+  
+  let(:expected_offences_after_ammendment) {
+    [
+      { name: "Updated text (CR: NEW_REFERENCE)" },
+      { name: "Abstract / use without authority electricity (CR: T20117495)" },
+      { name: "Some other description (CR: ANOTHER_REFERENCE)" }
+    ]
+  }
+
+  scenario 'ammending pre populated offences' do
+    stub_nomis_api_request(:get, "/offenders/#{detainee.prison_number}/charges", body: valid_json)
+
+    profile.click_edit_offences
+    offences.update(index: 0, description: "Updated text", case_reference: "NEW_REFERENCE")
+    offences.add(description: "Some other description", case_reference: "ANOTHER_REFERENCE")
+    offences.save_and_continue
+    profile.confirm_current_offences(expected_offences_after_ammendment)
+  end
+  
+  let(:expected_offences_after_failure) {
+    [
+      { name: "Manually adding an offence (CR: YET_ANOTHER_REFERENCE)" }
+    ]
+  }
+  
+  scenario 'saving an offence after pre populating offences fails' do
+    stub_nomis_api_request(:get, "/offenders/#{detainee.prison_number}/charges", status: 500)
+
+    profile.click_edit_offences
+    offences.confirm_api_unavailable_warning
+    offences.update(index: 0, description: "Manually adding an offence", case_reference: "YET_ANOTHER_REFERENCE")
+    offences.save_and_continue
+    profile.confirm_current_offences(expected_offences_after_failure)
+  end
+end

--- a/spec/features/detainee_profile_page_spec.rb
+++ b/spec/features/detainee_profile_page_spec.rb
@@ -369,6 +369,10 @@ RSpec.feature 'detainee profile page', type: :feature do
   end
 
   context 'offences section' do
+    before do
+      stub_nomis_api_request(:get, "/offenders/#{detainee.prison_number}/charges", status: 404)
+    end
+
     let(:detainee) { create(:detainee, :with_active_move, :with_no_offences) }
     let(:active_move) { detainee.active_move }
     let(:current_offences) {

--- a/spec/features/filling_in_a_per_spec.rb
+++ b/spec/features/filling_in_a_per_spec.rb
@@ -48,6 +48,9 @@ RSpec.feature 'filling in a PER', type: :feature do
     risk_summary.confirm_and_save
 
     profile.confirm_risk_details(risk_data)
+
+    stub_nomis_api_request(:get, "/offenders/#{detainee.prison_number}/charges", status: 404)
+
     profile.click_edit_offences
 
     offences.complete_form(offences_data)

--- a/spec/features/pages/offences.rb
+++ b/spec/features/pages/offences.rb
@@ -12,7 +12,30 @@ module Page
       end
     end
 
+    def update(index:, description:, case_reference:)
+      offence_row = all(".multiple-wrapper")[index]
+      insert_into_row(offence_row, description, case_reference)
+    end
+
+    def add(description:, case_reference:)
+      click_button 'Add offence'
+      offence_row = all(".multiple-wrapper").last
+      insert_into_row(offence_row, description, case_reference)
+    end
+
+    def confirm_api_unavailable_warning
+      expect(page).
+        to have_content("Offences aren't available right now, please try again or fill in the offences below")
+    end
+
     private
+
+    def insert_into_row(row, description, case_reference)
+      within row do
+        page.fill_in "Offence", with: description
+        page.fill_in "Case reference", with: case_reference
+      end
+    end
 
     def fill_current_offences(offences)
       return unless offences && !offences.empty?

--- a/spec/services/detainees/offences_fetcher_spec.rb
+++ b/spec/services/detainees/offences_fetcher_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe Detainees::OffencesFetcher do
+  let(:prison_number) { 'A1234AB' }
+  subject(:result) { described_class.new(prison_number).call }
+  
+  context 'unsuccessful api calls' do
+    context 'when the NOMIS API response is 400' do
+      before do
+        stub_charges_api_request(status: 400)
+      end
+      
+      specify {
+        expect(result.data).to eq({})
+        expect(result.error).to eq('invalid_input')
+      }
+    end
+    
+    context 'when the NOMIS API response is 404' do
+      before do
+        stub_charges_api_request(status: 404)
+      end
+      
+      specify {
+        expect(result.data).to eq({})
+        expect(result.error).to eq('not_found')
+      }
+    end
+    
+    context 'when the NOMIS API response is 500' do
+      before do
+        stub_charges_api_request(status: 500)
+      end
+      
+      specify {
+        expect(result.data).to eq({})
+        expect(result.error).to eq('api_error')
+      }
+    end
+    
+    context 'when the NOMIS API returns invalid JSON' do
+      before do
+        stub_charges_api_request(body: 'invalid-json')
+      end
+      
+      specify {
+        expect(result.data).to eq({})
+        expect(result.error).to eq('api_error')
+      }
+    end
+  end
+  
+  context 'when the NOMIS API returns a valid JSON response' do
+    let(:fixture_json_file_path) { 
+      Rails.root.join('spec', 'support', 'fixtures', 'valid-nomis-charges.json')
+    }
+    let(:valid_json) { File.read(fixture_json_file_path) }
+    
+    before do
+      stub_charges_api_request(body: valid_json)
+    end
+    
+    it 'transforms the api response returning offence data' do
+      offence_attributes = result.data.map(&:attributes)
+      
+      expect(offence_attributes).to match_array(
+        [
+          { 
+            offence: 'Attempt burglary dwelling with intent to inflict grievous bodily harm',
+            case_reference: 'T20117495'
+          },
+          { 
+            offence: 'Abstract / use without authority electricity',
+            case_reference: 'T20117495'
+          }
+        ]
+      )
+    end
+  end
+  
+  def stub_charges_api_request(options)
+    stub_nomis_api_request(:get, "/offenders/#{prison_number}/charges", options)
+  end
+end

--- a/spec/support/fixtures/valid-nomis-charges.json
+++ b/spec/support/fixtures/valid-nomis-charges.json
@@ -1,0 +1,88 @@
+{
+  "bookings": [
+    {
+      "booking_no": "A00001",
+      "booking_active": false,
+      "booking_started": "2011-12-19",
+      "booking_ended": "2012-02-17",
+      "legal_cases": [
+
+      ]
+    },
+    {
+      "booking_no": "A00002",
+      "booking_active": true,
+      "booking_started": "2011-11-07",
+      "release_date": "2016-01-01",
+      "legal_cases": [
+        {
+          "case_info_number": "T20117495",
+          "case_active": true,
+          "case_started": "2010-03-01",
+          "court": {
+            "code": "LEEDCC",
+            "desc": "Leeds Crown Court"
+          },
+          "legal_case_type": {
+            "code": "A",
+            "desc": "Adult"
+          },
+          "charges": [
+            {
+              "statute": {
+                "code": "TH68",
+                "desc": "Theft Act 1968"
+              },
+              "offence": {
+                "code": "TH68028A",
+                "desc": "Attempt burglary dwelling with intent to inflict grievous bodily harm"
+              },
+              "most_serious": true,
+              "charge_active": true,
+              "severity_ranking": "66",
+              "result": {
+                "code": "1007",
+                "desc": "Detention"
+              },
+              "disposition": {
+                "code": "F",
+                "desc": "Final"
+              },
+              "convicted": true,
+              "imprisonment_status": {
+              },
+              "band": {
+              }
+            },
+            {
+              "statute": {
+                "code": "TH68",
+                "desc": "Theft Act 1968"
+              },
+              "offence": {
+                "code": "TH68058",
+                "desc": "Abstract / use without authority electricity"
+              },
+              "most_serious": false,
+              "charge_active": true,
+              "severity_ranking": "86",
+              "result": {
+                "code": "1007",
+                "desc": "Detention"
+              },
+              "disposition": {
+                "code": "F",
+                "desc": "Final"
+              },
+              "convicted": true,
+              "imprisonment_status": {
+              },
+              "band": {
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Fetch nomis offences from nomis endpoint
- [x] Extract current offences only
- [x] Update the UI with the fetched offences
- [x] Inform the user when the api errors via the flash

Ticket: [#87](https://trello.com/c/RTRTgXge/87-5-implement-offences-interface-to-work-off-nomis)

<img width="975" alt="screen shot 2017-04-03 at 17 38 16" src="https://cloud.githubusercontent.com/assets/1006365/24620129/6b06b246-1894-11e7-81d1-0add47fb3b63.png">