### PR TITLE
Wording changes to the healthcare contact

### DIFF
--- a/app/models/escort.rb
+++ b/app/models/escort.rb
@@ -17,6 +17,10 @@ class Escort < ApplicationRecord
 
   delegate :offences, :offences=, to: :detainee, allow_nil: true
 
+  def current_establishment
+    @current_establishment ||= Establishment.current_for(prison_number)
+  end
+
   def completed?
     EscortCompletionValidator.call(self)
   end

--- a/app/models/establishment.rb
+++ b/app/models/establishment.rb
@@ -1,0 +1,16 @@
+class Establishment
+  def self.current_for(_prison_number)
+    # current will return a dummy record
+    # in the future should create an instance of the establishment
+    # which contains all the data related with the prisoner's
+    # current establishment
+    new
+  end
+
+  def default_healthcare_contact_number
+    # This value is harded-coded here until data
+    # is matched against the prisoner's current
+    # establishment
+    '01234373138'
+  end
+end

--- a/app/models/forms/healthcare/contact.rb
+++ b/app/models/forms/healthcare/contact.rb
@@ -1,8 +1,9 @@
 module Forms
   module Healthcare
     class Contact < Forms::Base
-      property :healthcare_professional, type: StrictString
-      property :contact_number, type: StrictString
+      property :contact_number, type: StrictString, default: proc { default_contact_number }
+
+      delegate :default_contact_number, to: :model
     end
   end
 end

--- a/app/models/healthcare.rb
+++ b/app/models/healthcare.rb
@@ -6,8 +6,13 @@ class Healthcare < ApplicationRecord
   StatusChangeError = Class.new(StandardError)
 
   delegate :not_started?, :needs_review?, :incomplete?, :unconfirmed?, :confirmed?, to: :healthcare_workflow
+  delegate :current_establishment, to: :escort, allow_nil: true
 
   has_many :medications, dependent: :destroy
+
+  def default_contact_number
+    current_establishment&.default_healthcare_contact_number
+  end
 
   def status
     healthcare_workflow&.status

--- a/config/assessments_schema.yml
+++ b/config/assessments_schema.yml
@@ -132,9 +132,6 @@ assessment:
       contact:
         questions:
           -
-            name: healthcare_professional
-            type: string
-          -
             name: contact_number
             type: string
   risk:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,6 +86,8 @@ en:
         conceals_sim_cards: SIM cards
         uses_weapons_choices:
           unknown: Clear selection
+      contact:
+        contact_number: Medical contact
       dependencies:
         dependencies_choices:
           unknown: Clear selection
@@ -253,6 +255,8 @@ en:
       allergies:
         allergies: "For example, dietary, medical or environmental allergies"
         allergies_details: 'Please give details:'
+      contact:
+        contact_number: "This is the contact number for Healthcare. To use a different number, enter it below:"
       concealed_weapons:
         uses_weapons_details: 'Give details of previous incidents:'
         conceals_weapons_details: 'Give details of previous incidents:'
@@ -278,7 +282,7 @@ en:
         date_most_recent_prisoners_hostage_taker_incident: DD/MM/YYYY
         date_most_recent_public_hostage_taker_incident: DD/MM/YYYY
       move:
-        date : DD/MM/YYYY
+        date: DD/MM/YYYY
         not_for_release: Is there a known reason that the detainee is not for release?
         not_for_release_reason_details: Give details of why the detainee is not for release
       mental:
@@ -350,7 +354,7 @@ en:
         allergies: Allergies and intolerances
         needs: Essential medication
         transport: Special vehicles
-        contact: Medical contact
+        contact: Medical contact details
     intro:
       breadcrumb: Health
       content: |
@@ -418,8 +422,7 @@ en:
           conceals_other_items: Conceals other items
           uses_weapons: Creates or uses weapons
         contact:
-          contact_number: Contact number
-          healthcare_professional: Healthcare professional
+          contact_number: Medical contact
         discrimination:
           discrimination_to_other_religions: Risk to other religions
           homophobic: Risk to LGBT people
@@ -507,7 +510,7 @@ en:
         category_a: Category A, potential Category A or Restricted Status
         concealed_weapons: Weapons, drugs or other items
         controlled_unlock_required: Controlled unlock
