### PR TITLE
Extend functionality for displaying assessment answers

### DIFF
--- a/app/models/assessments/question.rb
+++ b/app/models/assessments/question.rb
@@ -1,6 +1,6 @@
 module Assessments
   class Question < SimpleDelegator
-    attr_reader :schema, :parent, :group_questions
+    attr_reader :schema, :parent, :subquestions, :dependency_questions
 
     delegate :name, :group?, :string?, :complex?, to: :schema
 
@@ -8,7 +8,8 @@ module Assessments
       @schema = schema
       @parent = options[:parent]
       super(object)
-      @group_questions = initialize_group_questions
+      @subquestions = initialize_subquestions
+      @dependency_questions = initialize_dependency_questions
     end
 
     def value
@@ -21,10 +22,6 @@ module Assessments
 
     def has_dependencies?
       answer_schema&.has_dependencies?
-    end
-
-    def dependency_questions
-      answer_schema&.questions
     end
 
     def answered?
@@ -49,6 +46,10 @@ module Assessments
       parent&.parent&.value if belongs_to_group?
     end
 
+    def answer_requires_group_questions?
+      schema.answers.find(&:has_group_questions?).present?
+    end
+
     def section_name
       return unless parent
       return parent.name if parent.is_section?
@@ -65,12 +66,22 @@ module Assessments
 
     private
 
-    def initialize_group_questions
-      group_schema = schema.answers.find(&:has_group_questions?)&.group
-      return [] unless group_schema
-      group = self.class.new(model, group_schema, parent: self)
-      group_schema.subquestions.map do |question_schema|
-        self.class.new(model, question_schema, parent: group)
+    def initialize_subquestions
+      schema.subquestions.map do |question_schema|
+        self.class.new(model, question_schema, parent: self)
+      end
+    end
+
+    def initialize_dependency_questions
+      schema.answers.flat_map(&:questions).flat_map do |question_schema|
+        if question_schema.group?
+          group = self.class.new(model, question_schema, parent: self)
+          question_schema.subquestions.map do |subquestion_schema|
+            self.class.new(model, subquestion_schema, parent: group)
+          end
+        else
+          self.class.new(model, question_schema, parent: self)
+        end
       end
     end
 

--- a/app/models/assessments/question.rb
+++ b/app/models/assessments/question.rb
@@ -17,7 +17,8 @@ module Assessments
     end
 
     def relevant_answer?
-      answer_schema&.relevant? || value == 'yes'
+      return false unless answered?
+      schema.answers.any? ? answer_schema&.relevant? : true
     end
 
     def has_dependencies?

--- a/app/models/schemas/answer.rb
+++ b/app/models/schemas/answer.rb
@@ -27,7 +27,7 @@ module Schemas
     end
 
     def relevant?
-      relevant
+      relevant || value == 'yes' || value == true
     end
 
     private

--- a/app/presenters/print/assessment_question_presenter.rb
+++ b/app/presenters/print/assessment_question_presenter.rb
@@ -12,7 +12,6 @@ module Print
     end
 
     def answer_is_relevant?
-      value = public_send(name)
       case value
       when 'no', false
         false
@@ -24,18 +23,13 @@ module Print
       end
     end
 
-    def answer_requires_group_questions?
-      group_questions.present?
-    end
-
-    def group_questions
-      model.group_questions.map do |question|
+    def dependency_questions
+      model.dependency_questions.map do |question|
         self.class.new(question)
       end
     end
 
     def answer
-      value = public_send(name)
       case value
       when 'no', false
         'No'

--- a/app/presenters/print/assessment_question_presenter.rb
+++ b/app/presenters/print/assessment_question_presenter.rb
@@ -4,22 +4,10 @@ module Print
 
     def label
       content = t("print.section.questions.#{section_name}.#{name}")
-      if answer_is_relevant?
+      if relevant_answer?
         strong_title_label(content)
       else
         title_label(content)
