### PR TITLE
Changes to the Transport section in Healthcare assessment

### DIFF
--- a/app/views/escorts/_header.html.slim
+++ b/app/views/escorts/_header.html.slim
@@ -17,44 +17,44 @@ header#header
         #not_for_release_alert.tile-3
           div.alert-wrapper
             div.image#not_for_release_header class=(alerts.not_for_release_alert_class)
-              span.alert-title = 'Not for release'
+              span.alert-title = t('escort.alerts.title.not_for_release')
               span.red-tick
             span.alert-text = alerts.not_for_release_text
         #acct_status_alert.tile-3
           div.alert-wrapper
             div.image#acct_status_header class=(alerts.acct_status_alert_class)
-              span.alert-title = 'ACCT'
+              span.alert-title = t('escort.alerts.title.acct_status')
               span.red-tick
             span.alert-text = alerts.acct_status_text
 
         #rule_45_alert.tile-3
           div.alert-wrapper
             div.image#rule_45_header class=(alerts.rule_45_alert_class)
-              span.alert-title = 'Rule 45'
+              span.alert-title = t('escort.alerts.title.rule_45')
               span.red-tick
       .info-tiles
         #e_list_alert.tile-4
           div.alert-wrapper
             div.image#e_list_header class=(alerts.current_e_risk_alert_class)
-              span.alert-title = 'E list'
+              span.alert-title = t('escort.alerts.title.current_e_risk')
               span.red-tick
             span.alert-text = alerts.current_e_risk_text
 
         #csra_alert.tile-4
           div.alert-wrapper
             div.image#csra_header class=(alerts.csra_alert_class)
-              span.alert-title = 'CSRA'
+              span.alert-title = t('escort.alerts.title.csra')
               span.alert-toggle-text = alerts.csra_text
 
         #category_a_alert.tile-4
           div.alert-wrapper
             div.image#category_a_header class=(alerts.category_a_alert_class)
-              span.alert-title = 'Cat A'
+              span.alert-title = t('escort.alerts.title.category_a')
               span.red-tick
 
         #mpv_alert.tile-4
           div.alert-wrapper
             div.image#mpv_header class=(alerts.mpv_alert_class)
-              span.alert-title = 'MPV'
+              span.alert-title = t('escort.alerts.title.mpv')
               span.red-tick
   .clearer

--- a/app/views/healthcare/edit.html.slim
+++ b/app/views/healthcare/edit.html.slim
@@ -4,11 +4,13 @@
     - breadcrumb 'Healthcare summary', escort_healthcare_path(escort)
     - breadcrumb t("healthcare.form.title.#{form.name}")
 
-= render partial: 'shared/wizard_header'
+.grid-row
+  .column-two-thirds
+    = render partial: 'shared/wizard_header'
 
-.healthcare
-  = render partial: 'shared/wizard_step_form',
-    locals: { scope: 'healthcare',
-              assessment: AssessmentPresenter.new(healthcare, step),
-              form: form,
-              method: :put }
+  .healthcare.column-two-thirds
+    = render partial: 'shared/wizard_step_form',
+      locals: { scope: 'healthcare',
+                assessment: AssessmentPresenter.new(healthcare, step),
+                form: form,
+                method: :put }

--- a/app/views/healthcare/new.html.slim
+++ b/app/views/healthcare/new.html.slim
@@ -4,11 +4,13 @@
     - breadcrumb 'Healthcare'
     - breadcrumb t("healthcare.form.title.#{form.name}")
 
-= render partial: 'shared/wizard_header'
+.grid-row
+  .column-two-thirds
+    = render partial: 'shared/wizard_header'
 
-.healthcare
-  = render partial: 'shared/wizard_step_form',
-    locals: { scope: 'healthcare',
-              assessment: AssessmentPresenter.new(healthcare, step),
-              form: form,
-              method: :post }
+  .healthcare.column-two-thirds
+    = render partial: 'shared/wizard_step_form',
+      locals: { scope: 'healthcare',
+                assessment: AssessmentPresenter.new(healthcare, step),
+                form: form,
+                method: :post }

--- a/app/views/risks/edit.html.slim
+++ b/app/views/risks/edit.html.slim
@@ -4,11 +4,13 @@
     - breadcrumb 'Risk summary', escort_risks_path(escort)
     - breadcrumb t("risks.form.title.#{form.name}")
 
-= render partial: 'shared/wizard_header'
+.grid-row
+  .column-two-thirds
+    = render partial: 'shared/wizard_header'
 
-.risk
-  = render partial: 'shared/wizard_step_form',
-    locals: { scope: 'risks',
-              assessment: AssessmentPresenter.new(risk, step),
-              form: form,
-              method: :put }
+  .risk.column-two-thirds
+    = render partial: 'shared/wizard_step_form',
+      locals: { scope: 'risks',
+                assessment: AssessmentPresenter.new(risk, step),
+                form: form,
+                method: :put }

--- a/app/views/risks/new.html.slim
+++ b/app/views/risks/new.html.slim
@@ -4,11 +4,13 @@
     - breadcrumb 'Risk'
     - breadcrumb t("risks.form.title.#{form.name}")
 
-= render partial: 'shared/wizard_header'
+.grid-row
+  .column-two-thirds
+    = render partial: 'shared/wizard_header'
 
-.risk
-  = render partial: 'shared/wizard_step_form',
-    locals: { scope: 'risks',
-              assessment: AssessmentPresenter.new(risk, step),
-              form: form,
-              method: :post }
+  .risk.column-two-thirds
+    = render partial: 'shared/wizard_step_form',
+      locals: { scope: 'risks',
+                assessment: AssessmentPresenter.new(risk, step),
+                form: form,
+                method: :post }

