### PR TITLE
Remove indirection from escort to move models

### DIFF
--- a/app/controllers/escorts_controller.rb
+++ b/app/controllers/escorts_controller.rb
@@ -6,6 +6,8 @@ class EscortsController < ApplicationController
     escort = EscortCreator.call(escort_params)
     if escort.move
       redirect_to edit_escort_move_path(escort.id)
+    elsif escort.detainee
+      redirect_to new_escort_move_path(escort)
     else
       redirect_to new_escort_detainee_path(escort.id, escort_params)
     end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -1,15 +1,4 @@
 class Move < ApplicationRecord
   belongs_to :escort
   has_many :destinations, dependent: :destroy
-  has_one :move_workflow, foreign_key: :workflowable_id
-
-  before_create :set_defaults
-
-  scope :active, -> { joins(:move_workflow).merge(Workflow.not_issued) }
-
-  delegate :status, :active?, :issued?, :issued!, to: :move_workflow
-
-  def set_defaults
-    move_workflow || build_move_workflow
-  end
 end

--- a/app/models/move_workflow.rb
+++ b/app/models/move_workflow.rb
@@ -1,2 +1,0 @@
-class MoveWorkflow < Workflow
-end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -30,14 +30,4 @@ class Workflow < ApplicationRecord
       status: :confirmed
     )
   end
-
-  concerning :AppliesToMoveWorkflowOnly do
-    included do
-      scope :not_issued, -> { where.not(status: :issued) }
-
-      def active?
-        !issued?
-      end
-    end
-  end
 end

--- a/app/services/escort_creator.rb
+++ b/app/services/escort_creator.rb
@@ -21,12 +21,11 @@ class EscortCreator
 
   INCLUDE_GRAPH = [
     { detainee: [:offences] },
-    { move: [:destinations] },
     :risk,
     { healthcare: [:medications] }
   ].freeze
 
-  EXCEPT_GRAPH = [{ move: [:date] }].freeze
+  EXCEPT_GRAPH = [:issued_at].freeze
 
   def existent_escort
     @existent_escort ||= Escort.find_by(prison_number: prison_number)

--- a/app/services/escorts/delete_historic_unissued.rb
+++ b/app/services/escorts/delete_historic_unissued.rb
@@ -2,7 +2,7 @@ module Escorts
   module DeleteHistoricUnissued
     def call(options = {})
       logger = options.fetch(:logger, Rails.logger)
-      scope = Escort.active.where('date(now()) - date(date) >= 1')
+      scope = Escort.joins(:move).active.where('date(now()) - date(moves.date) >= 1')
       count = scope.count
       logger.info("Soft deleting #{count} unissued escorts past their date")
       scope.in_batches.update_all(deleted_at: Time.now.utc)

--- a/app/views/escorts/show.html.slim
+++ b/app/views/escorts/show.html.slim
@@ -5,12 +5,7 @@
 .escort
   = render partial: 'header', locals: { detainee: escort.detainee, alerts: EscortAlertsPresenter.new(escort) }
 
-  - if escort.move
-    = render partial: 'move', locals: { move: MovePresenter.new(escort.move) }
-  - else
-    h2 Move information
-    #no-active-move.alert.alert--warning
-      = link_to 'Create new move', new_escort_move_path(escort), class: 'button'
+  = render partial: 'move', locals: { move: MovePresenter.new(escort.move) }
 
   = render partial: 'detainee', locals: { detainee: DetaineePresenter.new(escort.detainee) }
 

--- a/app/views/homepage/_escorts.html.slim
+++ b/app/views/homepage/_escorts.html.slim
@@ -17,7 +17,7 @@
             | #{escort.detainee.surname}
           span
             |  #{escort.detainee.forenames}
-        td = escort.move.to
+        td = escort.move&.to
         - if escort.issued?
           td.issued colspan=3
             | Issued
@@ -25,11 +25,11 @@
             = link_to_print_in_new_window(escort, text: 'Reprint')
         - else
           td.completion-status
-            span class="#{escort.risk_complete?}"
+            span class="#{escort.risk_complete? ? true : false}"
           td.completion-status
-            span class="#{escort.healthcare_complete?}"
+            span class="#{escort.healthcare_complete? ? true : false}"
           td.completion-status