-      end
-    end
-
-    def answer_is_relevant?
-      case value
-      when 'no', false
-        false
-      when 'yes', true
-        true
-      else
-        return relevant_answer? if answer_schema
-        string? && value.present?
       end
     end
 

--- a/app/presenters/print/assessment_section_presenter.rb
+++ b/app/presenters/print/assessment_section_presenter.rb
@@ -20,7 +20,7 @@ module Print
     private
 
     def relevant?
-      questions.any?(&:answer_is_relevant?)
+      questions.any?(&:relevant_answer?)
     end
 
     def model

--- a/app/presenters/summary/assessment_section_presenter.rb
+++ b/app/presenters/summary/assessment_section_presenter.rb
@@ -8,7 +8,7 @@ module Summary
 
     def questions
       model.questions.flat_map do |question|
-        question.group_questions.present? ? question.group_questions : question
+        question.answer_requires_group_questions? ? question.dependency_questions : question
       end
     end
 

--- a/app/views/escorts/print/_question.html.slim
+++ b/app/views/escorts/print/_question.html.slim
@@ -1,4 +1,4 @@
-- if question.answer_is_relevant?
+- if question.relevant_answer?
   - if question.answer_requires_group_questions?
     - question.dependency_questions.each do |dependency_question|
       = render partial: 'escorts/print/question', locals: { question: dependency_question }

--- a/app/views/escorts/print/_question.html.slim
+++ b/app/views/escorts/print/_question.html.slim
@@ -1,7 +1,7 @@
 - if question.answer_is_relevant?
   - if question.answer_requires_group_questions?
-    - question.group_questions.each do |group_question|
-      = render partial: 'escorts/print/question', locals: { question: group_question }
+    - question.dependency_questions.each do |dependency_question|
+      = render partial: 'escorts/print/question', locals: { question: dependency_question }
   - else
     tr.top-dotted
      td.indented.column-30-percent

--- a/spec/models/assessments/question_spec.rb
+++ b/spec/models/assessments/question_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe Assessments::Question do
+  let(:answers) { [] }
+  let(:schema) { double(Schemas::Question, name: 'question_name', subquestions: [], answers: answers) }
+  let(:assessment) { double(:assessment, question_name: answer) }
+  subject(:question) { described_class.new(assessment, schema) }
+
+  describe '#answered?' do
+    context 'when answer is nil' do
+      let(:answer) { nil }
+      specify { expect(question.answered?).to be_falsey }
+    end
+
+    context 'when answer is "unknown"' do
+      let(:answer) { 'unknown' }
+      specify { expect(question.answered?).to be_falsey }
+    end
+
+    context 'when answer is not present' do
+      let(:answer) { '' }
+      specify { expect(question.answered?).to be_falsey }
+    end
+
+    context 'when answer is present' do
+      let(:answer) { 'value' }
+      specify { expect(question.answered?).to be_truthy }
+    end
+  end
+
+  describe '#relevant_answer?' do
+    let(:answer) { 'no' }
+
+    context 'when not answered' do
+      before { allow(question).to receive(:answered?).and_return(false) }
+      specify { expect(question.relevant_answer?).to be_falsey }
+    end
+
+    context 'when answered' do
+      before { allow(question).to receive(:answered?).and_return(true) }
+
+      context 'and the question has no set of possible answers' do
+        let(:answers) { [] }
+
+        specify { expect(question.relevant_answer?).to be_truthy }
+      end
+
+      context 'and the question has a set of possible answers' do
+        let(:answer_schema) { double(Schemas::Answer, questions: []) }
+        let(:answers) { [answer_schema] }
+
+        before { allow(schema).to receive(:answer_for).with(answer).and_return(answer_schema) }
+
+        context 'and the question does not have a schema for the provided answer' do
+          before { allow(schema).to receive(:answer_for).with(answer).and_return(nil) }
+          specify { expect(question.relevant_answer?).to be_falsey }
+        end
+
+        context 'and answer is relevant' do
+          before { allow(answer_schema).to receive(:relevant?).and_return(true) }
+          specify { expect(question.relevant_answer?).to be_truthy }
+        end
+
+        context 'and answer is not marked as relevant' do
+          before { allow(answer_schema).to receive(:relevant?).and_return(false) }
+          specify { expect(question.relevant_answer?).to be_falsey }
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/print/assessment_question_presenter_spec.rb
+++ b/spec/presenters/print/assessment_question_presenter_spec.rb
@@ -20,13 +20,13 @@ RSpec.describe Print::AssessmentQuestionPresenter do
 
   describe '#label' do
     before do
