### PR TITLE
Add missing locale for radio button option

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -174,6 +174,9 @@ en:
       physical:
         physical_issues_choices:
           unknown: Clear selection
+      other_risk:
+        other_risk_choices:
+          unknown: Clear selection
       risk_from_others:
         rule_45_choices:
           unknown: Clear selection


### PR DESCRIPTION
In the 'Other risk' section of the risk assessment.