-            span class="#{escort.offences_complete?}"
+            span class="#{escort.offences_complete? ? true : false}"
           td.print
             - if AccessPolicy.print?(escort: escort)
              = link_to_print_in_new_window(escort)

--- a/db/migrate/20170524102618_add_issued_at_to_escorts.rb
+++ b/db/migrate/20170524102618_add_issued_at_to_escorts.rb
@@ -1,0 +1,5 @@
+class AddIssuedAtToEscorts < ActiveRecord::Migration[5.0]
+  def change
+    add_column :escorts, :issued_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 20170524154953) do
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
     t.datetime "deleted_at"
+    t.datetime "issued_at"
     t.index ["deleted_at"], name: "index_escorts_on_deleted_at", using: :btree
     t.index ["prison_number"], name: "index_escorts_on_prison_number", using: :btree
   end

--- a/spec/factories/detainee_factory.rb
+++ b/spec/factories/detainee_factory.rb
@@ -25,7 +25,7 @@ FactoryGirl.define do
     end
 
     trait :with_incompleted_offences do
-      association :offences_workflow, :incomplete
+      association :offences_workflow
     end
 
     trait :with_needs_review_offences do

--- a/spec/factories/escort_factory.rb
+++ b/spec/factories/escort_factory.rb
@@ -52,10 +52,8 @@ FactoryGirl.define do
     end
 
     trait :issued do
-      association :detainee
-      association :move, :issued
-      association :risk
-      association :healthcare
+      completed
+      issued_at 1.day.ago
     end
   end
 end

--- a/spec/factories/move_factory.rb
+++ b/spec/factories/move_factory.rb
@@ -8,12 +8,6 @@ FactoryGirl.define do
     not_for_release 'no'
     has_destinations 'no'
 
-    association :move_workflow, strategy: :build
-
-    trait :issued do
-      association :move_workflow, :issued, strategy: :build
-    end
-
     trait :active do
       date { 1.week.from_now }
     end

--- a/spec/factories/workflow_factory.rb
+++ b/spec/factories/workflow_factory.rb
@@ -6,16 +6,9 @@ FactoryGirl.define do
       status :confirmed
     end
 
-    trait :issued do
-      status :issued
-    end
-
     trait :needs_review do
       status :needs_review
     end
-  end
-
-  factory :move_workflow, parent: :workflow, class: 'MoveWorkflow' do
   end
 
   factory :offences_workflow, parent: :workflow, class: 'OffencesWorkflow' do

--- a/spec/features/adding_offences_to_a_move_spec.rb
+++ b/spec/features/adding_offences_to_a_move_spec.rb
@@ -3,7 +3,7 @@ require 'feature_helper'
 RSpec.feature 'Adding offences to a move', type: :feature do
   let(:prison_number) { 'A45345DQ' }
   let(:detainee) { create(:detainee, :with_no_offences, prison_number: prison_number) }
-  let(:move) { create(:move, :active) }
+  let(:move) { create(:move) }
   let(:escort) { create(:escort, prison_number: prison_number, detainee: detainee, move: move) }
   let(:fixture_json_file_path) { Rails.root.join('spec', 'support', 'fixtures', 'valid-nomis-charges.json') }
   let(:valid_json) { File.read(fixture_json_file_path) }

--- a/spec/features/managing_healthcare_medications_spec.rb
+++ b/spec/features/managing_healthcare_medications_spec.rb
@@ -2,7 +2,7 @@ require 'feature_helper'
 
 RSpec.describe 'managing healthcare medications', type: :feature do
   let(:detainee) { create(:detainee) }
-  let(:move) { create(:move, :active) }
+  let(:move) { create(:move) }
   let(:escort) { create(:escort, detainee: detainee, move: move) }
 
   scenario 'adding and removing move medications' do

--- a/spec/features/managing_move_destinations_spec.rb
+++ b/spec/features/managing_move_destinations_spec.rb
@@ -3,7 +3,7 @@ require 'feature_helper'
 RSpec.describe 'managing move destinations', type: :feature do
   scenario 'adding and removing move destinations' do
     detainee = create(:detainee)