-        contact: Medical contact
+        contact: Medical contact details
         csra: CSRA (Cell Sharing Risk Assessment)
         discrimination: Discrimination against others
         escape_status: Escape status/history

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -256,7 +256,7 @@ en:
         allergies: "For example, dietary, medical or environmental allergies"
         allergies_details: 'Please give details:'
       contact:
-        contact_number: "This is the contact number for Healthcare. To use a different number, enter it below:"
+        contact_number: "This is the contact number for HMP Bedford Healthcare. To use a different number, enter it below:"
       concealed_weapons:
         uses_weapons_details: 'Give details of previous incidents:'
         conceals_weapons_details: 'Give details of previous incidents:'

--- a/db/migrate/20170524154953_remove_healthcare_professional_from_healthcare.rb
+++ b/db/migrate/20170524154953_remove_healthcare_professional_from_healthcare.rb
@@ -1,0 +1,5 @@
+class RemoveHealthcareProfessionalFromHealthcare < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :healthcare, :healthcare_professional, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170523144242) do
+ActiveRecord::Schema.define(version: 20170524154953) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,7 +68,6 @@ ActiveRecord::Schema.define(version: 20170523144242) do
     t.string   "has_medications",         default: "unknown"
     t.string   "mpv",                     default: "unknown"
     t.text     "mpv_details"
-    t.string   "healthcare_professional"
     t.string   "contact_number"
     t.datetime "created_at",                                  null: false
     t.datetime "updated_at",                                  null: false

--- a/spec/factories/healthcare_factory.rb
+++ b/spec/factories/healthcare_factory.rb
@@ -8,7 +8,6 @@ FactoryGirl.define do
     mpv 'no'
     has_medications 'no'
 
-    healthcare_professional { Faker::Name.name }
     contact_number { Faker::PhoneNumber.cell_phone }
 
     trait :with_medications do
@@ -17,7 +16,6 @@ FactoryGirl.define do
     end
 
     trait :incomplete do
-      healthcare_professional nil
       contact_number nil
     end
   end

--- a/spec/features/pages/healthcare.rb
+++ b/spec/features/pages/healthcare.rb
@@ -80,8 +80,7 @@ module Page
     end
 
     def fill_in_medical_contact
-      fill_in 'Healthcare professional', with: @hc.healthcare_professional
-      fill_in 'Contact number', with: @hc.contact_number
+      fill_in 'Medical contact', with: @hc.contact_number
       click_button 'Save and continue'
     end
   end

--- a/spec/features/printing_spec.rb
+++ b/spec/features/printing_spec.rb
@@ -81,7 +81,6 @@ RSpec.feature 'printing a PER', type: :feature do
         dependencies: 'no',
         has_medications: 'no',
         mpv: 'no',
-        healthcare_professional: 'John Doctor Doe',
         contact_number: '1-131-999-0232'
       })
     }
@@ -214,7 +213,6 @@ RSpec.feature 'printing a PER', type: :feature do
         medications: medications,
         mpv: 'yes',
         mpv_details: 'MPV details',
-        healthcare_professional: 'John Doctor Doe',
         contact_number: '1-131-999-0232'
       })
     }

--- a/spec/forms/healthcare/contact_spec.rb
+++ b/spec/forms/healthcare/contact_spec.rb
@@ -4,10 +4,7 @@ RSpec.describe Forms::Healthcare::Contact, type: :form do
   subject { described_class.new(Healthcare.new) }
 
   let(:params) {
-    {
-      healthcare_professional: 'Doctor Robert',
-      contact_number: '079876543',
-    }.with_indifferent_access
+    { contact_number: '079876543' }.with_indifferent_access
   }
 
   describe '#save' do

--- a/spec/models/escort_spec.rb
+++ b/spec/models/escort_spec.rb
@@ -22,7 +22,10 @@ RSpec.describe Escort do
     context 'when there is an associated detainee' do
       let(:detainee) { create(:detainee) }
       let(:escort) { create(:escort, detainee: detainee) }
-      specify { expect(escort.offences).to eq(detainee.offences) }
+
+      it 'returns the detainee offences' do
+        expect(escort.offences).to eq(detainee.offences)
+      end
     end
   end
 
