### PR TITLE
Manage status inside risk and healthcare

### DIFF
--- a/app/controllers/healthcare_controller.rb
+++ b/app/controllers/healthcare_controller.rb
@@ -76,9 +76,7 @@ class HealthcareController < ApplicationController
   end
 
   def update_document_workflow
-    if healthcare.no_questions_answered?
-      healthcare.not_started!
-    elsif healthcare.all_questions_answered?
+    if healthcare.all_questions_answered?
       healthcare.unconfirmed!
     else
       healthcare.incomplete!

--- a/app/controllers/risks_controller.rb
+++ b/app/controllers/risks_controller.rb
@@ -63,9 +63,7 @@ class RisksController < ApplicationController
   end
 
   def update_document_workflow
-    if risk.no_questions_answered?
-      risk.not_started!
-    elsif risk.all_questions_answered?
+    if risk.all_questions_answered?
       risk.unconfirmed!
     else
       risk.incomplete!

--- a/app/models/healthcare.rb
+++ b/app/models/healthcare.rb
@@ -1,51 +1,34 @@
 class Healthcare < ApplicationRecord
-  belongs_to :escort
   include Questionable
+
   act_as_assessment :healthcare
 
-  StatusChangeError = Class.new(StandardError)
+  STATES = {
+    incomplete: 0,
+    needs_review: 1,
+    unconfirmed: 2,
+    confirmed: 3
+  }.freeze
 
-  delegate :not_started?, :needs_review?, :incomplete?, :unconfirmed?, :confirmed?, to: :healthcare_workflow
+  enum status: STATES
+
+  belongs_to :escort
+  belongs_to :reviewer, class_name: 'User'
+  has_many :medications, dependent: :destroy
+
+  scope :not_confirmed, -> { where.not(status: :confirmed) }
+
   delegate :current_establishment, to: :escort, allow_nil: true
 
-  has_many :medications, dependent: :destroy
+  def confirm!(user:)
+    update_attributes!(
+      reviewer_id: user.id,
+      reviewed_at: DateTime.now,
+      status: :confirmed
+    )
+  end
 
   def default_contact_number
     current_establishment&.default_healthcare_contact_number
-  end
-
-  def status
-    healthcare_workflow&.status
-  end
-
-  def confirm!(user:)
-    status_change(:confirm_with_user!, user: user)
-  end
-
-  def not_started!
-    status_change(:not_started!)
-  end
-
-  def unconfirmed!
-    status_change(:unconfirmed!)
-  end
-
-  def incomplete!
-    status_change(:incomplete!)
-  end
-
-  private
-
-  def move
-    escort&.move
-  end
-
-  def healthcare_workflow
-    move&.healthcare_workflow
-  end
-
-  def status_change(method, *args)
-    raise(StatusChangeError, method) unless healthcare_workflow
-    healthcare_workflow.public_send(method, *args)
   end
 end

--- a/app/models/healthcare_workflow.rb
+++ b/app/models/healthcare_workflow.rb
@@ -1,2 +1,0 @@
-class HealthcareWorkflow < Workflow
-end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -1,48 +1,15 @@
 class Move < ApplicationRecord
   belongs_to :escort
   has_many :destinations, dependent: :destroy
-  has_one :healthcare_workflow
-  has_one :risk_workflow
-  has_one :offences_workflow
-  has_one :move_workflow
+  has_one :move_workflow, foreign_key: :workflowable_id
+
+  before_create :set_defaults
 
   scope :active, -> { joins(:move_workflow).merge(Workflow.not_issued) }
 
   delegate :status, :active?, :issued?, :issued!, to: :move_workflow
 
-  def initialize(*)
-    super
-    build_move_workflow
-    build_risk_workflow
-    build_healthcare_workflow
-    build_offences_workflow
-  end
-
-  def save_copy
-    transaction do
-      create_move_workflow
-      create_risk_workflow.needs_review!
-      create_healthcare_workflow.needs_review!
-      create_offences_workflow.needs_review!
-    end
-    save
-  end
-
-  def complete?
-    risk_complete? &&
-      healthcare_complete? &&
-      offences_complete?
-  end
-
-  def risk_complete?
-    risk_workflow.confirmed?
-  end
-
-  def healthcare_complete?
-    healthcare_workflow.confirmed?
-  end
-
-  def offences_complete?
-    offences_workflow.confirmed?
+  def set_defaults
+    move_workflow || build_move_workflow
   end
 end

--- a/app/models/risk.rb
+++ b/app/models/risk.rb
@@ -1,44 +1,27 @@
 class Risk < ApplicationRecord