-    move = create(:move, :active)
+    move = create(:move)
     escort = create(:escort, detainee: detainee, move: move)
 
     login

--- a/spec/features/pages/move_details.rb
+++ b/spec/features/pages/move_details.rb
@@ -6,7 +6,7 @@ module Page
       fill_in 'Date', with: move.date
       fill_in_not_for_release_details(move)
       destinations = options[:destinations]
-      fill_in_destinations(destinations) if destinations.present?
+      fill_in_destinations(destinations)
       save_and_continue
     end
 
@@ -30,11 +30,15 @@ module Page
     end
 
     def fill_in_destinations(destinations)
-      choose 'move_has_destinations_yes'
-      destinations.each_with_index do |destination, index|
-        fill_in "move_destinations_attributes_#{index}_establishment", with: destination[:establishment]
-        choose "move_destinations_attributes_#{index}_must_return_must_#{destination[:must]}"
-        click_button 'Add establishment' unless index == destinations.size - 1
+      if destinations.present?
+        choose 'move_has_destinations_yes'
+        destinations.each_with_index do |destination, index|
+          fill_in "move_destinations_attributes_#{index}_establishment", with: destination[:establishment]
+          choose "move_destinations_attributes_#{index}_must_return_must_#{destination[:must]}"
+          click_button 'Add establishment' unless index == destinations.size - 1
+        end
+      else
+        choose 'move_has_destinations_no'
       end
     end
   end

--- a/spec/features/per_show_page_spec.rb
+++ b/spec/features/per_show_page_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'PER show page', type: :feature do
     context 'Not for release alert' do
       context 'when the unissued PER has move details' do
         let(:options) { {} }
-        let(:move) { create(:move, :active, options) }
+        let(:move) { create(:move, options) }
 
         context 'when move has not for release set to unknown' do
           let(:options) { { not_for_release: 'unknown' } }
@@ -369,7 +369,7 @@ RSpec.feature 'PER show page', type: :feature do
     let(:escort) { create(:escort, detainee: detainee, move: move) }
 
     context 'issued PER' do
-      let(:move) { create(:move, :issued) }
+      let(:escort) { create(:escort, :issued, detainee: detainee, move: move) }
 
       scenario 'displays all the mandatory move information' do
         login
@@ -379,8 +379,8 @@ RSpec.feature 'PER show page', type: :feature do
       end
     end
 
-    context 'PER with an active move' do
-      let(:move) { create(:move, :active) }
+    context 'unissued PER' do
+      let(:move) { create(:move) }
 
       scenario 'displays all the mandatory move information' do
         login

--- a/spec/features/reuse_spec.rb
+++ b/spec/features/reuse_spec.rb
@@ -10,7 +10,8 @@ RSpec.feature 'Reuse of previously entered PER data', type: :feature do
 
     dashboard.search(detainee.prison_number)
     dashboard.click_add_new_escort
-    move_details.complete_date_field Date.tomorrow.strftime('%d/%m/%Y')
+    move_data = build(:move, date: 1.day.from_now)
+    move_details.complete_form(move_data)
 
     escort_page.confirm_healthcare_status('Review')
     escort_page.click_edit_healthcare

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'searching for a prisoner', type: :feature do
     scenario 'prisoner present with an active escort' do
       prison_number = 'A1324BC'
       detainee = create(:detainee, prison_number: prison_number)
-      move = create(:move, :active)
+      move = create(:move)
       escort = create(:escort, prison_number: prison_number, detainee: detainee, move: move)
 
       login
@@ -23,8 +23,8 @@ RSpec.feature 'searching for a prisoner', type: :feature do
     scenario 'prisoner present with a previously issued escort' do
       prison_number = 'A1324BC'
       detainee = create(:detainee, prison_number: prison_number)
-      move = create(:move, :issued)
-      create(:escort, prison_number: prison_number, detainee: detainee, move: move)
+      move = create(:move)
+      create(:escort, :issued, prison_number: prison_number, detainee: detainee, move: move)
 
       login
       search_with_valid_prison_number(prison_number)

--- a/spec/features/summary_page_spec.rb
+++ b/spec/features/summary_page_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Summary pages', type: :feature do
     login
 
     detainee = create(:detainee)
