### PR TITLE
Add reviewer info to profile and print page

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -155,6 +155,10 @@ table {
     page-break-inside: avoid;
   }
 
+  th {
+    padding: 10px 0;
+  }
+
   td {
     font-weight: lighter;
     padding: 0.3em 0;
@@ -207,6 +211,10 @@ table {
   color: grey;
   font-size: 48px;
   font-weight: bold;
+}
+
+.timestamp {
+  margin-left: 10px;
 }
 
 .footer {

--- a/app/models/healthcare.rb
+++ b/app/models/healthcare.rb
@@ -37,4 +37,8 @@ class Healthcare < ApplicationRecord
   def default_contact_number
     current_establishment&.default_healthcare_contact_number
   end
+
+  def reviewed?
+    reviewer.present? && reviewed_at.present?
+  end
 end

--- a/app/models/risk.rb
+++ b/app/models/risk.rb
@@ -23,4 +23,8 @@ class Risk < ApplicationRecord
       status: :confirmed
     )
   end
+
+  def reviewed?
+    reviewer.present? && reviewed_at.present?
+  end
 end

--- a/app/services/escort_creator.rb
+++ b/app/services/escort_creator.rb
@@ -25,7 +25,11 @@ class EscortCreator
     :healthcare
   ].freeze
 
-  EXCEPT_GRAPH = [:issued_at].freeze
+  EXCEPT_GRAPH = [
+    :issued_at,
+    { risk: [:reviewer_id, :reviewed_at] },
+    { healthcare: [:reviewer_id, :reviewed_at] }
+  ].freeze
 
   def existent_escort
     @existent_escort ||= Escort.find_by(prison_number: prison_number)

--- a/app/views/escorts/_healthcare.html.slim
+++ b/app/views/escorts/_healthcare.html.slim
@@ -4,7 +4,9 @@
 
   h2
     ' Healthcare
-    / small 16:44 | 04 Apr 2016
+    - if healthcare&.reviewed?
+      small
+        = t('assessment.confirmed_timestamp', name: healthcare.reviewer.full_name, time: healthcare.reviewed_at.to_s(:humanized))
   - if healthcare
     .info-table.info-table-big
       .grid-row

--- a/app/views/escorts/_risk.html.slim
+++ b/app/views/escorts/_risk.html.slim
@@ -1,12 +1,12 @@
 #risk
   = render partial: 'status',
-    locals: { workflow: risk,
-              not_started_path: new_escort_risks_path(escort),
-              summary_path: escort_risks_path(escort) }
+    locals: { workflow: risk, not_started_path: new_escort_risks_path(escort), summary_path: escort_risks_path(escort) }
 
   h2
     ' Risk
-    / small 16:44 | 04 Apr 2016
+    - if risk&.reviewed?
+      small
+        = t('assessment.confirmed_timestamp', name: risk.reviewer.full_name, time: risk.reviewed_at.to_s(:humanized))
   - if risk
     .info-table.info-table-big
       .grid-row

--- a/app/views/escorts/print/show.html.slim
+++ b/app/views/escorts/print/show.html.slim
@@ -24,18 +24,29 @@ html
       div#risk-section.section
         span.watermark = 'Risk'
         table#risk-table.section-table
+          tr
+            th colspan=3
+              span.heading-large= 'RISK'
+              span.timestamp= t('assessment.confirmed_timestamp', name: risk.reviewer.full_name, time: risk.reviewed_at.to_s(:humanized))
           - risk.sections.each do |section|
             = render partial: 'escorts/print/section',
               locals: { section: Print::AssessmentSectionPresenter.new(section) }
       div#healthcare-section.section
         span.watermark = 'Healthcare'
         table#healthcare-table.section-table
+          tr
+            th colspan=3
+              span.heading-large= 'HEALTHCARE'
+              span.timestamp= t('assessment.confirmed_timestamp', name: healthcare.reviewer.full_name, time: healthcare.reviewed_at.to_s(:humanized))
           - healthcare.sections.each do |section|
             = render partial: 'escorts/print/section',
               locals: { section: Print::AssessmentSectionPresenter.new(section) }
       div#offences-section.section
         span.watermark = 'Offences'
         table#offences-table.section-table
+          tr
+            th colspan=3
+              span.heading-large= 'OFFENCES'
           tr
             td.column-30-percent
               = offences.label

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,7 @@ module MovingPeopleSafely
     config.feedback_url = ''
     config.assets.paths << Rails.root.join('vendor', 'bower')
     config.autoload_paths << "#{Rails.root}/app/models/sections"
