### PR TITLE
Hide remove checkbox for multiples

### DIFF
--- a/app/assets/stylesheets/moving_people_safely/_forms.scss
+++ b/app/assets/stylesheets/moving_people_safely/_forms.scss
@@ -69,7 +69,7 @@ form {
 
       input[type='checkbox'] {
         position: absolute;
-        left: -1000px;
+        left: -2000px;
       }
     }
 


### PR DESCRIPTION
Same approach as before but handles wider screens.

#### Before:
<img width="1098" alt="screen shot 2017-04-05 at 14 50 18" src="https://cloud.githubusercontent.com/assets/1006365/24708884/1ffd88a6-1a10-11e7-885d-67c2fde856ae.png">

#### After:
<img width="1118" alt="screen shot 2017-04-05 at 14 51 13" src="https://cloud.githubusercontent.com/assets/1006365/24708885/1ffd9a6c-1a10-11e7-9ff8-184e19bd0eeb.png">