-  belongs_to :escort
   include Questionable
+
   act_as_assessment :risk
 
-  StatusChangeError = Class.new(StandardError)
+  STATES = {
+    incomplete: 0,
+    needs_review: 1,
+    unconfirmed: 2,
+    confirmed: 3
+  }.freeze
 
-  delegate :not_started?, :needs_review?, :incomplete?, :unconfirmed?, :confirmed?, to: :risk_workflow
+  enum status: STATES
 
-  def status
-    risk_workflow&.status
-  end
+  belongs_to :escort
+  belongs_to :reviewer, class_name: 'User'
+
+  scope :not_confirmed, -> { where.not(status: :confirmed) }
 
   def confirm!(user:)
-    status_change(:confirm_with_user!, user: user)
-  end
-
-  def not_started!
-    status_change(:not_started!)
-  end
-
-  def unconfirmed!
-    status_change(:unconfirmed!)
-  end
-
-  def incomplete!
-    status_change(:incomplete!)
-  end
-
-  private
-
-  def move
-    escort&.move
-  end
-
-  def risk_workflow
-    move&.risk_workflow
-  end
-
-  def status_change(method, *args)
-    raise(StatusChangeError, method) unless risk_workflow
-    risk_workflow.public_send(method, *args)
+    update_attributes!(
+      reviewer_id: user.id,
+      reviewed_at: DateTime.now,
+      status: :confirmed
+    )
   end
 end

--- a/app/models/risk_workflow.rb
+++ b/app/models/risk_workflow.rb
@@ -1,2 +1,0 @@
-class RiskWorkflow < Workflow
-end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -1,14 +1,13 @@
 class Workflow < ApplicationRecord
-  belongs_to :move
+  belongs_to :detainee, foreign_key: :workflowable_id
   belongs_to :reviewer, class_name: 'User'
 
   WORKFLOW_STATES = {
-    not_started: 0,
-    incomplete: 1,
-    needs_review: 2,
-    unconfirmed: 3,
-    confirmed: 4,
-    issued: 5
+    incomplete: 0,
+    needs_review: 1,
+    unconfirmed: 2,
+    confirmed: 3,
+    issued: 4
   }.freeze
 
   enum status: WORKFLOW_STATES

--- a/app/presenters/dashboard_presenter.rb
+++ b/app/presenters/dashboard_presenter.rb
@@ -59,11 +59,11 @@ class DashboardPresenter
   end
 
   def count_of_incomplete_risk
-    escorts.with_incomplete_risk.count
+    escorts.with_incomplete_risk.count + escorts.without_risk_assessment.count
   end
 
   def count_of_incomplete_healthcare
-    escorts.with_incomplete_healthcare.count
+    escorts.with_incomplete_healthcare.count + escorts.without_healthcare_assessment.count
   end
 
   def count_of_incomplete_offences

--- a/app/services/escort_completion_validator.rb
+++ b/app/services/escort_completion_validator.rb
@@ -4,8 +4,7 @@ class EscortCompletionValidator < SimpleDelegator
   end
 
   def call
-    valid_detainee? && valid_move? &&
-      valid_assessments? && completed?
+    valid_detainee? && valid_move? && valid_assessments?
   end
 
   private
@@ -20,9 +19,5 @@ class EscortCompletionValidator < SimpleDelegator
 
   def valid_assessments?
     risk_complete? && healthcare_complete? && offences_complete?
-  end
-
-  def completed?
-    move && move.complete?
   end
 end

--- a/app/views/escorts/show.html.slim
+++ b/app/views/escorts/show.html.slim
@@ -14,8 +14,7 @@
 
   = render partial: 'detainee', locals: { detainee: DetaineePresenter.new(escort.detainee) }
 
-  - if escort.move
-    = render partial: 'risk', locals: { risk: escort.risk, detainee: escort.detainee }
-    = render partial: 'healthcare', locals: { healthcare: escort.healthcare, detainee: escort.detainee }
-    = render partial: 'offences', locals: { offences: OffencesPresenter.new(escort.offences), detainee: escort.detainee }
-    = render partial: 'actions'
+  = render partial: 'risk', locals: { risk: escort.risk, detainee: escort.detainee }
+  = render partial: 'healthcare', locals: { healthcare: escort.healthcare, detainee: escort.detainee }
+  = render partial: 'offences', locals: { offences: OffencesPresenter.new(escort.offences), detainee: escort.detainee }
+  = render partial: 'actions'

