### PR TITLE
Change sex offence

### DIFF
--- a/config/assessments_schema.yml
+++ b/config/assessments_schema.yml
@@ -760,18 +760,14 @@ assessment:
                       -
                         name: sex_offence_under18_victim
                         type: boolean
-                        answers:
-                          -
-                            value: false
-                          -
-                            value: true
-                            questions:
-                              -
-                                name: sex_offence_under18_victim_details
-                                type: string
-                                validators:
-                                  -
-                                    name: 'Assessments::PresenceValidator'
+                  -
+                    name: date_most_recent_sexual_offence
+                    type: date
+                    validators:
+                      -
+                        name: 'Assessments::DateValidator'
+                        options:
+                          not_in_the_future: true
               -
                 value: 'no'
               -

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,7 +53,9 @@ en:
         previous_escape_attempts: Have they made previous escape attempts?
         previous_escape_attempts_type: 'Attempted to escape from (select all that apply):'
       sex_offences:
-        sex_offence: Sex offender
+        sex_offence: Are they a current or previous sex offender?
+        sex_offence_type: 'Victim (select all that apply):'
+        date_most_recent_sexual_offence: Date of most recent sexual offence
       social:
         personal_hygiene: Personal hygiene issues?
         personal_care: Personal care issues?
@@ -218,7 +220,7 @@ en:
         sex_offence_adult_male_victim: Adult male
         sex_offence_adult_female_victim: Adult female
         sex_offence_under18_victim: Under 18
-        sex_offence_under18_victim_details: Under 18 victim details
+        date_most_recent_sexual_offence: Date of most recent sexual offence
       social:
         personal_hygiene_choices:
           unknown: Clear selection
@@ -324,7 +326,8 @@ en:
         police_escape_attempt_details: Give details of last escape attempt
         other_type_escape_attempt_details: Give details of last escape attempt
       sex_offences:
-        sex_offence_under18_victim_details: Give details - state gender and age when under 18, if known
+        sex_offence: This doesn't include prostitution offences, but does include procuring others into prostitution.
+        date_most_recent_sexual_offence: DD/MM/YYYY
       social:
         personal_hygiene: Eg OCD, needs toilet support. For more information refer to the Social Care Act
         personal_hygiene_details: Give details and explain the significance
@@ -457,6 +460,7 @@ en:
           sex_offence_adult_male_victim: Adult male
           sex_offence_adult_female_victim: Adult female
           sex_offence_under18_victim: Under 18
+          date_most_recent_sexual_offence: Most recent sex offence
         risk_from_others:
           high_profile: High public interest
           rule_45: Rule 45

--- a/db/migrate/20170516164324_change_sex_offence.rb
+++ b/db/migrate/20170516164324_change_sex_offence.rb
@@ -1,0 +1,6 @@
+class ChangeSexOffence < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :risks, :sex_offence_under18_victim_details
+    add_column :risks, :date_most_recent_sexual_offence, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170515140132) do
+ActiveRecord::Schema.define(version: 20170516164324) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -191,7 +191,6 @@ ActiveRecord::Schema.define(version: 20170515140132) do
     t.boolean  "sex_offence_adult_male_victim"
     t.boolean  "sex_offence_adult_female_victim"
     t.boolean  "sex_offence_under18_victim"
-    t.text     "sex_offence_under18_victim_details"
     t.string   "previous_escape_attempts"
     t.boolean  "prison_escape_attempt"
     t.text     "prison_escape_attempt_details"
@@ -222,6 +221,7 @@ ActiveRecord::Schema.define(version: 20170515140132) do
     t.string   "discrimination_to_other_religions"
     t.text     "discrimination_to_other_religions_details"
     t.text     "violence_to_staff_details"
+    t.date     "date_most_recent_sexual_offence"
     t.index ["detainee_id"], name: "index_risks_on_detainee_id", using: :btree
   end
 

--- a/spec/features/pages/risk.rb
+++ b/spec/features/pages/risk.rb
@@ -147,6 +147,7 @@ module Page
         fill_in_checkbox('Adult male', @risk, :sex_offence_adult_male_victim)
         fill_in_checkbox('Adult female', @risk, :sex_offence_adult_female_victim)
         fill_in_checkbox_with_details('Under 18', @risk, :sex_offence_under18_victim)
+        fill_in 'sex_offence_date_most_recent_sexual_offence', with: @risk.date_most_recent_sexual_offence
       else
         choose 'sex_offences_sex_offence_no'
       end

