### PR TITLE
Add ability to retrieve application version info

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ end
 
 group :test do
   gem 'capybara'
+  gem 'climate_control'
   gem 'codeclimate-test-reporter', require: nil
   gem 'database_cleaner'
   gem 'diffy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
       xpath (~> 2.0)
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
+    climate_control (0.1.0)
     cliver (0.3.2)
     codeclimate-test-reporter (0.6.0)
       simplecov (>= 0.7.1, < 1.0.0)
@@ -370,6 +371,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   capybara
+  climate_control
   codeclimate-test-reporter
   connection_pool
   countries

--- a/app/controllers/ping_controller.rb
+++ b/app/controllers/ping_controller.rb
@@ -1,0 +1,17 @@
+class PingController < ActionController::Base
+  def show
+    render json: version_info
+  end
+
+  private
+
+  def version_info
+    {
+      build_date: ENV.fetch('APP_BUILD_DATE'),
+      build_tag: ENV.fetch('APP_BUILD_TAG'),
+      commit: ENV.fetch('APP_GIT_COMMIT')
+    }
+  rescue KeyError
+    {}
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   get '/auth/:provider/callback', to: 'sessions#create'
   resource :session, only: %i[ new destroy ]
 
+  get :ping, to: 'ping#show'
+
   resources :escorts, only: %i[new create show] do
     resource :detainee do
       resource :image, only: %i[show], controller: 'detainees/images', constraints: { format: 'jpg' }

--- a/spec/requests/ping_spec.rb
+++ b/spec/requests/ping_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'Pings', type: :request do
+  describe 'GET /ping' do
+    context 'when the correct environment variables have been set during the deploy process' do
+      before do
+        allow(ENV).to receive(:fetch).with('APP_BUILD_DATE').and_return('2017-04-06T14:47:13+0000')
+        allow(ENV).to receive(:fetch).with('APP_BUILD_TAG').and_return('branch-name.partial-sha')
+        allow(ENV).to receive(:fetch).with('APP_GIT_COMMIT').and_return('some-sha-from-git')
+      end
+
+      it 'returns json containing the applications version information' do
+        get '/ping'
+
+        expect(response.body).to eq(
+          {
+            build_date: '2017-04-06T14:47:13+0000',
+            build_tag: 'branch-name.partial-sha',
+            commit: 'some-sha-from-git'
+          }.to_json
+        )
+      end
+    end
+
+    context 'when the environment variables are not present' do
+      it 'returns an empty json object' do
+        get '/ping'
+
+        expect(response.body).to eq({}.to_json)
+      end
+    end
+  end
+end

--- a/spec/requests/ping_spec.rb
+++ b/spec/requests/ping_spec.rb
@@ -3,10 +3,14 @@ require 'rails_helper'
 RSpec.describe 'Pings', type: :request do
   describe 'GET /ping' do
     context 'when the correct environment variables have been set during the deploy process' do
-      before do
-        allow(ENV).to receive(:fetch).with('APP_BUILD_DATE').and_return('2017-04-06T14:47:13+0000')
-        allow(ENV).to receive(:fetch).with('APP_BUILD_TAG').and_return('branch-name.partial-sha')
-        allow(ENV).to receive(:fetch).with('APP_GIT_COMMIT').and_return('some-sha-from-git')
+      around do |example|
+        ClimateControl.modify(
+          'APP_BUILD_DATE' => '2017-04-06T14:47:13+0000',
+          'APP_BUILD_TAG' => 'branch-name.partial-sha',
+          'APP_GIT_COMMIT' => 'some-sha-from-git'
+        ) do
+          example.run
+        end
       end
 
       it 'returns json containing the applications version information' do


### PR DESCRIPTION
It’s useful across the environments to be able to see what has been
deployed and when it was deployed.

The information returned is consistent with what other apps in the
department return.

Example response from dev:

```json
{
  "build_date":"2017-04-11T14:31:18+0000",
  "build_tag":"pingendpoint.9a6ab35",
  "commit":"9a6ab3526cbf4b26869be7042398682b6a40b241"
}
```