+    config.time_zone = 'London'
 
     require "#{config.root}/app/form_builders/govuk_elements_errors_helper"
     require "#{config.root}/app/form_builders/mps_form_builder"

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,2 +1,3 @@
 Date::DATE_FORMATS[:default] = "%d/%m/%Y"
 Date::DATE_FORMATS[:humanized] = "%d %b %Y"
+Time::DATE_FORMATS[:humanized] = "%H:%M | %d %b %Y"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -574,6 +574,8 @@ en:
         mpv: MPV
         not_for_release: Not for release
         rule_45: Rule 45
+  assessment:
+    confirmed_timestamp: "Last confirmed: %{name}, %{time}"
   print:
     <<: *summary
     <<: *escort

--- a/spec/config/date_format_spec.rb
+++ b/spec/config/date_format_spec.rb
@@ -9,9 +9,16 @@ RSpec.describe 'custom date formats', type: :config do
   end
 
   describe 'humanized date format' do
-    it 'returns a date in the format DD/MM/YYYY' do
+    it 'returns a date in the format DD MM YYYY' do
       example_date = Date.civil(1940, 3, 10)
       expect(example_date.to_s(:humanized)).to eq '10 Mar 1940'
+    end
+  end
+
+  describe 'humanized time format' do
+    it 'returns a time in the format HH:MM | DD MM YYYY' do
+      example_time = DateTime.civil(1940, 3, 10, 12, 30)
+      expect(example_time.to_s(:humanized)).to eq '12:30 | 10 Mar 1940'
     end
   end
 end

--- a/spec/factories/healthcare_factory.rb
+++ b/spec/factories/healthcare_factory.rb
@@ -26,6 +26,8 @@ FactoryGirl.define do
 
     trait :confirmed do
       status :confirmed
+      association :reviewer, factory: :user
+      reviewed_at 1.day.ago
     end
 
     trait :issued do

--- a/spec/factories/risk_factory.rb
+++ b/spec/factories/risk_factory.rb
@@ -47,6 +47,8 @@ FactoryGirl.define do
 
     trait :confirmed do
       status :confirmed
+      association :reviewer, factory: :user
+      reviewed_at 1.day.ago
     end
 
     trait :issued do

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :user do
-    first_name            Faker::Name.first_name
-    last_name             Faker::Name.last_name
-    email                 Faker::Internet.email
+    first_name  { Faker::Name.first_name }
+    last_name   { Faker::Name.last_name }
+    email       { Faker::Internet.email }
   end
 end

--- a/spec/features/printing_spec.rb
+++ b/spec/features/printing_spec.rb
@@ -1,6 +1,9 @@
 require 'feature_helper'
 
 RSpec.feature 'printing a PER', type: :feature do
+  let(:reviewer) {
+    create(:user, first_name: 'Nelle', last_name: 'Bailey')
+  }
   let(:escort) {
     create(
       :escort,
@@ -70,7 +73,9 @@ RSpec.feature 'printing a PER', type: :feature do
         arson: 'no',
         must_return: 'no',
         must_not_return: 'no',
-        other_risk: 'no'
+        other_risk: 'no',
+        reviewer: reviewer,
+        reviewed_at: DateTime.civil(2016, 3, 10, 12, 30)
       )
     }
     let(:healthcare) {
@@ -83,7 +88,9 @@ RSpec.feature 'printing a PER', type: :feature do
         dependencies: 'no',
         has_medications: 'no',
         mpv: 'no',
-        contact_number: '1-131-999-0232'
+        contact_number: '1-131-999-0232',
+        reviewer: reviewer,
+        reviewed_at: DateTime.civil(2016, 3, 10, 12, 30)
       )
     }
 
@@ -204,7 +211,9 @@ RSpec.feature 'printing a PER', type: :feature do
           must_not_return: 'yes',
           must_not_return_details: must_not_return_details,
           other_risk: 'yes',
-          other_risk_details: 'suspected terrorist'
+          other_risk_details: 'suspected terrorist',
+          reviewer: reviewer,
+          reviewed_at: DateTime.civil(2016, 3, 10, 12, 30)
         )
       }
 
@@ -225,7 +234,9 @@ RSpec.feature 'printing a PER', type: :feature do
         medications: medications,
         mpv: 'yes',
         mpv_details: 'MPV details',
-        contact_number: '1-131-999-0232'
+        contact_number: '1-131-999-0232',
+        reviewer: reviewer,
+        reviewed_at: DateTime.civil(2016, 3, 10, 12, 30)
       )
     }
 