--- a/spec/features/printing_spec.rb
+++ b/spec/features/printing_spec.rb
@@ -155,7 +155,7 @@ RSpec.feature 'printing a PER', type: :feature do
           sex_offence_adult_male_victim: true,
           sex_offence_adult_female_victim: true,
           sex_offence_under18_victim: true,
-          sex_offence_under18_victim_details: 'under 18 sex offence victim details',
+          date_most_recent_sexual_offence: '12/10/2008',
           current_e_risk: 'yes',
           current_e_risk_details: 'e_list_escort',
           previous_escape_attempts: 'yes',

--- a/spec/support/fixtures/pdf-text-all-yes-answers.txt
+++ b/spec/support/fixtures/pdf-text-all-yes-answers.txt
@@ -83,52 +83,53 @@ Harassment and bullying          Yes
 Sex offender                     Yes
   Adult male                     Yes
   Adult female                   Yes
-W1234BY: McTest Testy                                                         Page 2 of 3
-  Under 18                       Yes   Under 18 sex offence victim details
+W1234BY: McTest Testy                                                                Page 2 of 3
+  Under 18                       Yes
+  Most recent sex offence        12/10/2008
 Escape status/history            Yes
-  Currently on E list            Yes   E-List-Escort
+  Currently on E list            Yes          E-List-Escort
 Made previous escape             Yes
 attempts
-  Prison                         Yes   Prison escape attempt details
-  Court                          Yes   Court escape attempt details
-  Police                         Yes   Police escape attempt details
-  Other                          Yes   Other type of escape attempt details
+  Prison                         Yes          Prison escape attempt details
+  Court                          Yes          Court escape attempt details
+  Police                         Yes          Police escape attempt details
+  Other                          Yes          Other type of escape attempt details
 Category A, potential Category   Yes
 A or Restricted Status
   Category A, potential          Yes
   Category A or Restricted
   Status
 Further security information     Yes
-  Escort Risk Assessment         Yes   Completed on: 26/11/2016
-  Escape Pack                    Yes   Completed on: 13/12/2016
+  Escort Risk Assessment         Yes          Completed on: 26/11/2016
+  Escape Pack                    Yes          Completed on: 13/12/2016
 Drug trafficking risk            Yes
   Drug trafficking risk          Yes
 Weapons, drugs or other items    Yes
-  Creates or uses weapons        Yes   Created and used a 3d gun
-  Conceals weapons               Yes   Conceals weapons details
-  Conceals drugs                 Yes   Conceals drugs details
+  Creates or uses weapons        Yes          Created and used a 3d gun
+  Conceals weapons               Yes          Conceals weapons details
+  Conceals drugs                 Yes          Conceals drugs details
   Conceals mobile phones         Yes
   Conceals SIM cards             Yes
-  Conceals other items           Yes   Conceals other items details
+  Conceals other items           Yes          Conceals other items details
 Arson                            Yes
   Arsonist                       Yes
 Other risk information           Yes
-  Other risk information         Yes   Suspected terrorist
+  Other risk information         Yes          Suspected terrorist
 Physical healthcare              Yes
-  Physical health needs          Yes   Physical issues details
+  Physical health needs          Yes          Physical issues details
 Mental healthcare                Yes
-  Mental health issues           Yes   Mental illness details
 
-  Phobias                        Yes   Phobias details
+  Mental health issues           Yes          Mental illness details
+  Phobias                        Yes          Phobias details
 Social healthcare                Yes
-  Personal hygiene issues        Yes   Personal hygiene details
-  Personal care issues           Yes   Personal care details
+  Personal hygiene issues        Yes          Personal hygiene details
+  Personal care issues           Yes          Personal care details
 Allergies                        Yes
-  Allergies                      Yes   Allergies details
+  Allergies                      Yes          Allergies details
 Medical health needs             Yes
-  Dependencies / misuse          Yes   Dependencies details
-  Regular medication             Yes
+  Dependencies / misuse          Yes          Dependencies details
 W1234BY: McTest Testy                                                                  Page 3 of 3
+ Regular medication           Yes
 Transport                     Yes
  MPV required                 Yes                Mpv details
 Communication / language      Yes


### PR DESCRIPTION
[trello](https://trello.com/c/CkMg92QI/109-3-update-sex-offender-screen)

In this piece of work we change the copy of the questions,
remove details for answer ‘Under 18’ and add a date field
where we ask the most recent sexual offence