### PR TITLE
Make offences data read only for issued PERs

### DIFF
--- a/app/views/offences/show.html.slim
+++ b/app/views/offences/show.html.slim
@@ -14,29 +14,39 @@
     header
       h1 Offences
 
-  = GovukElementsErrorsHelper.error_summary form,
-    'There were problems saving this form', ''
+  - if escort.issued?
+    table#offences-table
+      thead
+        tr
+          th Offence
+          th Case Reference
+      - escort.offences.each do |offence|
+        tr
+          td = offence.offence
+          td = offence.case_reference
+  - else
+    = form_for form, url: escort_offences_path(escort), method: :put do |f|
+      = f.error_messages
 
-  = form_for form, url: escort_offences_path(escort), method: :put do |f|
-    fieldset.form-group
-      legend.heading-medium Current offences
+      fieldset.form-group
+        legend.heading-medium Current offences
 
-      .multiple
-        = f.fields_for :offences do |cf|
-          .multiple-wrapper class=(cf.index == 0 ? 'multiple-first' : 'multiple-not-first')
-            = cf.hidden_field :id
-            .multiple-field.inline.wide
-              = cf.text_area :offence, rows: 1
-            .multiple-field.inline
-              = cf.text_field :case_reference
-            .multiple-field.inline.remove-link
-              = cf.label :_delete, 'Remove'
-              = cf.check_box :_delete
+        .multiple
+          = f.fields_for :offences do |cf|
+            .multiple-wrapper class=(cf.index == 0 ? 'multiple-first' : 'multiple-not-first')
+              = cf.hidden_field :id
+              .multiple-field.inline.wide
+                = cf.text_area :offence, rows: 1
+              .multiple-field.inline
+                = cf.text_field :case_reference
+              .multiple-field.inline.remove-link
+                = cf.label :_delete, 'Remove'
+                = cf.check_box :_delete
 
-        .multiple-field.multiple-add
-          =f.submit 'Add offence',
-            class: 'js-anchor-focus',
-            name: "offences_add_offence"
+          .multiple-field.multiple-add
+            =f.submit 'Add offence',
+              class: 'js-anchor-focus',
+              name: "offences_add_offence"
 
-    .form-actions
-      = f.submit 'Save and continue', class: 'button'
+      .form-actions
+        = f.submit 'Save and continue', class: 'button'

--- a/spec/features/issued_per_spec.rb
+++ b/spec/features/issued_per_spec.rb
@@ -1,0 +1,31 @@
+require 'feature_helper'
+
+RSpec.feature 'issued PERs', type: :feature do
+  scenario 'Checking issued PER sections are read only' do
+    login
+
+    escort = create(:escort, :issued)
+
+    visit escort_path(escort)
+
+    escort_page.confirm_read_only_detainee_details
+    escort_page.confirm_read_only_move_details
+
+    escort_page.confirm_healthcare_status('Complete')
+    escort_page.confirm_healthcare_action_link('View')
+    escort_page.click_edit_healthcare('View')
+    healthcare_summary.confirm_read_only
+    healthcare_summary.click_back_to_per_page
+
+    escort_page.confirm_risk_status('Complete')
+    escort_page.confirm_risk_action_link('View')
+    escort_page.click_edit_risk('View')
+    risk_summary.confirm_read_only
+    risk_summary.click_back_to_per_page
+
+    escort_page.confirm_offences_status('Complete')
+    escort_page.confirm_offences_action_link('View')
+    escort_page.click_edit_offences('View')
+    offences.confirm_read_only
+  end
+end

--- a/spec/features/pages/assessment_summary_page_helpers.rb
+++ b/spec/features/pages/assessment_summary_page_helpers.rb
@@ -1,0 +1,73 @@
+module Page
+  module AssessmentSummaryPageHelpers
+    def confirm_status(expected_status)
+      within('header h3') do
+        expect(page).to have_content(expected_status)
+      end
+    end
+
+    def confirm_read_only
+      expect(page).not_to have_link('Change')
+    end
+
+    def click_back_to_per_page
+      click_link 'View PER'
+    end
+
+    def check_section_is_all_no(doc, section, questions)
+      check_change_link(doc, section)
+      questions.each do |question|
+        check_question_is_no(doc, section, question)
+      end
+    end
+
+    def check_section(doc, section, questions)
+      check_change_link(doc, section)
+      questions.each do |question|
+        check_question(doc, section, question)
+      end
+    end
+
+    def check_change_link(doc, section)
+      within("table.#{section}") do
+        within('thead') { expect(page).to have_link "Change" }
+      end
+    end
+
+    def check_question_is_no(doc, section, question)
+      within("table.#{section}") do
+        within("tr.#{question.underscore} td:nth-child(2)") do
+          expect(page).to have_text('No'),
+            "Expected #{section}/#{question} to be 'No': wasn't."
+        end
+      end
+    end
+
+    def check_question(doc, section, question)
+      within("table.#{section}") do
+        within("tr.#{question.underscore} td:nth-child(2)") do
+          option = doc.public_send(question.to_sym)
+          boolean_result = [true, false].include?(option)
+          if boolean_result || option
+            if boolean_result
+              expected_answer = option ? 'Yes' : 'No'
+            else
+              expected_answer = option.titlecase
+            end
+            expect(page).to have_text(expected_answer),
+              "Expected #{section}/#{question} to be shown: wasn't."
+          else
+            fail "Expected #{section}/#{question} to be shown: wasn't."
+          end
+        end
+        within("tr.#{question.underscore} td:nth-child(3)") do
+          details = "#{question}_details".to_sym
+          if doc.respond_to?(details)
+            expect(page).to have_text(doc.public_send details),
+              "Expected more details from #{section}/#{question}: didn't get 'em."
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/pages/escort.rb
+++ b/spec/features/pages/escort.rb
@@ -59,6 +59,18 @@ module Page
       end
     end
 
