### PR TITLE
Change Social healthcare in Personal care

### DIFF
--- a/app/models/forms/healthcare/social.rb
+++ b/app/models/forms/healthcare/social.rb
@@ -1,7 +1,6 @@
 module Forms
   module Healthcare
     class Social < Forms::Base
-      optional_details_field :personal_hygiene
       optional_details_field :personal_care
     end
   end

--- a/config/assessments_schema.yml
+++ b/config/assessments_schema.yml
@@ -97,36 +97,6 @@ assessment:
                 value: 'no'
               -
                 value: 'unknown'
-      social:
-        questions:
-          -
-            name: personal_hygiene
-            type: string
-            answers:
-              -
-                value: 'yes'
-                questions:
-                  -
-                    name: personal_hygiene_details
-                    type: string
-              -
-                value: 'no'
-              -
-                value: 'unknown'
-          -
-            name: personal_care
-            type: string
-            answers:
-              -
-                value: 'yes'
-                questions:
-                  -
-                    name: personal_care_details
-                    type: string
-              -
-                value: 'no'
-              -
-                value: 'unknown'
       allergies:
         questions:
           -
@@ -138,6 +108,22 @@ assessment:
                 questions:
                   -
                     name: allergies_details
+                    type: string
+              -
+                value: 'no'
+              -
+                value: 'unknown'
+      social:
+        questions:
+          -
+            name: personal_care
+            type: string
+            answers:
+              -
+                value: 'yes'
+                questions:
+                  -
+                    name: personal_care_details
                     type: string
               -
                 value: 'no'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,8 +54,7 @@ en:
         sex_offence_type: 'Victim (select all that apply):'
         date_most_recent_sexual_offence: Date of most recent sexual offence
       social:
-        personal_hygiene: Personal hygiene issues?
-        personal_care: Personal care issues?
+        personal_care: Will they need help with personal tasks on this journey?
       substance_misuse:
         substance_supply: Is there a risk that they might traffic drugs on this journey?
       transport:
@@ -216,8 +215,6 @@ en:
         sex_offence_under18_victim: Under 18
         date_most_recent_sexual_offence: Date of most recent sexual offence
       social:
-        personal_hygiene_choices:
-          unknown: Clear selection
         personal_care_choices:
           unknown: Clear selection
       substance_misuse:
@@ -318,10 +315,8 @@ en:
         sex_offence: This doesn't include prostitution offences, but does include procuring others into prostitution.
         date_most_recent_sexual_offence: DD/MM/YYYY
       social:
-        personal_hygiene: Eg OCD, needs toilet support. For more information refer to the Social Care Act
-        personal_hygiene_details: Give details and explain the significance
-        personal_care: Eg needs help with dressing, eating or drinking
-        personal_care_details: Give details and explain the significance
+        personal_care: For example, going to the toilet, eating or drinking
+        personal_care_details: 'Please explain what they may need help with:'
       substance_misuse:
         substance_supply: Risk will be indicated by intelligence or past history of trafficking drugs.
       transport:
@@ -351,7 +346,7 @@ en:
         dependencies: Dependencies
         physical: Physical health issues
         mental: Mental health issues
-        social: Social healthcare
+        social: Personal care
         allergies: Allergies and intolerances
         needs: Essential medication
         transport: Special vehicles
@@ -483,7 +478,6 @@ en:
         escort_details: *summary_security
         social:
           personal_care: Personal care issues
-          personal_hygiene: Personal hygiene issues
         substance_misuse:
           substance_supply: Drug trafficking risk
         transport:
@@ -529,7 +523,7 @@ en:
         risk_to_self: Risk to self
         risk_from_others: Risk from others
         sex_offences: Sex offender
-        social: Social healthcare
+        social: Personal care
         substance_misuse: Drug trafficking risk
         transport: Special vehicles
         violence_to_general_public: Violent to anyone else

--- a/db/migrate/20170523143625_remove_personal_hygiene.rb
+++ b/db/migrate/20170523143625_remove_personal_hygiene.rb
@@ -1,0 +1,6 @@
+class RemovePersonalHygiene < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :healthcare, :personal_hygiene
+    remove_column :healthcare, :personal_hygiene_details
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,25 +55,23 @@ ActiveRecord::Schema.define(version: 20170523144242) do
   end
 
   create_table "healthcare", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "physical_issues",          default: "unknown"
+    t.string   "physical_issues",         default: "unknown"
     t.text     "physical_issues_details"
-    t.string   "mental_illness",           default: "unknown"
+    t.string   "mental_illness",          default: "unknown"
     t.text     "mental_illness_details"
-    t.string   "personal_hygiene",         default: "unknown"
-    t.text     "personal_hygiene_details"
-    t.string   "personal_care",            default: "unknown"
+    t.string   "personal_care",           default: "unknown"
     t.text     "personal_care_details"
-    t.string   "allergies",                default: "unknown"
+    t.string   "allergies",               default: "unknown"
     t.text     "allergies_details"
-    t.string   "dependencies",             default: "unknown"
+    t.string   "dependencies",            default: "unknown"
     t.text     "dependencies_details"
-    t.string   "has_medications",          default: "unknown"
-    t.string   "mpv",                      default: "unknown"
+    t.string   "has_medications",         default: "unknown"
+    t.string   "mpv",                     default: "unknown"
     t.text     "mpv_details"
     t.string   "healthcare_professional"
     t.string   "contact_number"