-      allow(presenter).to receive(:answer_is_relevant?).and_return(false)
+      allow(question).to receive(:relevant_answer?).and_return(false)
       localize_key("print.section.questions.#{section_name}.#{question_name}", 'Localised question')
     end
 
     context 'when the answer is relevant' do
       before do
-        allow(presenter).to receive(:answer_is_relevant?).and_return(true)
+        allow(question).to receive(:relevant_answer?).and_return(true)
       end
 
       it 'returns the highlighted label' do
@@ -74,11 +74,9 @@ RSpec.describe Print::AssessmentQuestionPresenter do
 
     context 'and the question is answered with some other value' do
       let(:answer) { 'some_other_value' }
-      let(:relevant_answer) { false }
-      let(:answer_schema) { instance_double(Schemas::Answer, relevant?: relevant_answer) }
 
       before do
-        allow(question_schema).to receive(:answer_for).with(answer).and_return(answer_schema)
+        allow(question).to receive(:relevant_answer?).and_return(false)
       end
 
       context 'and the answer has a locale for the print page' do
@@ -100,76 +98,12 @@ RSpec.describe Print::AssessmentQuestionPresenter do
       end
 
       context 'and the answer is considered relevant' do
-        let(:relevant_answer) { true }
+        before do
+          allow(question).to receive(:relevant_answer?).and_return(true)
+        end
 
         it 'returns the answer highlighted' do
           expect(presenter.answer).to eq '<div class="strong-text">Some other value</div>'
-        end
-      end
-    end
-  end
-
-  describe '#answer_is_relevant?' do
-    context 'and the question is answered no' do
-      let(:answer) { 'no' }
-
-      specify { expect(presenter.answer_is_relevant?).to be_falsey }
-    end
-
-    context 'and the question is answered false' do
-      let(:answer) { false }
-
-      specify { expect(presenter.answer_is_relevant?).to be_falsey }
-    end
-
-    context 'and the question is answered yes' do
-      let(:answer) { 'yes' }
-
-      specify { expect(presenter.answer_is_relevant?).to be_truthy }
-    end
-
-    context 'and the question is answered true' do
-      let(:answer) { true }
-
-      specify { expect(presenter.answer_is_relevant?).to be_truthy }
-    end
-
-    context 'and the question is answered with some other value' do
-      let(:answer) { 'some_other_value' }
-      let(:relevant_answer) { false }
-      let(:answer_schema) { instance_double(Schemas::Answer, relevant?: relevant_answer) }
-
-      before do
-        allow(question_schema).to receive(:answer_for).with(answer).and_return(answer_schema)
-      end
-
-      specify { expect(presenter.answer_is_relevant?).to be_falsey }
-
-      context 'and the answer is considered relevant' do
-        let(:relevant_answer) { true }
-        specify { expect(presenter.answer_is_relevant?).to be_truthy }
-      end
-
-      context 'and there is no schema for the provided answer' do
-        let(:answer_schema) { nil }
-
-        context 'and question is of type other than string' do
-          let(:question_type) { 'boolean' }
-          specify { expect(presenter.answer_is_relevant?).to be_falsey }
-        end
-
-        context 'and question is of type string' do
-          let(:question_type) { 'string' }
-
-          context 'but answer value is empty' do
-            let(:answer) { '' }
-            specify { expect(presenter.answer_is_relevant?).to be_falsey }
-          end
-
-          context 'and answer value is present' do
-            let(:answer) { 'some-value' }
-            specify { expect(presenter.answer_is_relevant?).to be_truthy }
-          end
         end
       end
     end