+    def confirm_read_only_detainee_details
+      within('#personal-details') do
+        expect(page).not_to have_link('Edit')
+      end
+    end
+
+    def confirm_read_only_move_details
+      within('.move-information') do
+        expect(page).not_to have_link('Edit')
+      end
+    end
+
     def confirm_detainee_details(detainee)
       within('#personal-details') do
         expect(page).to have_content detainee.prison_number
@@ -135,29 +147,47 @@ module Page
       end
     end
 
-    def click_edit_healthcare
-      within('#healthcare') do
-        click_link 'Edit'
-      end
+    def click_edit_healthcare(name = 'Edit')
+      click_per_section_action_link(:healthcare, name)
     end
 
-    def click_edit_risk
-      within('#risk') do
-        click_link 'Edit'
-      end
+    def click_edit_risk(name = 'Edit')
+      click_per_section_action_link(:risk, name)
     end
 
-    def click_edit_offences
-      within('#offences') do
-        click_link 'Edit'
-      end
+    def click_edit_offences(name = 'Edit')
+      click_per_section_action_link(:offences, name)
     end
 
     def click_print
       click_link 'Print'
     end
 
+    def confirm_healthcare_action_link(name)
+      confirm_per_section_action_link(:healthcare, name)
+    end
+
+    def confirm_risk_action_link(name)
+      confirm_per_section_action_link(:risk, name)
+    end
+
+    def confirm_offences_action_link(name)
+      confirm_per_section_action_link(:offences, name)
+    end
+
     private
+
+    def click_per_section_action_link(section, name = 'Edit')
+      within("##{section}") do
+        click_link name
+      end
+    end
+
+    def confirm_per_section_action_link(section, name)
+      within("##{section}") do
+        expect(page).to have_link(name)
+      end
+    end
 
     def age(dob)
       now = Time.now.utc.to_date

--- a/spec/features/pages/healthcare_summary.rb
+++ b/spec/features/pages/healthcare_summary.rb
@@ -1,9 +1,5 @@
 module Page
   class HealthcareSummary < Base
-    def confirm_status(expected_status)
-      within('header h3') do
-        expect(page).to have_content(expected_status)
-      end
-    end
+    include Page::AssessmentSummaryPageHelpers
   end
 end

--- a/spec/features/pages/offences.rb
+++ b/spec/features/pages/offences.rb
@@ -28,6 +28,11 @@ module Page
         to have_content("Offences aren't available right now, please try again or fill in the offences below")
     end
 
+    def confirm_read_only
+      expect(page).not_to have_selector('form.edit_offences')
+      expect(page).to have_selector('#offences-table')
+    end
+
     private
 
     def insert_into_row(row, description, case_reference)

--- a/spec/features/pages/risk_summary.rb
+++ b/spec/features/pages/risk_summary.rb
@@ -1,10 +1,6 @@
 module Page
   class RiskSummary < Base
-    def confirm_status(expected_status)
-      within('header h3') do
-        expect(page).to have_content(expected_status)
-      end
-    end
+    include Page::AssessmentSummaryPageHelpers
 
     def confirm_risk_details(risk)
       check_section(risk, 'risk_to_self', %w[acct_status])
@@ -18,62 +14,6 @@ module Page
       check_section(risk, 'substance_misuse', %w[substance_supply])
       check_concealed_weapons_section(risk)
       check_section(risk, 'arson', %w[ arson ])
-    end
-
-    def check_section_is_all_no(doc, section, questions)
-      check_change_link(doc, section)
-      questions.each do |question|
-        check_question_is_no(doc, section, question)
-      end
-    end
-
-    def check_section(doc, section, questions)
-      check_change_link(doc, section)
-      questions.each do |question|
-        check_question(doc, section, question)
-      end
-    end
-
-    def check_change_link(doc, section)
-      within("table.#{section}") do
-        within('thead') { expect(page).to have_link "Change" }
-      end
-    end
-
-    def check_question_is_no(doc, section, question)
-      within("table.#{section}") do
-        within("tr.#{question.underscore} td:nth-child(2)") do
-          expect(page).to have_text('No'),
-            "Expected #{section}/#{question} to be 'No': wasn't."
-        end
-      end
-    end
-
-    def check_question(doc, section, question)
-      within("table.#{section}") do
-        within("tr.#{question.underscore} td:nth-child(2)") do
-          option = doc.public_send(question.to_sym)
-          boolean_result = [true, false].include?(option)
-          if boolean_result || option
-            if boolean_result
-              expected_answer = option ? 'Yes' : 'No'
-            else
-              expected_answer = option.titlecase
-            end
-            expect(page).to have_text(expected_answer),
-              "Expected #{section}/#{question} to be shown: wasn't."
-          else
-            fail "Expected #{section}/#{question} to be shown: wasn't."
-          end
-        end
-        within("tr.#{question.underscore} td:nth-child(3)") do
-          details = "#{question}_details".to_sym
-          if doc.respond_to?(details)
-            expect(page).to have_text(doc.public_send details),
-              "Expected more details from #{section}/#{question}: didn't get 'em."
-          end
-        end
-      end
     end
 
     private


### PR DESCRIPTION
So far, after the PER had been issued it was still possible to attempt
to change the offences information (although, once the form was
submitted an error would be shown).

These changes ensure that the user can no longer attempt to change that
information, and that information is displayed in a table format rather
than in a form as they were until now.

Took the opportunity as well to do some small refactoring in the specs
for the assessment summary pages and extract their common functionality
into a mixin.