-    move = create(:move, :active)
+    move = create(:move)
     risk = create(:risk)
     healthcare = create(:healthcare)
     escort = create(:escort, detainee: detainee, move: move, risk: risk, healthcare: healthcare)

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -2,24 +2,4 @@ require 'rails_helper'
 
 RSpec.describe Move, type: :model do
   subject(:move) { described_class.new }
-
-  describe '#issued?' do
-    context 'when the move is still in incomplete status' do
-      let(:move_workflow) { build(:move_workflow) }
-      subject(:move) { build(:move, move_workflow: move_workflow) }
-      specify { is_expected.not_to be_issued }
-    end
-
-    context 'when the move is in confirmed status' do
-      let(:move_workflow) { build(:move_workflow, :confirmed) }
-      subject(:move) { build(:move, move_workflow: move_workflow) }
-      specify { is_expected.not_to be_issued }
-    end
-
-    context 'when the move is in issued status' do
-      let(:move_workflow) { build(:move_workflow, :issued) }
-      subject(:move) { build(:move, move_workflow: move_workflow) }
-      specify { is_expected.to be_issued }
-    end
-  end
 end

--- a/spec/models/move_workflow_spec.rb
+++ b/spec/models/move_workflow_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe MoveWorkflow do
-  subject { described_class.new }
-  specify { expect(subject.type).to eq('move') }
-  include_examples 'workflow'
-end

--- a/spec/presenters/move_presenter_spec.rb
+++ b/spec/presenters/move_presenter_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe MovePresenter, type: :presenter do
-  let(:move) { FactoryGirl.create(:move) }
+  let(:move) { create(:move) }
   subject { described_class.new(move) }
 
   describe '#humanized_date' do
-    let(:move) { FactoryGirl.build(:move, date: Date.civil(2017, 6, 14)) }
+    let(:move) { build(:move, date: Date.civil(2017, 6, 14)) }
     its(:humanized_date) { is_expected.to eq '14 Jun 2017' }
   end
 

--- a/spec/requests/confirm_healthcare_assessment_request_spec.rb
+++ b/spec/requests/confirm_healthcare_assessment_request_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe 'Confirm healthcare assessment requests', type: :request do
 
     context 'but the escort is no longer editable' do
       let(:healthcare) { create(:healthcare) }
-      let(:move) { create(:move, :issued) }
+      let(:move) { create(:move) }
       let(:detainee) { create(:detainee) }
-      let(:escort) { create(:escort, detainee: detainee, move: move, healthcare: healthcare) }
+      let(:escort) { create(:escort, :issued, detainee: detainee, move: move, healthcare: healthcare) }
 
       it 'redirects to the homepage displaying an appropriate error' do
         put "/escorts/#{escort.id}/healthcare/confirm"

--- a/spec/requests/confirm_risk_assessment_request_spec.rb
+++ b/spec/requests/confirm_risk_assessment_request_spec.rb
@@ -36,10 +36,7 @@ RSpec.describe 'Confirm risk assessment requests', type: :request do
     end
 
     context 'but the escort is no longer editable' do
-      let(:healthcare) { create(:healthcare) }
-      let(:move) { create(:move, :issued) }
-      let(:detainee) { create(:detainee) }
-      let(:escort) { create(:escort, detainee: detainee, move: move, healthcare: healthcare) }
+      let(:escort) { create(:escort, :issued) }
 
       it 'redirects to the homepage displaying an appropriate error' do
         put "/escorts/#{escort.id}/risk/confirm"

--- a/spec/requests/create_escort_request_spec.rb
+++ b/spec/requests/create_escort_request_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe 'Create escort request', type: :request do
 
       escort = Escort.where(prison_number: prison_number).first
       expect(escort.detainee).to be_an_instance_of(Detainee)
-      expect(escort.move).to be_an_instance_of(Move)
+      expect(escort.move).to be_nil
 
-      expect(response).to redirect_to(edit_escort_move_path(escort))
+      expect(response).to redirect_to(new_escort_move_path(escort))
     end
   end
 end

--- a/spec/requests/edit_detainee_request_spec.rb
+++ b/spec/requests/edit_detainee_request_spec.rb
@@ -27,8 +27,7 @@ RSpec.describe 'Edit detainee requests', type: :request do
     end
 
     context 'when the escort is no longer editable' do