--- a/spec/presenters/print/assessment_section_presenter_spec.rb
+++ b/spec/presenters/print/assessment_section_presenter_spec.rb
@@ -3,20 +3,20 @@ require 'rails_helper'
 RSpec.describe Print::AssessmentSectionPresenter do
   let(:name) { 'some_section' }
   let(:section) { instance_double(Assessments::Section, name: name) }
+  let(:question) { double(Assessments::Question) }
+  let(:question_presenter) { Print::AssessmentQuestionPresenter.new(question) }
+  let(:questions) { [question_presenter] }
 
   subject(:presenter) { described_class.new(section) }
 
   describe '#relevant' do
-    let(:question) { instance_double(Print::AssessmentQuestionPresenter) }
-    let(:questions) { [question] }
-
     before do
       allow(presenter).to receive(:questions).and_return(questions)
     end
 
     context 'when there is no relevant questions for the section' do
       before do
-        allow(question).to receive(:answer_is_relevant?).and_return(false)
+        allow(question).to receive(:relevant_answer?).and_return(false)
       end
 
       it 'returns the non-highlighted No' do
@@ -26,7 +26,7 @@ RSpec.describe Print::AssessmentSectionPresenter do
 
     context 'when there is at least one relevant question for the section' do
       before do
-        allow(question).to receive(:answer_is_relevant?).and_return(true)
+        allow(question).to receive(:relevant_answer?).and_return(true)
       end
 
       it 'returns the highlighted Yes' do
@@ -36,9 +36,6 @@ RSpec.describe Print::AssessmentSectionPresenter do
   end
 
   describe '#label' do
-    let(:question) { instance_double(Print::AssessmentQuestionPresenter) }
-    let(:questions) { [question] }
-
     before do
       allow(presenter).to receive(:questions).and_return(questions)
       localize_key("print.section.titles.#{name}", 'Localised section name')
@@ -46,7 +43,7 @@ RSpec.describe Print::AssessmentSectionPresenter do
 
     context 'when there is no relevant questions for the section' do
       before do
-        allow(question).to receive(:answer_is_relevant?).and_return(false)
+        allow(question).to receive(:relevant_answer?).and_return(false)
       end
 
       it 'returns the non-highlighted version of the label' do
@@ -56,7 +53,7 @@ RSpec.describe Print::AssessmentSectionPresenter do
 
     context 'when there is at least one relevant question for the section' do
       before do
-        allow(question).to receive(:answer_is_relevant?).and_return(true)
+        allow(question).to receive(:relevant_answer?).and_return(true)
       end
 
       it 'returns the highlighted version of the label' do


### PR DESCRIPTION
The current implementation had a limitation when the question being
processed contained an answer that requires an additional group of
questions to be answered, the display would only render that group of
questions.

The new functionality, maintains the condition (question contains an
answer that requires an additional group of questions), but instead of
displaying only that group of questions, it will display any questions
that the answer depends upon.

As an example:

- Question 1 is answered with Answer A.
- Answer A requires two additional questions to be answered, Question 2 and Question 3.
- Question 2 is just a text field, so doesn't require any additional
information.
- Question 3 is of type group and contains 2 Questions, Question 3G1 and
Question 3G2, both just boolean fields.

The presentation of Question 1 in the summary and print out given the
previous question definition will be:
- Does not display Question 1
- Displays answer for Question 2
- Does not display answer for Question 3
- Displays answers for Question 3G1 and Question 3G2