### PR TITLE
Use action controllers view context to build image tag

### DIFF
--- a/app/presenters/print/detainee_presenter.rb
+++ b/app/presenters/print/detainee_presenter.rb
@@ -1,8 +1,5 @@
 module Print
   class DetaineePresenter < SimpleDelegator
-    include WickedPdf::WickedPdfHelper::Assets
-    include ActionView::Helpers::AssetTagHelper
-
     def identifier
       "#{prison_number}: #{surname}"
     end
@@ -35,13 +32,17 @@ module Print
 
     def image
       if model.image.present?
-        image_tag("data:image;base64,#{model.image}")
+        h.image_tag("data:image;base64,#{model.image}")
       else
-        wicked_pdf_image_tag('photo_unavailable.png')
+        h.wicked_pdf_image_tag('photo_unavailable.png')
       end
     end
 
     private
+
+    def h
+      @h ||= ActionController::Base.new.view_context
+    end
 
     def model
       __getobj__


### PR DESCRIPTION
This fixes the missing placeholder photo when an offender doesn't have a mugshot.

The problem is pre-compilation vs not having pre-compilation of assets in dev & test & the way asset lookup works outside of a controller context. Including the helpers alone that provide the necessary image methods won't work in prod.

This provides similar functionality as that found in the alerts presenter that currently works in production.