-      let(:move) { create(:move, :issued) }
-      let(:escort) { create(:escort, prison_number: prison_number, move: move) }
+      let(:escort) { create(:escort, :issued) }
 
       it 'redirects to the homepage displaying an appropriate error' do
         get "/escorts/#{escort.id}/detainee/edit"

--- a/spec/requests/new_detainee_request_spec.rb
+++ b/spec/requests/new_detainee_request_spec.rb
@@ -37,8 +37,7 @@ RSpec.describe 'New detainee requests', type: :request do
     end
 
     context 'when the escort is no longer editable' do
-      let(:move) { create(:move, :issued) }
-      let(:escort) { create(:escort, prison_number: prison_number, move: move) }
+      let(:escort) { create(:escort, :issued, prison_number: prison_number) }
 
       it 'redirection to the home page' do
         get "/escorts/#{escort.id}/detainee/new"

--- a/spec/requests/new_move_request_spec.rb
+++ b/spec/requests/new_move_request_spec.rb
@@ -25,8 +25,7 @@ RSpec.describe 'New Move requests', type: :request do
       end
 
       context 'but the escort is no longer editable' do
-        let(:move) { create(:move, :issued) }
-        let(:escort) { create(:escort, detainee: detainee, move: move) }
+        let(:escort) { create(:escort, :issued, detainee: detainee) }
 
         it 'redirects to the homepage displaying an appropriate error' do
           get "/escorts/#{escort.id}/move/new"
@@ -36,7 +35,7 @@ RSpec.describe 'New Move requests', type: :request do
       end
 
       context "when the PER already has a move" do
-        let(:move) { create(:move, :active) }
+        let(:move) { create(:move) }
         let(:escort) { create(:escort, detainee: detainee, move: move) }
 
         it "redirects to the PER page" do
@@ -74,8 +73,7 @@ RSpec.describe 'New Move requests', type: :request do
       end
 
       context 'but the escort is no longer editable' do
-        let(:move) { create(:move, :issued) }
-        let(:escort) { create(:escort, detainee: detainee, move: move) }
+        let(:escort) { create(:escort, :issued, detainee: detainee) }
 
         it 'redirects to the homepage displaying an appropriate error' do
           post "/escorts/#{escort.id}/move", params: move_params
@@ -85,7 +83,7 @@ RSpec.describe 'New Move requests', type: :request do
       end
 
       context "when the PER already has a move" do
-        let(:move) { create(:move, :active) }
+        let(:move) { create(:move) }
         let(:escort) { create(:escort, detainee: detainee, move: move) }
 
         it "redirects to the PER page displaying the appropriate error" do

--- a/spec/requests/offences_request_spec.rb
+++ b/spec/requests/offences_request_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 RSpec.describe 'Offences', type: :request do
   let(:prison_number) { 'A1234BC' }
   let(:detainee) { create(:detainee, prison_number: prison_number) }
-  let(:move) { create(:move, :active) }
+  let(:move) { create(:move) }
   let(:escort) { create(:escort, prison_number: prison_number, detainee: detainee, move: move) }
   let(:offences) { escort.offences }