@@ -218,6 +221,14 @@ RSpec.describe Escort do
       let(:offences_workflow) { create(:offences_workflow, :needs_review) }
 
       specify { expect(escort.needs_review?).to be_truthy }
+    end
+  end
+
+  describe '#current_establishment' do
+    subject(:escort) { described_class.new }
+
+    it 'returns the current establishment the prisoner is at' do
+      expect(escort.current_establishment).to be_instance_of(Establishment)
     end
   end
 end

--- a/spec/models/healthcare_spec.rb
+++ b/spec/models/healthcare_spec.rb
@@ -98,4 +98,26 @@ RSpec.describe Healthcare, type: :model do
       end
     end
   end
+
+  describe '#default_contact_number' do
+    context 'when there is no current establishment set for the detainee' do
+      before do
+        expect(healthcare).to receive(:current_establishment).and_return(nil)
+      end
+
+      specify { expect(healthcare.default_contact_number).to be_nil }
+    end
+
+    context 'when there is a current establishment set for the detainee' do
+      let(:establishment) { double(Establishment, default_healthcare_contact_number: '111111') }
+
+      before do
+        expect(healthcare).to receive(:current_establishment).and_return(establishment)
+      end
+
+      it 'returns the default healthcare contact number for that establishment' do
+        expect(healthcare.default_contact_number).to eq('111111')
+      end
+    end
+  end
 end

--- a/spec/support/fixtures/pdf-text-all-no-answers.txt
+++ b/spec/support/fixtures/pdf-text-all-no-answers.txt
@@ -34,12 +34,12 @@ About this Person Escort Record
    This PER was produced by the the Moving People Safely digital PER service, currently being piloted at
    HMP Bedford. If you have feedback or questions about the service, contact the Moving People Safely team
    at: moving-people-safely@digital.justice.gov.uk
-W1234BY: McTest Testy                                                         Page 1 of 1
+W1234BY: McTest Testy                                                        Page 1 of 1
 
- NOT FOR RELEASE                         ACCT                 RULE 45
+ NOT FOR RELEASE                         ACCT                RULE 45
 
 
- E LIST                         CSRA STANDARD         CAT A             MPV
+ E LIST                         CSRA STANDARD        CAT A             MPV
 
 Risk to self                        No
 Risk from others                    No
@@ -69,9 +69,8 @@ Essential medication                No
 Dependencies                        No
 Allergies and intolerances          No
 Personal care                       No
-Medical contact                     Yes
-  Healthcare professional           John doctor doe
-  Contact number                    1-131-999-0232
+Medical contact details             Yes
+  Medical contact                   1-131-999-0232
 Current offences                    None
 
 

--- a/spec/support/fixtures/pdf-text-all-yes-answers.txt
+++ b/spec/support/fixtures/pdf-text-all-yes-answers.txt
@@ -129,14 +129,13 @@ Dependencies                     Yes
   Dependencies                   Yes          Dependencies details
 Allergies and intolerances       Yes
   Allergies and intolerances     Yes          Allergies details
-W1234BY: McTest Testy                                                                 Page 3 of 3
-Personal care                Yes
- Personal care issues        Yes                Personal care details
-Medical contact              Yes
- Healthcare professional     John doctor doe
- Contact number              1-131-999-0232
-Current offences             Yes                Burglary (LXAHTGNJQF) | Sex offence
-                                                (QDPREIBMSF)
-Must return to             HMP Brixton: Its a lovely place.
-Must NOT return to         HMP Clive House: Its too cold.
+W1234BY: McTest Testy                                                                Page 3 of 3
+Personal care               Yes
+ Personal care issues       Yes                Personal care details
+Medical contact details     Yes
+ Medical contact            1-131-999-0232
+Current offences            Yes                Burglary (LXAHTGNJQF) | Sex offence
+                                               (QDPREIBMSF)
+Must return to            HMP Brixton: Its a lovely place.
+Must NOT return to        HMP Clive House: Its too cold.
 


### PR DESCRIPTION
[Trello](https://trello.com/c/fHjnoqd6/177-2-update-medical-contact-screen)

- Remove healthcare profession field from healthcare contact section
- Re-worded the remaining fields
- Set a default for the healthcare contact number. Currently this points
to a dummy finder. In the future this should return the matching data
for the prisoner's current establishment.