### PR TITLE
Fix answer in summary when parent is question

### DIFF
--- a/app/models/assessments/question.rb
+++ b/app/models/assessments/question.rb
@@ -2,7 +2,7 @@ module Assessments
   class Question < SimpleDelegator
     attr_reader :schema, :parent, :subquestions, :dependency_questions
 
-    delegate :name, :group?, :string?, :complex?, to: :schema
+    delegate :name, :group?, :string?, :boolean?, :complex?, to: :schema
 
     def initialize(object, schema, options = {})
       @schema = schema

--- a/app/models/schemas/question.rb
+++ b/app/models/schemas/question.rb
@@ -35,6 +35,10 @@ module Schemas
       type == 'string'
     end
 
+    def boolean?
+      type == 'boolean'
+    end
+
     private
 
     attr_reader :hash

--- a/app/presenters/summary/assessment_question_presenter.rb
+++ b/app/presenters/summary/assessment_question_presenter.rb
@@ -7,15 +7,9 @@ module Summary
     end
 
     def answer
-      return default_answer unless belongs_to_group?
-      case parent_group_answer
-      when 'unknown', nil
-        error_content('Missing')
-      when 'no', false
-        'No'
-      else
-        format_answered_value
-      end
+      return parent_based_answer(parent_group_answer) if belongs_to_group?
+      return parent_based_answer(parent.value) if parent&.is_question?
+      default_answer
     end
 
     def details
@@ -30,6 +24,17 @@ module Summary
     end
 
     private
+
+    def parent_based_answer(parent_value)
+      case parent_value
+      when 'unknown', nil
+        error_content('Missing')
+      when 'no', false
+        boolean? ? 'No' : 'None'
+      else
+        format_answered_value
+      end
+    end
 
     def format_answered_value
       case value


### PR DESCRIPTION
[Trello](https://trello.com/c/CQ2lTRLP/182-bug-see-q1234rs-for-18-5-17-sex-offences-showing-as-no-but-most-recent-sex-offence-shown-as-missing)

Fix answer in summary when parent is question

When we display the summary and a question has a parent for which the value 
is no or false, we need to display the value of the field based on the value 
of the parent. If the type of the field is a boolean, we show 'No', otherwise
we show 'None'