--- a/db/migrate/20170524102720_add_workflow_fields.rb
+++ b/db/migrate/20170524102720_add_workflow_fields.rb
@@ -1,0 +1,13 @@
+class AddWorkflowFields < ActiveRecord::Migration[5.0]
+  def change
+    add_column :risks, :status, :integer, default: 0
+    add_column :risks, :reviewer_id, :integer
+    add_column :risks, :reviewed_at, :datetime
+
+    add_column :healthcare, :status, :integer, default: 0
+    add_column :healthcare, :reviewer_id, :integer
+    add_column :healthcare, :reviewed_at, :datetime
+
+    rename_column :workflows, :move_id, :workflowable_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -73,6 +73,9 @@ ActiveRecord::Schema.define(version: 20170524154953) do
     t.datetime "updated_at",                                  null: false
     t.uuid     "detainee_id"
     t.uuid     "escort_id"
+    t.integer  "status",                  default: 0
+    t.integer  "reviewer_id"
+    t.datetime "reviewed_at"
     t.index ["detainee_id"], name: "index_healthcare_on_detainee_id", using: :btree
     t.index ["escort_id"], name: "index_healthcare_on_escort_id", using: :btree
   end
@@ -216,6 +219,9 @@ ActiveRecord::Schema.define(version: 20170524154953) do
     t.text     "discrimination_to_other_religions_details"
     t.text     "violence_to_staff_details"
     t.date     "date_most_recent_sexual_offence"
+    t.integer  "status",                                            default: 0
+    t.integer  "reviewer_id"
+    t.datetime "reviewed_at"
     t.index ["detainee_id"], name: "index_risks_on_detainee_id", using: :btree
     t.index ["escort_id"], name: "index_risks_on_escort_id", using: :btree
   end
@@ -241,15 +247,15 @@ ActiveRecord::Schema.define(version: 20170524154953) do
   end
 
   create_table "workflows", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "move_id"
-    t.string   "type",                    null: false
-    t.integer  "status",      default: 0
+    t.uuid     "workflowable_id"
+    t.string   "type",                        null: false
+    t.integer  "status",          default: 0
     t.datetime "reviewed_at"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
     t.integer  "reviewer_id"
-    t.index ["move_id"], name: "index_workflows_on_move_id", using: :btree
     t.index ["type"], name: "index_workflows_on_type", using: :btree
+    t.index ["workflowable_id"], name: "index_workflows_on_workflowable_id", using: :btree
   end
 
 end

--- a/spec/factories/detainee_factory.rb
+++ b/spec/factories/detainee_factory.rb
@@ -19,5 +19,17 @@ FactoryGirl.define do
     trait :with_no_offences do
       offences { [] }
     end
+
+    trait :with_completed_offences do
+      association :offences_workflow, :confirmed
+    end
+
+    trait :with_incompleted_offences do
+      association :offences_workflow, :incomplete
+    end
+
+    trait :with_needs_review_offences do
+      association :offences_workflow, :needs_review
+    end
   end
 end

--- a/spec/factories/escort_factory.rb
+++ b/spec/factories/escort_factory.rb
@@ -14,24 +14,46 @@ FactoryGirl.define do
       association :move
     end
 
+    trait :with_complete_risk_assessment do
+      association :risk, :confirmed
+    end
+
+    trait :with_complete_healthcare_assessment do
+      association :healthcare, :confirmed
+    end
+
+    trait :with_complete_offences do
+      association :detainee, :with_completed_offences
+    end
+
     trait :with_incomplete_risk_assessment do
-      association :risk, :incomplete, strategy: :build
+      association :risk, :incomplete
     end
 
     trait :with_incomplete_healthcare_assessment do
-      association :healthcare, :incomplete, strategy: :build
+      association :healthcare, :incomplete
+    end
+
+    trait :with_incomplete_offences do
+      association :detainee, :with_incompleted_offences
     end
 
     trait :completed do
-      association :detainee
-      association :move, :confirmed
-      association :risk
-      association :healthcare
+      association :detainee, :with_completed_offences
+      association :move
+      association :risk, :confirmed
+      association :healthcare, :confirmed
+    end
+
+    trait :needs_review do
+      association :detainee, :with_needs_review_offences
+      association :risk, :needs_review
+      association :healthcare, :needs_review
     end
 
     trait :issued do
       association :detainee
-      association :move, :issued, :confirmed
+      association :move, :issued
       association :risk
       association :healthcare
     end

--- a/spec/factories/healthcare_factory.rb
+++ b/spec/factories/healthcare_factory.rb
@@ -9,6 +9,7 @@ FactoryGirl.define do
     has_medications 'no'
 
     contact_number { Faker::PhoneNumber.cell_phone }
+    status :incomplete
 
     trait :with_medications do
       has_medications 'yes'
