### PR TITLE
Remove no longer necessary columns for risk and healthcare

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -364,14 +364,8 @@ en:
         controlled_unlock_details: 'Give details of personal protection equipment (PPE) required:'
         co_defendant_details: Give details
         csra: In NOMIS, check the header section of the prisoner’s record for the CSRA risk level.
-        escort_or_court_staff_details: Give details eg spits, punches, kicks, shouts, uses weapons
         gang_member_details: Give details
-        healthcare_staff_details: Give details eg spits, punches, kicks, shouts, uses weapons
-        other_detainees_details: Give details eg spits, punches, kicks, shouts, uses weapons
         other_violence_to_other_detainees_details: Give details
-        police_details: Give details eg spits, punches, kicks, shouts, uses weapons
-        prison_staff_details: Give details eg spits, punches, kicks, shouts, uses weapons
-        public_offence_related_details: Give details eg spits, punches, kicks, shouts, uses weapons
         violence_to_general_public_html: 'In NOMIS, check the header section of the prisoner’s record for relevant alerts, <i>Case management > Case notes</i>, and <i>Adjudications</i> for relevant information.'
         violence_to_general_public_details: Give details
         violence_to_other_detainees_html: 'In NOMIS, check alert comments if the CSRA High alert is active and <i>Security > Non-association</i> for known risks to named prisoners.'
@@ -524,14 +518,8 @@ en:
           co_defendant: Co-defendant
           controlled_unlock_required: Controlled unlock
           csra: CSRA (Cell Sharing Risk Assessment)
-          escort_or_court_staff: Escort or court staff
           gang_member: Gang member
-          healthcare_staff: Healthcare staff
-          other_detainees: Other detainees
           other_violence_to_other_detainees: Other known conflicts
-          police: Police
-          prison_staff: Prison staff
-          public_offence_related: Public/offence related
           violence_to_general_public: Violent to anyone else
           violence_to_staff: Violent to staff
         csra: *summary_violence

--- a/db/migrate/20170605103446_remove_obsolete_risk_columns.rb
+++ b/db/migrate/20170605103446_remove_obsolete_risk_columns.rb
@@ -1,0 +1,23 @@
+class RemoveObsoleteRiskColumns < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :risks, :detainee_id, :uuid
+    remove_column :risks, :category_a_details, :text
+    remove_column :risks, :bully, :boolean
+    remove_column :risks, :bully_details, :text
+    remove_column :risks, :intimidator, :boolean
+    remove_column :risks, :intimidator_details, :text
+    remove_column :risks, :police, :boolean
+    remove_column :risks, :police_details, :text
+    remove_column :risks, :public_offence_related, :boolean
+    remove_column :risks, :public_offence_related_details, :text
+    remove_column :risks, :other_detainees, :boolean
+    remove_column :risks, :other_detainees_details, :text
+    remove_column :risks, :healthcare_staff, :boolean
+    remove_column :risks, :healthcare_staff_details, :text
+    remove_column :risks, :escort_or_court_staff, :boolean
+    remove_column :risks, :escort_or_court_staff_details, :text
+    remove_column :risks, :prison_staff, :boolean
+    remove_column :risks, :prison_staff_details, :text
+    remove_column :risks, :violent, :string
+  end
+end

--- a/db/migrate/20170605105913_remove_obsolete_healthcare_columns.rb
+++ b/db/migrate/20170605105913_remove_obsolete_healthcare_columns.rb
@@ -1,0 +1,5 @@
+class RemoveObsoleteHealthcareColumns < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :healthcare, :detainee_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170601090245) do
+ActiveRecord::Schema.define(version: 20170605105913) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,13 +62,11 @@ ActiveRecord::Schema.define(version: 20170601090245) do
     t.string   "contact_number"
     t.datetime "created_at",                                  null: false
     t.datetime "updated_at",                                  null: false
-    t.uuid     "detainee_id"
     t.uuid     "escort_id"
     t.integer  "status",                  default: 0
     t.integer  "reviewer_id"
     t.datetime "reviewed_at"
     t.text     "medications"
-    t.index ["detainee_id"], name: "index_healthcare_on_detainee_id", using: :btree
     t.index ["escort_id"], name: "index_healthcare_on_escort_id", using: :btree
   end
 
@@ -97,41 +95,22 @@ ActiveRecord::Schema.define(version: 20170601090245) do
   create_table "risks", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string   "rule_45",                                           default: "unknown"
     t.string   "csra",                                              default: "unknown"
-    t.string   "violent",                                           default: "unknown"
-    t.boolean  "prison_staff"
-    t.text     "prison_staff_details"
     t.string   "risk_to_females"
     t.text     "risk_to_females_details"
-    t.boolean  "escort_or_court_staff"
-    t.text     "escort_or_court_staff_details"
-    t.boolean  "healthcare_staff"
-    t.text     "healthcare_staff_details"
-    t.boolean  "other_detainees"
-    t.text     "other_detainees_details"
     t.string   "homophobic"
     t.text     "homophobic_details"
     t.string   "racist"
     t.text     "racist_details"
-    t.boolean  "public_offence_related"
-    t.text     "public_offence_related_details"
-    t.boolean  "police"
-    t.text     "police_details"
-    t.boolean  "intimidator"
-    t.text     "intimidator_details"
-    t.boolean  "bully"
-    t.text     "bully_details"
     t.string   "sex_offence",                                       default: "unknown"
     t.string   "current_e_risk",                                    default: "unknown"
     t.text     "current_e_risk_details"
     t.string   "category_a",                                        default: "unknown"
-    t.text     "category_a_details"
     t.string   "substance_supply",                                  default: "unknown"
     t.string   "conceals_weapons",                                  default: "unknown"
     t.text     "conceals_weapons_details"
     t.string   "arson",                                             default: "unknown"
     t.datetime "created_at",                                                            null: false
     t.datetime "updated_at",                                                            null: false
-    t.uuid     "detainee_id"
     t.string   "acct_status"
     t.text     "acct_status_details"
     t.date     "date_of_most_recently_closed_acct"
@@ -208,7 +187,6 @@ ActiveRecord::Schema.define(version: 20170601090245) do
     t.text     "must_return_to_details"
     t.string   "must_not_return"
     t.text     "must_not_return_details"
-    t.index ["detainee_id"], name: "index_risks_on_detainee_id", using: :btree
     t.index ["escort_id"], name: "index_risks_on_escort_id", using: :btree
   end
 


### PR DESCRIPTION
This columns are no longer used in the application and as so should just be removed.

📓 This shows again that having a table that we need to keep adding/removing columns based on the assessment requirements is not sustainable. We should be moving towards a solution that can record questions without the need to add new columns to a table in the database.