-    t.datetime "created_at",                                   null: false
-    t.datetime "updated_at",                                   null: false
+    t.datetime "created_at",                                  null: false
+    t.datetime "updated_at",                                  null: false
     t.uuid     "detainee_id"
     t.uuid     "escort_id"
     t.index ["detainee_id"], name: "index_healthcare_on_detainee_id", using: :btree

--- a/spec/factories/healthcare_factory.rb
+++ b/spec/factories/healthcare_factory.rb
@@ -3,7 +3,6 @@ FactoryGirl.define do
     allergies 'no'
     physical_issues 'no'
     mental_illness 'no'
-    personal_hygiene 'no'
     personal_care 'no'
     dependencies 'no'
     mpv 'no'

--- a/spec/features/pages/healthcare.rb
+++ b/spec/features/pages/healthcare.rb
@@ -14,8 +14,8 @@ module Page
       fill_in_transport
       fill_in_healthcare_needs
       fill_in_dependencies
-      fill_in_social_healthcare
       fill_in_allergies
+      fill_in_social_healthcare
       fill_in_medical_contact
     end
 
@@ -34,8 +34,7 @@ module Page
     end
 
     def fill_in_social_healthcare
-      fill_in_optional_details('Personal hygiene issues?', @hc, :personal_hygiene)
-      fill_in_optional_details('Personal care issues?', @hc, :personal_care)
+      fill_in_optional_details('Will they need help with personal tasks on this journey?', @hc, :personal_care)
       click_button 'Save and continue'
     end
 

--- a/spec/features/printing_spec.rb
+++ b/spec/features/printing_spec.rb
@@ -76,7 +76,6 @@ RSpec.feature 'printing a PER', type: :feature do
       create(:healthcare, {
         physical_issues: 'no',
         mental_illness: 'no',
-        personal_hygiene: 'no',
         personal_care: 'no',
         allergies: 'no',
         dependencies: 'no',
@@ -199,8 +198,6 @@ RSpec.feature 'printing a PER', type: :feature do
         physical_issues_details: 'physical issues details',
         mental_illness: 'yes',
         mental_illness_details: 'mental illness details',
-        personal_hygiene: 'yes',
-        personal_hygiene_details: 'personal hygiene details',
         personal_care: 'yes',
         personal_care_details: 'personal care details',
         allergies: 'yes',

--- a/spec/forms/healthcare/social_spec.rb
+++ b/spec/forms/healthcare/social_spec.rb
@@ -5,15 +5,12 @@ RSpec.describe Forms::Healthcare::Social, type: :form do
 
   let(:params) {
     {
-      personal_hygiene: 'yes',
-      personal_hygiene_details: 'Dirty guy',
       personal_care: 'yes',
       personal_care_details: 'Not changing clothes',
     }.with_indifferent_access
   }
 
   describe '#validate' do
-    it { is_expected.to validate_optional_details_field(:personal_hygiene) }
     it { is_expected.to validate_optional_details_field(:personal_care) }
   end
 

--- a/spec/support/fixtures/pdf-text-all-no-answers.txt
+++ b/spec/support/fixtures/pdf-text-all-no-answers.txt
@@ -67,8 +67,8 @@ Mental health issues                No
 Special vehicles                    No
 Essential medication                No
 Dependencies                        No
-Social healthcare                   No
 Allergies and intolerances          No
+Personal care                       No
 Medical contact                     Yes
   Healthcare professional           John doctor doe
   Contact number                    1-131-999-0232

--- a/spec/support/fixtures/pdf-text-all-yes-answers.txt
+++ b/spec/support/fixtures/pdf-text-all-yes-answers.txt
@@ -126,17 +126,16 @@ Essential medication             Yes
   Essential medication           Yes
 Dependencies                     Yes
   Dependencies                   Yes          Dependencies details
-Social healthcare                Yes
-  Personal hygiene issues        Yes          Personal hygiene details
-W1234BY: McTest Testy                                                                    Page 3 of 3
- Personal care issues           Yes                Personal care details
-Allergies and intolerances      Yes
- Allergies and intolerances     Yes                Allergies details
-Medical contact                 Yes
- Healthcare professional        John doctor doe
- Contact number                 1-131-999-0232
-Current offences                Yes                Burglary (LXAHTGNJQF) | Sex offence
-                                                   (QDPREIBMSF)
-Must return to                HMP Brixton: Its a lovely place.
-Must NOT return to            HMP Clive House: Its too cold.
+Allergies and intolerances       Yes
+  Allergies and intolerances     Yes          Allergies details
+W1234BY: McTest Testy                                                                 Page 3 of 3
+Personal care                Yes
+ Personal care issues        Yes                Personal care details
+Medical contact              Yes
+ Healthcare professional     John doctor doe
+ Contact number              1-131-999-0232
+Current offences             Yes                Burglary (LXAHTGNJQF) | Sex offence
+                                                (QDPREIBMSF)
+Must return to             HMP Brixton: Its a lovely place.
+Must NOT return to         HMP Clive House: Its too cold.
 


### PR DESCRIPTION
[Trello](https://trello.com/c/YMelN4W5/176-2-update-social-healthcare-screen)
This work renames the social healthcare section in healthcare to become
personal care. It changes also the ordering of it, moving it from the third
step to the seventh, and removes the question about personal hygiene.