@@ -17,6 +18,22 @@ FactoryGirl.define do
 
     trait :incomplete do
       contact_number nil
+    end
+
+    trait :unconfirmed do
+      status :unconfirmed
+    end
+
+    trait :confirmed do
+      status :confirmed
+    end
+
+    trait :issued do
+      status :issued
+    end
+
+    trait :needs_review do
+      status :needs_review
     end
   end
 end

--- a/spec/factories/move_factory.rb
+++ b/spec/factories/move_factory.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
     not_for_release 'no'
     has_destinations 'no'
 
-    association :move_workflow, :incomplete, strategy: :build
+    association :move_workflow, strategy: :build
 
     trait :issued do
       association :move_workflow, :issued, strategy: :build
@@ -18,45 +18,9 @@ FactoryGirl.define do
       date { 1.week.from_now }
     end
 
-    trait :confirmed do
-      association :risk_workflow, :confirmed, strategy: :build
-      association :healthcare_workflow, :confirmed, strategy: :build
-      association :offences_workflow, :confirmed, strategy: :build
-    end
-
-    trait :needs_review do
-      association :risk_workflow, :needs_review, strategy: :build
-      association :healthcare_workflow, :needs_review, strategy: :build
-      association :offences_workflow, :needs_review, strategy: :build
-    end
-
-    trait :with_complete_risk_workflow do
-      association :risk_workflow, :confirmed, strategy: :build
-    end
-
-    trait :with_complete_healthcare_workflow do
-      association :healthcare_workflow, :confirmed, strategy: :build
-    end
-
-    trait :with_complete_offences_workflow do
-      association :offences_workflow, :confirmed, strategy: :build
-    end
-
     trait :with_destinations do
       has_destinations 'yes'
       destinations { build_list :destination, rand(1..5) }
-    end
-
-    trait :with_incomplete_risk_workflow do
-      association :risk_workflow, :incomplete, strategy: :build
-    end
-
-    trait :with_incomplete_healthcare_workflow do
-      association :healthcare_workflow, :incomplete, strategy: :build
-    end
-
-    trait :with_incomplete_offences_workflow do
-      association :offences_workflow, :incomplete, strategy: :build
     end
   end
 end

--- a/spec/factories/risk_factory.rb
+++ b/spec/factories/risk_factory.rb
@@ -28,6 +28,7 @@ FactoryGirl.define do
     uses_weapons 'no'
     arson 'no'
     other_risk 'no'
+    status :incomplete
 
     trait :with_high_csra do
       csra 'high'
@@ -36,6 +37,22 @@ FactoryGirl.define do
     trait :incomplete do
       rule_45 'unknown'
       conceals_weapons 'unknown'
+    end
+
+    trait :unconfirmed do
+      status :unconfirmed
+    end
+
+    trait :confirmed do
+      status :confirmed
+    end
+
+    trait :issued do
+      status :issued
+    end
+
+    trait :needs_review do
+      status :needs_review
     end
   end
 end

--- a/spec/factories/workflow_factory.rb
+++ b/spec/factories/workflow_factory.rb
@@ -1,10 +1,6 @@
 FactoryGirl.define do
   factory :workflow do
-    status :not_started
-
-    trait :incomplete do
-      status :incomplete
-    end
+    status :incomplete
 
     trait :confirmed do
       status :confirmed
@@ -20,12 +16,6 @@ FactoryGirl.define do
   end
 
   factory :move_workflow, parent: :workflow, class: 'MoveWorkflow' do
-  end
-
-  factory :risk_workflow, parent: :workflow, class: 'RiskWorkflow' do
-  end
-
-  factory :healthcare_workflow, parent: :workflow, class: 'HealthcareWorkflow' do
   end
 
   factory :offences_workflow, parent: :workflow, class: 'OffencesWorkflow' do

--- a/spec/features/detainees_due_to_move_spec.rb
+++ b/spec/features/detainees_due_to_move_spec.rb
@@ -13,25 +13,20 @@ RSpec.feature 'detainees due to move', type: :feature do
 
   context 'when there are detainees due to move for the date provided' do
     scenario 'show associated escorts and incomplete gauges for all the PER components' do
-      detainee = create(:detainee)
-      move = create(:move, :with_complete_healthcare_workflow, date: '11/08/2016')
-      create(:escort, detainee: detainee, move: move)
+      move = create(:move, date: '11/08/2016')
+      create(:escort, :with_detainee, :with_complete_healthcare_assessment, move: move)
 