--- a/spec/models/healthcare_spec.rb
+++ b/spec/models/healthcare_spec.rb
@@ -10,12 +10,11 @@ RSpec.describe Healthcare, type: :model do
 
   let(:detainee) { create(:detainee) }
   let(:move) { create(:move) }
+  let(:user) { build(:user) }
 
   subject(:healthcare) { described_class.new }
 
   describe '#confirm!' do
-    let(:user) { build(:user) }
-
     before { create_escort }
 
     context 'when the risk assessment is not confirmed' do
@@ -56,6 +55,17 @@ RSpec.describe Healthcare, type: :model do
       it 'returns the default healthcare contact number for that establishment' do
         expect(healthcare.default_contact_number).to eq('111111')
       end
+    end
+  end
+
+  describe '#reviewed?' do
+    context 'when has been reviewed' do
+      subject { described_class.new(reviewer: user, reviewed_at: 1.day.ago)}
+      specify { expect(subject.reviewed?).to be_truthy }
+    end
+
+    context 'when has not been reviewed' do
+      specify { expect(subject.reviewed?).to be_falsey }
     end
   end
 end

--- a/spec/models/risk_spec.rb
+++ b/spec/models/risk_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe Risk, type: :model do
 
   let(:detainee) { create(:detainee) }
   let(:move) { create(:move) }
+  let(:user) { build(:user) }
 
   subject(:risk) { described_class.new }
 
   describe '#confirm!' do
-    let(:user) { build(:user) }
 
     before { create_escort }
 
@@ -34,6 +34,17 @@ RSpec.describe Risk, type: :model do
           risk.confirm!(user: user)
         }.to_not change { risk.reload.status }
       end
+    end
+  end
+
+  describe '#reviewed?' do
+    context 'when has been reviewed' do
+      subject { described_class.new(reviewer: user, reviewed_at: 1.day.ago)}
+      specify { expect(subject.reviewed?).to be_truthy }
+    end
+
+    context 'when has not been reviewed' do
+      specify { expect(subject.reviewed?).to be_falsey }
     end
   end
 end

--- a/spec/services/create_escort_spec.rb
+++ b/spec/services/create_escort_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe EscortCreator, type: :service do
   end
 
   def except_assessment_attributes
-    %w(id escort_id created_at updated_at status)
+    %w(id escort_id created_at updated_at status reviewer_id reviewed_at)
   end
 
   def except_offences_attributes

--- a/spec/support/fixtures/pdf-text-all-no-answers.txt
+++ b/spec/support/fixtures/pdf-text-all-no-answers.txt
@@ -34,12 +34,15 @@ About this Person Escort Record
    This PER was produced by the the Moving People Safely digital PER service, currently being piloted at
    HMP Bedford. If you have feedback or questions about the service, contact the Moving People Safely team
    at: moving-people-safely@digital.justice.gov.uk
-W1234BY: McTest Testy                                                        Page 1 of 1
+W1234BY: McTest Testy                                                                         Page 1 of 1
 
- NOT FOR RELEASE                         ACCT                RULE 45
+ NOT FOR RELEASE                         ACCT                                 RULE 45
 
 
- E LIST                         CSRA STANDARD        CAT A             MPV
+ E LIST                         CSRA STANDARD             CAT A                         MPV
+
+
+RISK      Last confirmed: Nelle Bailey, 12:30 | 10 Mar 2016
 
 Risk to self                        No
 Risk from others                    No
@@ -63,6 +66,9 @@ Weapons, drugs or other items       No
 Arson                               No
 Return Instructions                 No
 Other risk information              No
+
+HEALTHCARE                Last confirmed: Nelle Bailey, 12:30 | 10 Mar 2016
+
 Physical health issues              No
 Mental health issues                No
 Special vehicles                    No
@@ -72,5 +78,7 @@ Allergies and intolerances          No
 Personal care                       No
 Medical contact details             Yes
   Medical contact                   1-131-999-0232
+
+OFFENCES
 Current offences                    None
 

--- a/spec/support/fixtures/pdf-text-all-yes-answers.txt
+++ b/spec/support/fixtures/pdf-text-all-yes-answers.txt
@@ -36,100 +36,105 @@ About this Person Escort Record
    This PER was produced by the the Moving People Safely digital PER service, currently being piloted at
    HMP Bedford. If you have feedback or questions about the service, contact the Moving People Safely team
    at: moving-people-safely@digital.justice.gov.uk
