### PR TITLE
Remove breadcrumb link for detainee page in move forms

### DIFF
--- a/app/helpers/breadcrumbs_helper.rb
+++ b/app/helpers/breadcrumbs_helper.rb
@@ -9,7 +9,7 @@ module BreadcrumbsHelper
     @root_breadcrumb ||= Breadcrumb.new('Home', root_path)
   end
 
-  def add_breadcrumb(title, url)
+  def add_breadcrumb(title, url = nil)
     breadcrumbs << Breadcrumb.new(title, url)
   end
   alias breadcrumb add_breadcrumb

--- a/app/views/detainees/edit.html.slim
+++ b/app/views/detainees/edit.html.slim
@@ -1,6 +1,6 @@
 = content_for :breadcrumbs do
   - breadcrumbs_for_page root: true do
     - breadcrumb detainee_breadcrumb(escort.detainee), escort_path(escort)
-    - breadcrumb 'Detainee information', '#'
+    - breadcrumb 'Detainee information'
 
 = render partial: 'form', locals: { form: form, submit_path: escort_detainee_path(escort), method: :patch }

--- a/app/views/detainees/new.html.slim
+++ b/app/views/detainees/new.html.slim
@@ -1,5 +1,5 @@
 = content_for :breadcrumbs do
   - breadcrumbs_for_page root: true do
-    - breadcrumb 'Detainee information', '#'
+    - breadcrumb 'Detainee information'
 
 = render partial: 'form', locals: { form: form, submit_path: escort_detainee_path(escort), method: :post }

--- a/app/views/escorts/show.html.slim
+++ b/app/views/escorts/show.html.slim
@@ -1,6 +1,6 @@
 = content_for :breadcrumbs do
   - breadcrumbs_for_page root: true do
-    - breadcrumb detainee_breadcrumb(escort.detainee), '#'
+    - breadcrumb detainee_breadcrumb(escort.detainee)
 
 .escort
   = render partial: 'header', locals: { detainee: escort.detainee, alerts: EscortAlertsPresenter.new(escort) }

--- a/app/views/healthcare/show.html.slim
+++ b/app/views/healthcare/show.html.slim
@@ -2,7 +2,7 @@
   - breadcrumbs_for_page root: true do
     - breadcrumb detainee_breadcrumb(escort.detainee), escort_path(escort)
     - breadcrumb 'Healthcare summary', summary_escort_healthcare_path(escort)
-    - breadcrumb t("healthcare.form.title.#{form.name}"), '#'
+    - breadcrumb t("healthcare.form.title.#{form.name}")
 
 = render partial: 'shared/wizard_header'
 

--- a/app/views/moves/edit.html.slim
+++ b/app/views/moves/edit.html.slim
@@ -1,6 +1,6 @@
 = content_for :breadcrumbs do
   - breadcrumbs_for_page root: true do
-    - breadcrumb detainee_breadcrumb(escort.detainee), escort_path(escort)
-    - breadcrumb 'Move information', '#'
+    - breadcrumb detainee_breadcrumb(escort.detainee)
+    - breadcrumb 'Move information'
 
 = render partial: 'form', locals: { form: form, submit_path: escort_move_path(escort), method: :patch }

--- a/app/views/moves/new.html.slim
+++ b/app/views/moves/new.html.slim
@@ -1,6 +1,6 @@
 = content_for :breadcrumbs do
   - breadcrumbs_for_page root: true do
-    - breadcrumb detainee_breadcrumb(escort.detainee), escort_path(escort)
-    - breadcrumb 'Move information', '#'
+    - breadcrumb detainee_breadcrumb(escort.detainee)
+    - breadcrumb 'Move information'
 
 = render partial: 'form', locals: { form: form, submit_path: escort_move_path(escort), method: :post }

--- a/app/views/offences/show.html.slim
+++ b/app/views/offences/show.html.slim
@@ -1,7 +1,7 @@
 = content_for :breadcrumbs do
   - breadcrumbs_for_page root: true do
     - breadcrumb detainee_breadcrumb(escort.detainee), escort_path(escort)
-    - breadcrumb 'Offences', '#'
+    - breadcrumb 'Offences'
 
 .offences
   - if offences.needs_review?

--- a/app/views/risks/show.html.slim
+++ b/app/views/risks/show.html.slim
@@ -2,7 +2,7 @@
   - breadcrumbs_for_page root: true do
     - breadcrumb detainee_breadcrumb(escort.detainee), escort_path(escort)
     - breadcrumb 'Risk summary', summary_escort_risks_path(escort)
-    - breadcrumb t("risks.form.title.#{form.name}"), '#'
+    - breadcrumb t("risks.form.title.#{form.name}")
 
 = render partial: 'shared/wizard_header'
 

--- a/app/views/shared/_breadcrumbs.html.slim
+++ b/app/views/shared/_breadcrumbs.html.slim
@@ -1,7 +1,7 @@
 .breadcrumbs
   ol
     - breadcrumbs.each do |breadcrumb|
-      - unless breadcrumb == breadcrumbs.last
+      - if breadcrumb.url
         li = link_to breadcrumb.title, breadcrumb.url
       - else
         li = breadcrumb.title

--- a/app/views/summary/healthcare.html.slim
+++ b/app/views/summary/healthcare.html.slim
@@ -1,7 +1,7 @@
 = content_for :breadcrumbs do
   - breadcrumbs_for_page root: true do
     - breadcrumb detainee_breadcrumb(escort.detainee), escort_path(escort)
-    - breadcrumb 'Healthcare summary', '#'
+    - breadcrumb 'Healthcare summary'
 
 .summary
   = render partial: 'summary/status', locals: { workflow: healthcare, title: 'Healthcare' }

--- a/app/views/summary/risk.html.slim
+++ b/app/views/summary/risk.html.slim
@@ -1,7 +1,7 @@
 = content_for :breadcrumbs do
   - breadcrumbs_for_page root: true do
     - breadcrumb detainee_breadcrumb(escort.detainee), escort_path(escort)
-    - breadcrumb 'Risk summary', '#'
+    - breadcrumb 'Risk summary'
 
 .summary
   = render partial: 'summary/status', locals: { workflow: risk, title: 'Risk' }

--- a/spec/helpers/breadcrumbs_helper_spec.rb
+++ b/spec/helpers/breadcrumbs_helper_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe BreadcrumbsHelper, type: :helper do
       last_crumb = helper.breadcrumbs.last
       expect(last_crumb.title).to eq('Other')
       expect(last_crumb.url).to eq('/other-url')
+
+      expect {
+        helper.add_breadcrumb('No Link')
+      }.to change { helper.breadcrumbs.size }.from(2).to(3)
+      last_crumb = helper.breadcrumbs.last
+      expect(last_crumb.title).to eq('No Link')
+      expect(last_crumb.url).to be_nil
     end
   end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/mgPKiBBx/35-1-amend-breadcrumb-on-move-screen)

Breadcrumb in move forms no longer requires a link to the PER show page.