-      detainee = create(:detainee)
-      move = create(:move, :with_complete_risk_workflow, :with_complete_healthcare_workflow, date: '11/08/2016')
-      create(:escort, detainee: detainee, move: move)
+      move = create(:move, date: '11/08/2016')
+      create(:escort, :with_detainee, :with_complete_risk_assessment, :with_complete_healthcare_assessment, move: move)
 
-      detainee = create(:detainee)
-      move = create(:move, :with_complete_healthcare_workflow, :with_complete_offences_workflow,  date: '11/08/2016')
-      create(:escort, detainee: detainee, move: move)
+      move = create(:move,  date: '11/08/2016')
+      create(:escort, :with_detainee, :with_complete_healthcare_assessment, :with_complete_offences, move: move)
 
-      detainee = create(:detainee)
-      move = create(:move, :with_complete_offences_workflow, :with_complete_healthcare_workflow,  date: '11/08/2016')
-      create(:escort, detainee: detainee, move: move)
+      move = create(:move, date: '11/08/2016')
+      create(:escort, :with_detainee, :with_complete_offences, :with_complete_healthcare_assessment, move: move)
 
-      detainee = create(:detainee)
-      move = create(:move, :confirmed, date: '11/08/2016')
-      create(:escort, detainee: detainee, move: move)
+      move = create(:move, date: '11/08/2016')
+      create(:escort, :with_detainee, :completed, move: move)
 
       login
       dashboard.search_escorts_due_on('11/08/2016')