-  let(:form_data) { 
-    { 
+  let(:form_data) {
+    {
       offences: {
         offences_attributes: {
-          "0" => { 
+          "0" => {
             id: "some-uuid",
             offence: "some offence",
             case_reference: "1234LOL",
@@ -51,15 +51,14 @@ RSpec.describe 'Offences', type: :request do
       end
 
       context 'but the escort is no longer editable' do
-        let(:move) { create(:move, :issued) }
-        let(:escort) { create(:escort, detainee: detainee, move: move) }
+        let(:escort) { create(:escort, :issued) }
 
         it 'still displays the offences page' do
           get "/escorts/#{escort.id}/offences"
           expect(response).to have_http_status(200)
         end
       end
-      
+
       context 'and there are no offences associated with the detainee' do
         let(:detainee) { create(:detainee, :with_no_offences, prison_number: prison_number) }
         let(:move) { create(:move) }
@@ -107,8 +106,7 @@ RSpec.describe 'Offences', type: :request do
       end
 
       context 'but the escort is no longer editable' do
-        let(:move) { create(:move, :issued) }
-        let(:escort) { create(:escort, detainee: detainee, move: move) }
+        let(:escort) { create(:escort, :issued) }
 
         it 'redirects to the homepage displaying an appropriate error' do
           put "/escorts/#{escort.id}/offences", params: form_data

--- a/spec/requests_confirm_healthcare_assessment_request_spec.rb
+++ b/spec/requests_confirm_healthcare_assessment_request_spec.rb
@@ -36,10 +36,7 @@ RSpec.describe 'Confirm healthcare assessment requests', type: :request do
     end
 
     context 'but the escort is no longer editable' do
-      let(:healthcare) { create(:healthcare) }
-      let(:move) { create(:move, :issued) }
-      let(:detainee) { create(:detainee) }
-      let(:escort) { create(:escort, detainee: detainee, move: move, healthcare: healthcare) }
+      let(:escort) { create(:escort, :issued) }
 
       it 'redirects to the homepage displaying an appropriate error' do
         put "/escorts/#{escort.id}/healthcare/confirm"

--- a/spec/services/create_escort_spec.rb
+++ b/spec/services/create_escort_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe EscortCreator, type: :service do
       expect_risk_assessment_to_be_cloned(existent_escort, escort)
       expect_healthcare_assessment_to_be_cloned(existent_escort, escort)
       expect_offences_to_be_cloned(existent_escort, escort)
-      expect_moves_to_be_cloned(existent_escort, escort)
+      expect(escort.move).to be_nil
     end
   end
 
@@ -58,18 +58,6 @@ RSpec.describe EscortCreator, type: :service do
     expected_offences_attributes = existent_escort.offences.map { |o| o.attributes.except(*except_current_offences_attributes) }
     offences_attributes = new_escort.offences.map { |o| o.attributes.except(*except_current_offences_attributes) }
     expect(offences_attributes).to match_array(expected_offences_attributes)
-  end
-
-  def expect_moves_to_be_cloned(existent_escort, new_escort)
-    move_attributes = existent_escort.move.attributes.except(*except_move_attributes)
-    expect(new_escort.move.id).not_to eq(existent_escort.move.id)
-    expect(new_escort.move.date).to be_nil
-    expect(new_escort.move).to have_attributes(move_attributes)
-    expect(new_escort.move.status).to eq('incomplete')
-
-    expected_destinations_attributes = existent_escort.move.destinations.map { |d| d.attributes.except(*except_destinations_attributes) }
-    destinations_attributes = new_escort.move.destinations.map { |d| d.attributes.except(*except_destinations_attributes) }
-    expect(destinations_attributes).to match_array(expected_destinations_attributes)
   end
 
   def except_attributes

--- a/spec/services/escorts/delete_historic_unissued_spec.rb
+++ b/spec/services/escorts/delete_historic_unissued_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Escorts::DeleteHistoricUnissued do
     create(:escort, move: create(:move, date: 3.days.ago))
     create(:escort, move: create(:move, date: 1.day.ago))
 
-    create(:escort, move: create(:move, :issued, date: 3.days.ago))
-    create(:escort, move: create(:move, :issued, date: 1.day.ago))
+    create(:escort, :issued, move: create(:move, date: 3.days.ago))
+    create(:escort, :issued, move: create(:move, date: 1.day.ago))
 
     create(:escort, move: create(:move, date: 1.hour.ago))
-    create(:escort, move: create(:move, :issued, date: 1.hour.ago))
+    create(:escort, :issued, move: create(:move, date: 1.hour.ago))
 
     expect { described_class.call(options) }.to change { Escort.count }.from(6).to(4)
     expect(Escort.unscoped.count).to eq(6)


### PR DESCRIPTION
[Trello](https://trello.com/c/bG6jHjqP/47-2-as-someone-adding-new-move-details-to-an-existing-profile-with-a-previous-move-on-moving-people-safely-i-do-not-want-the-appli)

Until now asserting the state of the escort was being delegated to the
move due to the phased migration from the legacy data model.

From now on, escort will respond directly to its current status.

Also, whenever we're re-using an existent escort to create a new one for the same prisoner, the move details are not copied across.