-W1234BY: McTest Testy                                                                 Page 1 of 3
+W1234BY: McTest Testy                                                                                Page 1 of 3
 
- NOT FOR RELEASE                   ACCT                          RULE 45
+ NOT FOR RELEASE                        ACCT                                    RULE 45
 
-                                  Open
+                                      Open
 
- E LIST                      CSRA HIGH     CAT A                           MPV
+ E LIST                       CSRA HIGH                   CAT A                           MPV
 
 E-List-Escort
 
-Risk to self                     Yes
-  ACCT status                    Open
-Risk from others                 Yes
-  Rule 45                        Yes
-  High public interest           Yes      High profile details
-Discrimination against others    Yes
-  Risk to females                Yes      Risk to females details
-  Risk to LGBT people            Yes      Lgtb details
-  Racist                         Yes      Violence racist details
-  Risk to other religions        Yes      Discrimination to other religion details
-  Risk to other groups           Yes      Other violence due to discrimination details
-CSRA (Cell Sharing Risk          Yes
+RISK       Last confirmed: Nelle Bailey, 12:30 | 10 Mar 2016
+
+Risk to self                         Yes
+  ACCT status                        Open
+Risk from others                     Yes
+  Rule 45                            Yes
+  High public interest               Yes                 High profile details
+Discrimination against others        Yes
+  Risk to females                    Yes                 Risk to females details
+  Risk to LGBT people                Yes                 Lgtb details
+  Racist                             Yes                 Violence racist details
+  Risk to other religions            Yes                 Discrimination to other religion details
+  Risk to other groups               Yes                 Other violence due to discrimination details
+CSRA (Cell Sharing Risk              Yes
 Assessment)
-  CSRA (Cell Sharing Risk        High
+  CSRA (Cell Sharing Risk            High
   Assessment)
-Violent to staff                 Yes
-  Violent to staff               Yes      Violent to staff details
-Violent to other prisoners       Yes
-  Co-defendant                   Yes      Violente co-defendant details
-  Gang member                    Yes      Violence gang member details
-  Other known conflicts          Yes      Other violence to other detainees details
-Violent to anyone else           Yes
-  Violent to anyone else         Yes      Violence to general public details
-Controlled unlock                Yes
-  Controlled unlock              Yes      More than 4 officers | Many people to hold the prisoner
-Hostage taker                    Yes
-  Staff                          Yes      Last incident: 12/03/2010
-  Prisoners                      Yes      Last incident: 24/05/2012
-  Public                         Yes      Last incident: 02/09/2007
-Harassment and bullying          Yes
-  Staff                          Yes      Intimidation to staff details
-  Public                         Yes      Intimidation to public details
-  Prisoners                      Yes      Intimidation to other detainees details
-  Witnesses                      Yes      Intimidation to witnesses details
-Sex offender                     Yes
-  Adult male                     Yes
-  Adult female                   Yes
-W1234BY: McTest Testy                                                                  Page 2 of 3
-  Under 18                       Yes
-  Most recent sex offence        12/10/2008
-Escape status/history            Yes
-  Currently on E list            Yes          E-List-Escort
-Made previous escape             Yes
+Violent to staff                     Yes
+  Violent to staff                   Yes                 Violent to staff details
+Violent to other prisoners           Yes
+  Co-defendant                       Yes                 Violente co-defendant details
+  Gang member                        Yes                 Violence gang member details
+  Other known conflicts              Yes                 Other violence to other detainees details
+Violent to anyone else               Yes
+  Violent to anyone else             Yes                 Violence to general public details
+Controlled unlock                    Yes
+  Controlled unlock                  Yes                 More than 4 officers | Many people to hold the prisoner
+Hostage taker                        Yes
+  Staff                              Yes                 Last incident: 12/03/2010
+  Prisoners                          Yes                 Last incident: 24/05/2012
+  Public                             Yes                 Last incident: 02/09/2007
+Harassment and bullying              Yes
+  Staff                              Yes                 Intimidation to staff details
+
+  Public                             Yes                 Intimidation to public details
+  Prisoners                          Yes                 Intimidation to other detainees details
+  Witnesses                          Yes                 Intimidation to witnesses details
+Sex offender                         Yes
+W1234BY: McTest Testy                                                                             Page 2 of 3
+  Adult male                        Yes
+  Adult female                      Yes
+  Under 18                          Yes
+  Most recent sex offence           12/10/2008
+Escape status/history               Yes
+  Currently on E list               Yes                  E-List-Escort
+Made previous escape                Yes
 attempts
-  Prison                         Yes          Prison escape attempt details
-  Court                          Yes          Court escape attempt details
-  Police                         Yes          Police escape attempt details
-  Other                          Yes          Other type of escape attempt details
-Category A, potential Category   Yes
+  Prison                            Yes                  Prison escape attempt details
+  Court                             Yes                  Court escape attempt details
+  Police                            Yes                  Police escape attempt details
+  Other                             Yes                  Other type of escape attempt details
+Category A, potential Category      Yes
 A or Restricted Status
-  Category A, potential          Yes
+  Category A, potential             Yes
   Category A or Restricted
   Status
-Further security information     Yes
-  Escort Risk Assessment         Yes          Completed on: 26/11/2016
-  Escape Pack                    Yes          Completed on: 13/12/2016
-Drug trafficking risk            Yes
-  Drug trafficking risk          Yes
-Weapons, drugs or other items    Yes
-  Creates or uses weapons        Yes          Created and used a 3d gun
-  Conceals weapons               Yes          Conceals weapons details
-  Conceals drugs                 Yes          Conceals drugs details
-  Conceals mobile phones         Yes
-  Conceals SIM cards             Yes
-  Conceals other items           Yes          Conceals other items details
-Arson                            Yes
-  Arsonist                       Yes
-Return Instructions              Yes
-  Must Return                    Yes          Alcatraz | Some special reason
-  Must Not Return                Yes          Alcatraz | Bad bad stuff happens there
-                                              York castle prison | Does not like it
-Other risk information           Yes
+Further security information        Yes
+  Escort Risk Assessment            Yes                  Completed on: 26/11/2016
+  Escape Pack                       Yes                  Completed on: 13/12/2016
+Drug trafficking risk               Yes
+  Drug trafficking risk             Yes
+Weapons, drugs or other items       Yes
+  Creates or uses weapons           Yes                  Created and used a 3d gun
+  Conceals weapons                  Yes                  Conceals weapons details
+  Conceals drugs                    Yes                  Conceals drugs details
+  Conceals mobile phones            Yes
+  Conceals SIM cards                Yes
+  Conceals other items              Yes                  Conceals other items details
+Arson                               Yes
+  Arsonist                          Yes
+Return Instructions                 Yes
+  Must Return                       Yes                  Alcatraz | Some special reason
+  Must Not Return                   Yes                  Alcatraz | Bad bad stuff happens there
+                                                         York castle prison | Does not like it
+Other risk information              Yes
+  Other risk information            Yes                  Suspected terrorist
 
-  Other risk information         Yes          Suspected terrorist
-Physical health issues           Yes
-  Physical health needs          Yes          Physical issues details
-Mental health issues             Yes
-  Mental health issues           Yes          Mental illness details
-Special vehicles                 Yes
-  Special vehicle required       Yes          Mpv details
-Essential medication             Yes
-  Essential medication           Yes          Xanax | Every 4 hours | Carried by: Escort
-                                              Paracetamol | 2 days a week | Carried by: Prisoner
-W1234BY: McTest Testy                                                                Page 3 of 3
+HEALTHCARE                Last confirmed: Nelle Bailey, 12:30 | 10 Mar 2016
+
+Physical health issues              Yes
+  Physical health needs             Yes                  Physical issues details
+Mental health issues                Yes
+  Mental health issues              Yes                  Mental illness details
+Special vehicles                    Yes
+W1234BY: McTest Testy                                                                 Page 3 of 3
+ Special vehicle required     Yes              Mpv details
+Essential medication          Yes
+ Essential medication         Yes              Xanax | Every 4 hours | Carried by: Escort
+                                               Paracetamol | 2 days a week | Carried by: Prisoner
 Dependencies                  Yes
  Dependencies                 Yes              Dependencies details
 Allergies and intolerances    Yes
@@ -138,6 +143,8 @@ Personal care                 Yes
  Personal care issues         Yes              Personal care details
 Medical contact details       Yes
  Medical contact              1-131-999-0232
+
+OFFENCES
 Current offences              Yes              Burglary (LXAHTGNJQF) | Sex offence
                                                (QDPREIBMSF)
 


### PR DESCRIPTION
[Trello](https://trello.com/c/xAaYj9Ip/194-add-date-and-time-stamp-plus-details-of-user-who-confirms-and-saves-the-risk-and-health-sections)

This PR will add the user who confirmed an assessment (only risk and healthcare) and the datetime of when that happened, to the profile page and the print page