--- a/spec/features/printing_spec.rb
+++ b/spec/features/printing_spec.rb
@@ -13,7 +13,6 @@ RSpec.feature 'printing a PER', type: :feature do
   let(:move) {
     create(
       :move,
-      :confirmed,
       from: 'HMP Bedford',
       to: 'Luton Crown Court',
       date: Date.civil(2099, 4, 22),
@@ -26,6 +25,7 @@ RSpec.feature 'printing a PER', type: :feature do
   let(:detainee) {
     create(
       :detainee,
+      :with_completed_offences,
       prison_number: 'W1234BY',
       forenames: 'Testy',
       surname: 'McTest',
@@ -42,7 +42,8 @@ RSpec.feature 'printing a PER', type: :feature do
   context 'when a PER is completed with all answers as no' do
     let(:destinations) { [] }
     let(:risk) {
-      create(:risk, {
+      create(:risk,
+        :confirmed,
         acct_status: 'none',
         rule_45: 'no',
         csra: 'standard',
@@ -70,10 +71,11 @@ RSpec.feature 'printing a PER', type: :feature do
         uses_weapons: 'no',
         arson: 'no',
         other_risk: 'no'
-      })
+      )
     }
     let(:healthcare) {
-      create(:healthcare, {
+      create(:healthcare,
+        :confirmed,
         physical_issues: 'no',
         mental_illness: 'no',
         personal_care: 'no',
@@ -82,7 +84,7 @@ RSpec.feature 'printing a PER', type: :feature do
         has_medications: 'no',
         mpv: 'no',
         contact_number: '1-131-999-0232'
-      })
+      )
     }
 
     scenario 'user prints the PER' do
@@ -112,7 +114,8 @@ RSpec.feature 'printing a PER', type: :feature do
       ]
     }
     let(:risk) {
-      create(:risk, {
+      create(:risk,
+          :confirmed,
           acct_status: 'open',
           rule_45: 'yes',
           csra: 'high',
@@ -194,11 +197,12 @@ RSpec.feature 'printing a PER', type: :feature do
           arson: 'yes',
           other_risk: 'yes',
           other_risk_details: 'suspected terrorist'
-        })
+        )
       }
 
     let(:healthcare) {
-      create(:healthcare, {
+      create(:healthcare,
+        :confirmed,
         physical_issues: 'yes',
         physical_issues_details: 'physical issues details',
         mental_illness: 'yes',
@@ -214,7 +218,7 @@ RSpec.feature 'printing a PER', type: :feature do
         mpv: 'yes',
         mpv_details: 'MPV details',
         contact_number: '1-131-999-0232'
-      })
+      )
     }
 
     scenario 'user prints the PER' do

--- a/spec/models/healthcare_spec.rb
+++ b/spec/models/healthcare_spec.rb
@@ -17,84 +17,23 @@ RSpec.describe Healthcare, type: :model do
   describe '#confirm!' do
     let(:user) { build(:user) }
 
-    context 'when there is no move' do
-      it 'raises a StatusChangeError exception' do
-        expect { healthcare.confirm!(user: user) }
-          .to raise_error(Healthcare::StatusChangeError, 'confirm_with_user!')
+    before { create_escort }
+
+    context 'when the risk assessment is not confirmed' do
+      it 'marks the healthcare assessment as confirmed' do
+        expect {
+          healthcare.confirm!(user: user)
+        }.to change { healthcare.reload.status }.from('incomplete').to('confirmed')
       end
     end
 
-    context 'when there is a move' do
-      before { create_escort }
+    context 'when the risk assessment is already confirmed' do
+      subject(:healthcare) { described_class.new(status: Healthcare::STATES[:confirmed]) }
 
       it 'marks the healthcare assessment as confirmed' do
         expect {
           healthcare.confirm!(user: user)
-        }.to change { healthcare.reload.status }.from('not_started').to('confirmed')
-      end
-    end
-  end
-
-  describe '#not_started!' do
-    let(:user) { build(:user) }
-
-    context 'when there is no move' do
-      it 'raises a StatusChangeError exception' do
-        expect { healthcare.not_started! }
-          .to raise_error(Healthcare::StatusChangeError, 'not_started!')
-      end
-    end
-
-    context 'when there is a move' do
-      before { create_escort }
-
-      it 'marks the healthcare assessment as not started' do
-        healthcare.unconfirmed!
-        expect {
-          healthcare.not_started!
-        }.to change { healthcare.reload.status }.from('unconfirmed').to('not_started')
-      end
-    end
-  end
-
-  describe '#unconfirmed!' do
-    let(:user) { build(:user) }
-
-    context 'when there is no move' do
-      it 'raises a StatusChangeError exception' do
-        expect { healthcare.unconfirmed! }
-          .to raise_error(Healthcare::StatusChangeError, 'unconfirmed!')
-      end
-    end
-
-    context 'when there is a move' do
-      before { create_escort }
-
-      it 'marks the healthcare assessment as uncorfirmed' do
-        expect {
-          healthcare.unconfirmed!
-        }.to change { healthcare.reload.status }.from('not_started').to('unconfirmed')
-      end
-    end
-  end
-
-  describe '#incomplete!' do
-    let(:user) { build(:user) }
-
-    context 'when there is no move' do
-      it 'raises a StatusChangeError exception' do
-          expect { healthcare.incomplete! }
-          .to raise_error(Healthcare::StatusChangeError, 'incomplete!')
-      end
-    end
-
-    context 'when there is a move' do
-      before { create_escort }
-
-      it 'marks the healthcare assessment as incomplete' do
-        expect {
-          healthcare.incomplete!
-        }.to change { healthcare.reload.status }.from('not_started').to('incomplete')
+        }.to_not change { healthcare.reload.status }
       end
     end
   end

--- a/spec/models/healthcare_workflow_spec.rb
+++ b/spec/models/healthcare_workflow_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe HealthcareWorkflow do
-  subject { described_class.new }
-  specify { expect(subject.type).to eq('healthcare') }
-  include_examples 'workflow'
-end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -4,14 +4,8 @@ RSpec.describe Move, type: :model do
   subject(:move) { described_class.new }
 
   describe '#issued?' do
-    context 'when the move is still in not started status' do
-      let(:move_workflow) { build(:move_workflow, status: :not_started) }
-      subject(:move) { build(:move, move_workflow: move_workflow) }
-      specify { is_expected.not_to be_issued }
-    end
-
     context 'when the move is still in incomplete status' do
-      let(:move_workflow) { build(:move_workflow, :incomplete) }
+      let(:move_workflow) { build(:move_workflow) }
       subject(:move) { build(:move, move_workflow: move_workflow) }
       specify { is_expected.not_to be_issued }
     end
@@ -26,26 +20,6 @@ RSpec.describe Move, type: :model do
       let(:move_workflow) { build(:move_workflow, :issued) }
       subject(:move) { build(:move, move_workflow: move_workflow) }
       specify { is_expected.to be_issued }
-    end
-  end
-
-  describe "#save_copy" do
-    before { subject.save_copy }
-
-    it "creates a not-started workflow" do
-      expect(subject.move_workflow.not_started?).to be true
-    end
-
-    it "creates a needs-review workflow for risk" do
-      expect(subject.risk_workflow.needs_review?).to be true
-    end
-
-    it "creates a needs-review workflow for healthcare" do
-      expect(subject.healthcare_workflow.needs_review?).to be true
-    end
-
-    it "creates a needs-review workflow for offences" do
-      expect(subject.offences_workflow.needs_review?).to be true
     end
   end
 end

--- a/spec/models/risk_spec.rb
+++ b/spec/models/risk_spec.rb
@@ -16,91 +16,24 @@ RSpec.describe Risk, type: :model do
   describe '#confirm!' do
     let(:user) { build(:user) }
 
-    context 'when there is no move' do
-      it 'raises a StatusChangeError exception' do
-        expect { risk.confirm!(user: user) }
-          .to raise_error(Risk::StatusChangeError, 'confirm_with_user!')
+    before { create_escort }
+
+    context 'when the risk assessment is not confirmed' do
+      it 'marks the risk assessment as confirmed' do
+        expect {
+          risk.confirm!(user: user)
+        }.to change { risk.reload.status }.from('incomplete').to('confirmed')
       end
     end
 
-    context 'when there is a move' do
-      before { create_escort }
+    context 'when the risk assessment is already confirmed' do
+      subject(:risk) { described_class.new(status: Risk::STATES[:confirmed]) }
 
       it 'marks the risk assessment as confirmed' do
         expect {
           risk.confirm!(user: user)
-        }.to change { risk.reload.status }.from('not_started').to('confirmed')
+        }.to_not change { risk.reload.status }
       end
