### PR TITLE
Update hostage taker text

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,4 +13,10 @@ module ApplicationHelper
   def select_values_for(field)
     I18n.t("helpers.label.#{field}_choices").invert
   end
+
+  def fieldset_title(section, field)
+    scope = %i[helpers fieldset]
+    default_title = I18n.t('default_title', scope: scope)
+    I18n.t("#{section}.#{field}", scope: scope, default: default_title)
+  end
 end

--- a/app/views/shared/_fieldset.html.slim
+++ b/app/views/shared/_fieldset.html.slim
@@ -1,6 +1,6 @@
 fieldset
   span.form-hint
-    | Select all that apply
+    = fieldset_title(f.object.name, question.name)
 
     - question.subquestions.each do |group_question|
       = render partial: "shared/#{group_question.display_type}", locals: { f: f, question: group_question }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,7 @@
 en:
   helpers:
     fieldset:
+      default_title: 'Select all that apply:'
       allergies:
         allergies: Allergies?
       arson:
@@ -15,7 +16,8 @@ en:
         harassment: Harasser
         intimidation: Intimidator / bully
       hostage_taker:
-        hostage_taker: History of taking hostages
+        hostage_taker: Do they have a history of taking hostages?
+        hostage_taker_type: 'Group involved (select all that apply):'
       move:
         has_destinations: Are there establishments the detainee must or must not be sent?
         not_for_release: Not for release?
@@ -355,7 +357,7 @@ en:
         arson: Arson
         concealed_weapons: Concealed weapons, drugs or other items
         harassments: Risk to others - harasser and/or bully
-        hostage_taker: Risk to others - hostage taker
+        hostage_taker: Hostage taker
         other_risk: Other risk on this journey
         risk_to_self: Risk to self
         risk_from_others: Risk from others
@@ -500,7 +502,7 @@ en:
         escape_status: Escape status/history
         escort_details: Escort Risk Assessment/Escape Pack
         harassment: "Risk to others: harasser and/or bully"
-        hostage_taker: "Risk to others - hostage taker"
+        hostage_taker: "Hostage taker"
         intimidation: "Intimidator/bully"
         mental: Mental healthcare
         needs: Medical health needs

--- a/spec/support/fixtures/pdf-text-all-no-answers.txt
+++ b/spec/support/fixtures/pdf-text-all-no-answers.txt
@@ -48,7 +48,7 @@ Violent to staff                   No
 Violent to other detainees         No
 Violent to general public          No
 Controlled unlock                  No
-Risk to others - hostage taker     No
+Hostage taker                      No
 Risk to others: harasser and/or    No
 bully
 Intimidator/bully                  No

--- a/spec/support/fixtures/pdf-text-all-yes-answers.txt
+++ b/spec/support/fixtures/pdf-text-all-yes-answers.txt
@@ -70,7 +70,7 @@ Violent to general public         Yes
   General public                  Yes      Violence to general public details
 Controlled unlock                 Yes
   Controlled unlock               Yes      More than 4 officers. Many people to hold the prisoner
-Risk to others - hostage taker    Yes
+Hostage taker                     Yes
   Staff                           Yes      12/03/2010
   Prisoners                       Yes      24/05/2012
   Public                          Yes      02/09/2007

--- a/spec/support/matchers/validate_as_pdf_that_contains_text.rb
+++ b/spec/support/matchers/validate_as_pdf_that_contains_text.rb
@@ -1,6 +1,7 @@
-RSpec::Matchers.define :validate_as_pdf_that_contains_text do |file_name|
+RSpec::Matchers.define :validate_as_pdf_that_contains_text do |file_name, options = {}|
   match do |pdf_content|
     @pdf_text = extract_pdf_text(pdf_content)
+    overwrite_with_actual_content(file_name) if options[:overwrite]
     @expected_text = File.open(expected_text_file_path(file_name)).read
 
     @pdf_text == @expected_text
@@ -37,5 +38,9 @@ RSpec::Matchers.define :validate_as_pdf_that_contains_text do |file_name|
 
   def text_difference
     Diffy::Diff.new(@pdf_text, @expected_text, context: 1).to_s(:text)
+  end
+
+  def overwrite_with_actual_content(file_name)
+    File.open(expected_text_file_path(file_name), 'wb+') { |file| file.write(@pdf_text) }
   end
 end


### PR DESCRIPTION
This PR will also introduce an optional parameter to the validate_as_pdf_that_contains_text matcher to regenerate the PDF file with the actual content.