### PR TITLE
Details for a question are now separate by a pipe.

### DIFF
--- a/app/presenters/print/assessment_question_presenter.rb
+++ b/app/presenters/print/assessment_question_presenter.rb
@@ -37,7 +37,7 @@ module Print
         elsif public_send(subquestion.name).present?
           output << detail_content(subquestion.name)
         end
-      end.join('. ')
+      end.join(' | ')
     end
 
     private

--- a/app/presenters/summary/assessment_question_presenter.rb
+++ b/app/presenters/summary/assessment_question_presenter.rb
@@ -20,7 +20,7 @@ module Summary
         elsif public_send(dependency.name).present?
           output << detail_content(dependency.name)
         end
-      end.join('. ')
+      end.join(' | ')
     end
 
     private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -485,8 +485,6 @@ en:
           sex_offence_adult_female_victim: Adult female
           sex_offence_under18_victim: Under 18
           date_most_recent_sexual_offence: Most recent sex offence
-        return_instructions:
-          must_return_to: 'Prison name: '
         risk_from_others:
           high_profile: High public interest
           rule_45: Rule 45

--- a/spec/presenters/print/assessment_question_presenter_spec.rb
+++ b/spec/presenters/print/assessment_question_presenter_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Print::AssessmentQuestionPresenter do
       }
 
       it 'returns a string with the combined details for the question' do
-        expect(presenter.details).to eq('Foo. Bar')
+        expect(presenter.details).to eq('Foo | Bar')
       end
 
       context 'when one of the details is empty' do
@@ -179,7 +179,7 @@ RSpec.describe Print::AssessmentQuestionPresenter do
         end
 
         it 'prepends the localised label for the specified detail in the returned string' do
-          expect(presenter.details).to eq('Localised question detail 1: Foo. Bar')
+          expect(presenter.details).to eq('Localised question detail 1: Foo | Bar')
         end
       end
 
@@ -191,7 +191,7 @@ RSpec.describe Print::AssessmentQuestionPresenter do
         end
 
         it 'prepends the localised label for the specified detail in the returned string' do
-          expect(presenter.details).to eq('Foo. Localised answer detail 2')
+          expect(presenter.details).to eq('Foo | Localised answer detail 2')
         end
       end
     end

--- a/spec/support/fixtures/pdf-text-all-yes-answers.txt
+++ b/spec/support/fixtures/pdf-text-all-yes-answers.txt
@@ -70,7 +70,7 @@ Violent to other prisoners       Yes
 Violent to anyone else           Yes
   Violent to anyone else         Yes      Violence to general public details
 Controlled unlock                Yes
-  Controlled unlock              Yes      More than 4 officers. Many people to hold the prisoner
+  Controlled unlock              Yes      More than 4 officers | Many people to hold the prisoner
 Hostage taker                    Yes
   Staff                          Yes      Last incident: 12/03/2010
   Prisoners                      Yes      Last incident: 24/05/2012
@@ -114,7 +114,7 @@ Weapons, drugs or other items    Yes
 Arson                            Yes
   Arsonist                       Yes
 Return Instructions              Yes
-  Must Return                    Yes          Prison name: Alcatraz. Some special reason
+  Must Return                    Yes          Alcatraz | Some special reason
   Must Not Return                Yes          Alcatraz | Bad bad stuff happens there
                                               York castle prison | Does not like it
 Other risk information           Yes


### PR DESCRIPTION
Relates to: [Trello](https://trello.com/c/jC5rtj3j/181-(3)-must%2Fmust-not---amends-to-profile%2C-risk-summary-and-print-out)

Previously the list of details for a question presented both in the
summary and the printout were separate by a dot.