-    end
-  end
-
-  describe '#not_started!' do
-    let(:user) { build(:user) }
-
-    context 'when there is no move' do
-      it 'raises a StatusChangeError exception' do
-        expect { risk.not_started! }
-          .to raise_error(Risk::StatusChangeError, 'not_started!')
-      end
-    end
-
-    context 'when there is a move' do
-      before { create_escort }
-
-      it 'marks the risk assessment as not started' do
-        risk.unconfirmed!
-        expect {
-          risk.not_started!
-        }.to change { risk.reload.status }.from('unconfirmed').to('not_started')
-      end
-    end
-  end
-
-  describe '#unconfirmed!' do
-    let(:user) { build(:user) }
-
-    context 'when there is no move' do
-      it 'raises a StatusChangeError exception' do
-        expect { risk.unconfirmed! }
-          .to raise_error(Risk::StatusChangeError, 'unconfirmed!')
-      end
-    end
-
-    context 'when there is a move' do
-      before { create_escort }
-
-      it 'marks the risk assessment as uncorfirmed' do
-        expect {
-          risk.unconfirmed!
-        }.to change { risk.reload.status }.from('not_started').to('unconfirmed')
-      end
-    end
-  end
-
-  describe '#incomplete!' do
-    let(:user) { build(:user) }
-
-    context 'when there is no move' do
-      it 'raises a StatusChangeError exception' do
-          expect { risk.incomplete! }
-          .to raise_error(Risk::StatusChangeError, 'incomplete!')
-      end
-    end
-
-    context 'when there is a move' do
-      before { create_escort }
-
-      it 'marks the risk assessment as incomplete' do
-        expect {
-          risk.incomplete!
-        }.to change { risk.reload.status }.from('not_started').to('incomplete')
-      end
-    end
-  end
-
-  describe '#schema' do
-    it 'returns an object representation of the risk schema' do
-      expect(subject.schema).to be_an_instance_of(Schemas::Assessment)
     end
   end
 end

--- a/spec/models/risk_workflow_spec.rb
+++ b/spec/models/risk_workflow_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe RiskWorkflow do
-  subject { described_class.new }
-  specify { expect(subject.type).to eq('risk') }
-  include_examples 'workflow'
-end

--- a/spec/requests/confirm_healthcare_assessment_request_spec.rb
+++ b/spec/requests/confirm_healthcare_assessment_request_spec.rb
@@ -60,8 +60,7 @@ RSpec.describe 'Confirm healthcare assessment requests', type: :request do
 
     context 'and the healthcare assessment is not yet complete' do
       let(:detainee) { create(:detainee) }
-      let(:move) { create(:move, :with_incomplete_healthcare_workflow) }
-      let(:healthcare_workflow) { move.healthcare_workflow }
+      let(:move) { create(:move) }
       let(:escort) { create(:escort, :with_incomplete_healthcare_assessment, detainee: detainee, move: move) }
 
       it 'sets a flash error' do
@@ -70,17 +69,16 @@ RSpec.describe 'Confirm healthcare assessment requests', type: :request do
         expect(flash[:error]).to eq('Healthcare assessment cannot be confirmed until all mandatory answers are filled')
       end
 
-      it 'does not change the state of the healthcare workflow' do
+      it 'does not change the state of the healthcare assessment' do
         expect {
           put "/escorts/#{escort.id}/healthcare/confirm"
-        }.not_to change { healthcare_workflow.reload.status }.from('incomplete')
+        }.not_to change { escort.healthcare.reload.status }.from('incomplete')
       end
     end
 
