### PR TITLE
Don't throw an error on nil move date

### DIFF
--- a/app/views/homepage/_result.html.slim
+++ b/app/views/homepage/_result.html.slim
@@ -19,7 +19,7 @@ table
 
     - if move
       td = move.to
-      td = move.date.to_s(:humanized)
+      td = move.date&.to_s(:humanized)
     - else
       td colspan=2
 


### PR DESCRIPTION
When we duplicate an escort from an existing one, we copy all
the data from the old one except the move date that we know has
to be different. If we interrupt the process before setting a
date for the move, we end up having escorts with moves with 
a nil date. This fix will prevent the results from the search
on the dashboard from throwing an error.