--- a/config/assessments_schema.yml
+++ b/config/assessments_schema.yml
@@ -34,6 +34,22 @@ assessment:
                 value: 'no'
               -
                 value: 'unknown'
+      transport:
+        questions:
+          -
+            name: mpv
+            type: string
+            answers:
+              -
+                value: 'yes'
+                questions:
+                  -
+                    name: mpv_details
+                    type: string
+              -
+                value: 'no'
+              -
+                value: 'unknown'
       social:
         questions:
           -
@@ -121,22 +137,6 @@ assessment:
                             value: 'escort'
                           -
                             value: 'detainee'
-              -
-                value: 'no'
-              -
-                value: 'unknown'
-      transport:
-        questions:
-          -
-            name: mpv
-            type: string
-            answers:
-              -
-                value: 'yes'
-                questions:
-                  -
-                    name: mpv_details
-                    type: string
               -
                 value: 'no'
               -

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,7 +61,7 @@ en:
       substance_misuse:
         substance_supply: Is there a risk that they might traffic drugs on this journey?
       transport:
-        mpv: Requires MPV?
+        mpv: Do they need to travel in a special vehicle on this journey?
       violence:
         controlled_unlock_required: Are they on a controlled unlock?
         controlled_unlock: Number of officers required
@@ -233,7 +233,7 @@ en:
       transport:
         mpv_choices:
           unknown: Clear selection
-        mpv_details: MPV details
+        mpv_details: Details for need of a special vehicle
       violence:
         co_defendant: Co-defendant
         co_defendant_details: Co-defendant violence details
@@ -335,8 +335,8 @@ en:
       substance_misuse:
         substance_supply: Risk will be indicated by intelligence or past history of trafficking drugs.
       transport:
-        mpv: Eg disability, claustrophobia, pregnancy.
-        mpv_details: Give details and explain the significance
+        mpv: This could be a specially-adapted prison van (for example, to accommodate wheelchairs) or a taxi.
+        mpv_details: 'Please explain why you feel they need a special vehicle:'
       violence:
         controlled_unlock_details: 'Give details of personal protection equipment (PPE) required:'
         co_defendant_details: Give details
@@ -364,7 +364,7 @@ en:
         social: Social healthcare
         allergies: Allergies
         needs: Medical health needs
-        transport: Transport
+        transport: Special vehicles
         contact: Medical contact
     intro:
       breadcrumb: Health
@@ -496,7 +496,7 @@ en:
         substance_misuse:
           substance_supply: Drug trafficking risk
         transport:
-          mpv: MPV required
+          mpv: Special vehicle required
         violence: &summary_violence
           co_defendant: Co-defendant
           controlled_unlock_required: Controlled unlock
@@ -540,6 +540,7 @@ en:
         sex_offences: Sex offender
         social: Social healthcare
         substance_misuse: Drug trafficking risk
+        transport: Special vehicles
         violence_to_general_public: Violent to anyone else
         violence_to_other_detainees: Violent to other prisoners
         violence_to_staff: Violent to staff

--- a/spec/features/pages/healthcare.rb
+++ b/spec/features/pages/healthcare.rb
@@ -11,10 +11,10 @@ module Page
       continue_from_intro
       fill_in_physical_healthcare
       fill_in_mental_healthcare
+      fill_in_transport
       fill_in_social_healthcare
       fill_in_allergies
       fill_in_healthcare_needs
-      fill_in_transport
       fill_in_communication
       fill_in_medical_contact
     end
@@ -72,7 +72,7 @@ module Page
     end
 
     def fill_in_transport
-      fill_in_optional_details('Requires MPV?', @hc, :mpv)
+      fill_in_optional_details('Do they need to travel in a special vehicle on this journey?', @hc, :mpv)
       click_button 'Save and continue'
     end
 

--- a/spec/support/fixtures/pdf-text-all-no-answers.txt
+++ b/spec/support/fixtures/pdf-text-all-no-answers.txt
@@ -64,10 +64,10 @@ Arson                               No
 Other risk information              No
 Physical healthcare                 No
 Mental health issues                No
+Special vehicles                    No
 Social healthcare                   No
 Allergies                           No
 Medical health needs                No
-Transport                           No
 Communication / language            No
 difficulties
 Medical contact                     Yes

--- a/spec/support/fixtures/pdf-text-all-yes-answers.txt
+++ b/spec/support/fixtures/pdf-text-all-yes-answers.txt
@@ -120,17 +120,17 @@ Physical healthcare              Yes
 Mental health issues             Yes
 
   Mental health issues           Yes          Mental illness details
+Special vehicles                 Yes
+  Special vehicle required       Yes          Mpv details
 Social healthcare                Yes
   Personal hygiene issues        Yes          Personal hygiene details
   Personal care issues           Yes          Personal care details
 Allergies                        Yes
   Allergies                      Yes          Allergies details
 Medical health needs             Yes
-  Dependencies / misuse          Yes          Dependencies details
-  Regular medication             Yes
 W1234BY: McTest Testy                                                                  Page 3 of 3
-Transport                     Yes
- MPV required                 Yes                Mpv details
+ Dependencies / misuse        Yes                Dependencies details
+ Regular medication           Yes
 Communication / language      Yes
 difficulties
  Hearing / speech / sight     Yes                Hearing/speech/sight issues details


### PR DESCRIPTION
[Trello](https://trello.com/c/DxLgurwF/168-2-update-transport-screen)

This PR includes the following changes:

**Display changes**

- Use locales to display escort alerts in escort summary page
- Add display classes to assessment forms in order to make display of forms confined to a third of the page. This will make the long label fields to wrap into new lines, resulting in a better presentation.

**Changes to transport section**

- Move transport section form just after mental health issues section
- Wording changes