-    context 'and the healthcare assessment is complete' do
-      let(:escort) { create(:escort, detainee: detainee, move: move, healthcare: healthcare) }
-      let(:move) { create(:move, :with_incomplete_healthcare_workflow) }
-      let(:healthcare_workflow) { move.healthcare_workflow }
+    context 'and the healthcare assessment is unconfirmed' do
+      let(:healthcare) { create(:healthcare, :unconfirmed) }
+      let(:escort) { create(:escort, :with_detainee, :with_move, healthcare: healthcare) }
 
       it 'redirects to the PER page' do
         put "/escorts/#{escort.id}/healthcare/confirm"
@@ -88,10 +86,10 @@ RSpec.describe 'Confirm healthcare assessment requests', type: :request do
         expect(response).to redirect_to(escort_path(escort))
       end
 
-      it 'marks healthcare workflow as confirmed' do
+      it 'marks healthcare assessment as confirmed' do
         expect {
           put "/escorts/#{escort.id}/healthcare/confirm"
-        }.to change { healthcare_workflow.reload.status }.from('incomplete').to('confirmed')
+        }.to change { healthcare.reload.status }.from('unconfirmed').to('confirmed')
       end
     end
   end

--- a/spec/requests/create_escort_request_spec.rb
+++ b/spec/requests/create_escort_request_spec.rb
@@ -20,9 +20,7 @@ RSpec.describe 'Create escort request', type: :request do
   end
 
   context 'when there is a previous escort for given prison number' do
-    let(:detainee) { create(:detainee) }
-    let(:move) { create(:move) }
-    let!(:existent_escort) { create(:escort, prison_number: prison_number, detainee: detainee, move: move) }
+    let!(:existent_escort) { create(:escort, :completed, prison_number: prison_number) }
 
     it 'creates a new escort record with the data from the existent escort and redirects to the new move form' do
       expect {

--- a/spec/requests/print_escort_spec.rb
+++ b/spec/requests/print_escort_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Escorts::PrintController', type: :request do
-  let(:detainee) { create(:detainee) }
-  let(:move) { create(:move, :confirmed) }
-  let(:escort) { create(:escort, detainee: detainee, move: move) }
+  let(:escort) { create(:escort, :completed) }
 
   describe "#show" do
     context 'when user is not authorized' do
@@ -56,7 +54,7 @@ RSpec.describe 'Escorts::PrintController', type: :request do
       end
 
       context "with an incomplete PER" do
-        let(:move) { create :move }
+        let(:escort) { create(:escort) }
 
         it "redirects back to the referring page" do
           get "/escorts/#{escort.id}/print", headers: { "HTTP_REFERER" => 'prev_page' }

--- a/spec/services/create_escort_spec.rb
+++ b/spec/services/create_escort_spec.rb
@@ -14,11 +14,7 @@ RSpec.describe EscortCreator, type: :service do
   end
 
   context 'when there are existing escorts for the given prison number' do
-    let(:risk) { create(:risk) }
-    let(:healthcare) { create(:healthcare, :with_medications) }
-    let(:detainee) { create(:detainee) }
-    let(:move) { create(:move, :with_destinations, :confirmed) }
-    let!(:existent_escort) { create(:escort, prison_number: prison_number, detainee: detainee, move: move, risk: risk, healthcare: healthcare) }
+    let!(:existent_escort) { create(:escort, :completed, prison_number: prison_number) }
 
     it 'creates a clone of the most recent escort' do
       expect(Escort.where(prison_number: prison_number).count).to eq(1)
@@ -69,7 +65,7 @@ RSpec.describe EscortCreator, type: :service do
     expect(new_escort.move.id).not_to eq(existent_escort.move.id)
     expect(new_escort.move.date).to be_nil
     expect(new_escort.move).to have_attributes(move_attributes)
-    expect(new_escort.move.status).to eq('not_started')
+    expect(new_escort.move.status).to eq('incomplete')
 
     expected_destinations_attributes = existent_escort.move.destinations.map { |d| d.attributes.except(*except_destinations_attributes) }
     destinations_attributes = new_escort.move.destinations.map { |d| d.attributes.except(*except_destinations_attributes) }
@@ -85,7 +81,7 @@ RSpec.describe EscortCreator, type: :service do
   end
 
   def except_assessment_attributes
-    %w(id escort_id created_at updated_at)
+    %w(id escort_id created_at updated_at status)
   end
 
   def except_medication_attributes


### PR DESCRIPTION
Manage status inside risk and healthcare

We want to manage the status changes of assessments inside the assessments
as this will simplify things, so we added a status column to Risk and
Healthcare models.

In this work we also got rid of the not_started state for assessments.

This is the first step in getting rid of the concept of Workflow