### PR TITLE
Alerts for assessments in review mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,6 @@ group :development, :test do
   gem 'pdftotext'
   gem 'pry-byebug'
   gem 'pry-rails'
-  gem 'timecop'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :development, :test do
   gem 'pdftotext'
   gem 'pry-byebug'
   gem 'pry-rails'
+  gem 'timecop'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,6 +336,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
+    timecop (0.8.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uber (0.0.15)
@@ -413,6 +414,7 @@ DEPENDENCIES
   slim-rails
   spring
   spring-watcher-listen (~> 2.0.0)
+  timecop
   uglifier (>= 1.3.0)
   virtus
   webmock
@@ -421,4 +423,4 @@ DEPENDENCIES
   wkhtmltopdf-binary
 
 BUNDLED WITH
-   1.13.6
+   1.14.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,7 +336,6 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
-    timecop (0.8.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uber (0.0.15)
@@ -414,7 +413,6 @@ DEPENDENCIES
   slim-rails
   spring
   spring-watcher-listen (~> 2.0.0)
-  timecop
   uglifier (>= 1.3.0)
   virtus
   webmock

--- a/app/assets/stylesheets/moving_people_safely/_alerts.scss
+++ b/app/assets/stylesheets/moving_people_safely/_alerts.scss
@@ -20,7 +20,7 @@
 }
 
 .alert--warning {
-  @include alert-variant(#F4D188, #FAF1C5)
+  background-color: #FAF1C5;
 }
 
 .alert--alert {

--- a/app/assets/stylesheets/moving_people_safely/_labels.scss
+++ b/app/assets/stylesheets/moving_people_safely/_labels.scss
@@ -6,10 +6,9 @@
 .status-label {
   @include status-label-colour;
   display: inline-block;
+  font-weight: bold;
   min-width: 120px;
   padding: 0 .6em;
-  border-radius: 8px;
-  margin-right: 20px;
   text-align: center;
 }
 
@@ -19,4 +18,16 @@
 
 .status-label--incomplete {
   @include status-label-colour(red);
+}
+
+.per-page {
+  .status-label {
+    margin-right: 10px;
+  }
+}
+
+.per-section-page {
+  .status-label {
+    margin-left: 10px;
+  }
 }

--- a/app/assets/stylesheets/moving_people_safely/_labels.scss
+++ b/app/assets/stylesheets/moving_people_safely/_labels.scss
@@ -7,8 +7,7 @@
   @include status-label-colour;
   display: inline-block;
   font-weight: bold;
-  min-width: 120px;
-  padding: 0 .6em;
+  padding: .250em .5em;
   text-align: center;
 }
 
@@ -21,6 +20,10 @@
 }
 
 .per-page {
+  .per-section-header {
+    padding-bottom: 10px;
+  }
+
   .status-label {
     margin-right: 10px;
   }

--- a/app/assets/stylesheets/moving_people_safely/_summary.scss
+++ b/app/assets/stylesheets/moving_people_safely/_summary.scss
@@ -63,4 +63,21 @@
   tr.even td {
     background-color: $highlight-colour;
   }
+
+  .alert--warning {
+    padding: 20px;
+    margin: 20px 0px;
+    min-height: 50px;
+
+    .alert-sign {
+      position: relative;
+      float: left;
+    }
+
+    .alert-content {
+      position: relative;
+      float: left;
+      padding-left: 20px;
+    }
+  }
 }

--- a/app/models/escort.rb
+++ b/app/models/escort.rb
@@ -7,6 +7,8 @@ class Escort < ApplicationRecord
   has_one :move, dependent: :destroy
   has_one :risk, dependent: :destroy
   has_one :healthcare, dependent: :destroy
+  has_one :clone, class_name: 'Escort', foreign_key: :cloned_id
+  belongs_to :twig, class_name: 'Escort', foreign_key: :cloned_id
 
   scope :for_date, ->(date) { eager_load(:move).where(moves: { date: date }) }
   scope :with_incomplete_risk, -> { joins(:risk).merge(Risk.not_confirmed) }

--- a/app/presenters/presenter_helpers.rb
+++ b/app/presenters/presenter_helpers.rb
@@ -1,3 +1,4 @@
+require 'time_diff'
 module PresenterHelpers
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::TranslationHelper
@@ -9,5 +10,9 @@ module PresenterHelpers
 
   def title_label(label)
     content_tag(:div, label, class: 'title')
+  end
+
+  def time_diff(start_time, end_time)
+    TimeDiff.new(start_time, end_time).to_s
   end
 end

--- a/app/presenters/summary/escort_section_status_presenter.rb
+++ b/app/presenters/summary/escort_section_status_presenter.rb
@@ -33,7 +33,8 @@ module Summary
     end
 
     def last_updated_info
-      time_difference = time_diff(escort.updated_at.utc, Time.now.utc)
+      start_time = twig&.send(name)&.reviewed_at || section.updated_at
+      time_difference = time_diff(start_time.utc, Time.now.utc)
       t('summary.alerts.last_updated_info', time_difference: time_difference)
     end
 
@@ -53,6 +54,10 @@ module Summary
     def set_status
       return unless %w[incomplete needs_review confirmed].include?(section.status)
       section.status
+    end
+
+    def twig
+      escort.twig
     end
   end
 end

--- a/app/presenters/summary/escort_section_status_presenter.rb
+++ b/app/presenters/summary/escort_section_status_presenter.rb
@@ -2,6 +2,8 @@ module Summary
   class EscortSectionStatusPresenter
     include PresenterHelpers
 
+    delegate :needs_review?, to: :section
+
     def initialize(section, name:)
       @section = section
       @name = name
@@ -28,6 +30,15 @@ module Summary
 
     def has_status?
       status.present?
+    end
+
+    def last_updated_info
+      time_difference = time_diff(escort.updated_at.utc, Time.now.utc)
+      t('summary.alerts.last_updated_info', time_difference: time_difference)
+    end
+
+    def up_to_date_warning
+      t('summary.alerts.up_to_date_warning')
     end
 
     private

--- a/app/presenters/summary/escort_section_status_presenter.rb
+++ b/app/presenters/summary/escort_section_status_presenter.rb
@@ -1,0 +1,47 @@
+module Summary
+  class EscortSectionStatusPresenter
+    include PresenterHelpers
+
+    def initialize(section, name:)
+      @section = section
+      @name = name
+      @status = set_status
+    end
+
+    def title
+      return default_title if escort.issued? || !status.present?
+      t("summary.status.#{status}.title")
+    end
+
+    def label
+      return unless status
+      t("summary.status.#{status}.label")
+    end
+
+    def label_status
+      {
+        'incomplete' => 'incomplete',
+        'needs_review' => 'incomplete',
+        'confirmed' => 'complete'
+      }[status]
+    end
+
+    def has_status?
+      status.present?
+    end
+
+    private
+
+    attr_reader :section, :name, :status
+    delegate :escort, to: :section
+
+    def default_title
+      t("summary.#{name}.title")
+    end
+
+    def set_status
+      return unless %w[incomplete needs_review confirmed].include?(section.status)
+      section.status
+    end
+  end
+end

--- a/app/services/escort_creator.rb
+++ b/app/services/escort_creator.rb
@@ -9,7 +9,10 @@ class EscortCreator
 
   def call
     if existent_escort
-      deep_clone_escort.tap(&:needs_review!)
+      deep_clone_escort.tap do |clone|
+        clone.twig = existent_escort
+        clone.needs_review!
+      end
     else
       Escort.create(prison_number: prison_number)
     end

--- a/app/views/escorts/_healthcare.html.slim
+++ b/app/views/escorts/_healthcare.html.slim
@@ -2,11 +2,12 @@
   = render partial: 'status',
     locals: { workflow: healthcare, not_started_path: intro_escort_healthcare_path(escort), summary_path: escort_healthcare_path(escort) }
 
-  h2
-    ' Healthcare
-    - if healthcare&.reviewed?
-      small
-        = t('assessment.confirmed_timestamp', name: healthcare.reviewer.full_name, time: healthcare.reviewed_at.to_s(:humanized))
+  .per-section-header
+    h2
+      ' Healthcare
+      - if healthcare&.reviewed?
+        small
+          = t('assessment.confirmed_timestamp', name: healthcare.reviewer.full_name, time: healthcare.reviewed_at.to_s(:humanized))
   - if healthcare
     .info-table.info-table-big
       .grid-row

--- a/app/views/escorts/_offences.html.slim
+++ b/app/views/escorts/_offences.html.slim
@@ -2,8 +2,9 @@
   = render partial: 'status',
     locals: { workflow: offences, not_started_path: escort_offences_path(escort), summary_path: escort_offences_path(escort) }
 
-  h2
-    ' Offences
+  .per-section-header
+    h2
+      ' Offences
   - if offences.all_questions_answered?
     .info-table
       .grid-row

--- a/app/views/escorts/_risk.html.slim
+++ b/app/views/escorts/_risk.html.slim
@@ -2,11 +2,12 @@
   = render partial: 'status',
     locals: { workflow: risk, not_started_path: new_escort_risks_path(escort), summary_path: escort_risks_path(escort) }
 
-  h2
-    ' Risk
-    - if risk&.reviewed?
-      small
-        = t('assessment.confirmed_timestamp', name: risk.reviewer.full_name, time: risk.reviewed_at.to_s(:humanized))
+  .per-section-header
+    h2
+      ' Risk
+      - if risk&.reviewed?
+        small
+          = t('assessment.confirmed_timestamp', name: risk.reviewer.full_name, time: risk.reviewed_at.to_s(:humanized))
   - if risk
     .info-table.info-table-big
       .grid-row

--- a/app/views/escorts/show.html.slim
+++ b/app/views/escorts/show.html.slim
@@ -2,7 +2,7 @@
   - breadcrumbs_for_page root: true do
     - breadcrumb detainee_breadcrumb(escort.detainee)
 
-.escort
+.escort.per-page
   = render partial: 'header', locals: { detainee: escort.detainee, alerts: EscortAlertsPresenter.new(escort) }
 
   = render partial: 'move', locals: { move: MovePresenter.new(escort.move) }

--- a/app/views/healthcare/show.html.slim
+++ b/app/views/healthcare/show.html.slim
@@ -4,7 +4,8 @@
     - breadcrumb 'Healthcare summary'
 
 .summary.per-section-page
-  = render partial: 'summary/status', locals: { workflow: healthcare, title: 'Healthcare' }
+  = render partial: 'summary/status',
+    locals: { workflow: Summary::EscortSectionStatusPresenter.new(healthcare, name: :healthcare) }
 
   - healthcare.sections.each do |section|
     = render partial: 'summary/section',

--- a/app/views/healthcare/show.html.slim
+++ b/app/views/healthcare/show.html.slim
@@ -3,7 +3,7 @@
     - breadcrumb detainee_breadcrumb(escort.detainee), escort_path(escort)
     - breadcrumb 'Healthcare summary'
 
-.summary
+.summary.per-section-page
   = render partial: 'summary/status', locals: { workflow: healthcare, title: 'Healthcare' }
 
   - healthcare.sections.each do |section|

--- a/app/views/offences/show.html.slim
+++ b/app/views/offences/show.html.slim
@@ -3,11 +3,11 @@
     - breadcrumb detainee_breadcrumb(escort.detainee), escort_path(escort)
     - breadcrumb 'Offences'
 
-.offences
+.offences.per-section-page
   - if offences.needs_review?
     header
       h1 Review before you save and continue
-      h3
+      p#offences-status
         ' Status
         span.status-label.status-label--incomplete Review
   - else

--- a/app/views/risks/show.html.slim
+++ b/app/views/risks/show.html.slim
@@ -4,7 +4,8 @@
     - breadcrumb 'Risk summary'
 
 .summary.per-section-page
-  = render partial: 'summary/status', locals: { workflow: risk, title: 'Risk' }
+  = render partial: 'summary/status',
+    locals: { workflow: Summary::EscortSectionStatusPresenter.new(risk, name: :risk) }
 
   - risk.sections.each do |section|
     = render partial: 'summary/section',

--- a/app/views/risks/show.html.slim
+++ b/app/views/risks/show.html.slim
@@ -3,7 +3,7 @@
     - breadcrumb detainee_breadcrumb(escort.detainee), escort_path(escort)
     - breadcrumb 'Risk summary'
 
-.summary
+.summary.per-section-page
   = render partial: 'summary/status', locals: { workflow: risk, title: 'Risk' }
 
   - risk.sections.each do |section|

--- a/app/views/summary/_status.html.slim
+++ b/app/views/summary/_status.html.slim
@@ -5,3 +5,13 @@ header
     h3
       ' Status
       span.status-label class=("status-label--#{workflow.label_status}") = workflow.label
+
+    - if workflow.needs_review?
+      .alert--warning.review-warning
+        div.alert-sign
+          i.icon.icon-important
+            span.visually-hidden Warning
+        div.alert-content
+          span.bold-small = workflow.last_updated_info
+          br
+          span = workflow.up_to_date_warning

--- a/app/views/summary/_status.html.slim
+++ b/app/views/summary/_status.html.slim
@@ -1,24 +1,7 @@
-- if workflow.incomplete?
-  header
-    h1 Please complete the missing answers
+header
+  h1 = workflow.title
+
+  - if workflow.has_status?
     h3
       ' Status
-      span.status-label.status-label--incomplete Incomplete
-
-- elsif workflow.needs_review?
-  header
-    h1 Check all answers, then confirm and save
-    h3
-      ' Status
-      span.status-label.status-label--incomplete Review
-
-- elsif workflow.unconfirmed?
-  header
-    h1 Check all answers, then confirm and save
-
-- elsif workflow.confirmed?
-  header
-    h1 = title
-    h3
-      ' Status
-      span.status-label.status-label--complete Complete
+      span.status-label class=("status-label--#{workflow.label_status}") = workflow.label

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -418,6 +418,9 @@ en:
       risk_complete: Risk complete
       risk_incomplete: Risk incomplete
   summary: &summary
+    alerts:
+      last_updated_info: 'This information was last saved %{time_difference} ago.'
+      up_to_date_warning: Make sure all answers are up to date and check history and events in the last PER for any relevant updates.
     healthcare:
       title: Healthcare
     risk:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -418,6 +418,10 @@ en:
       risk_complete: Risk complete
       risk_incomplete: Risk incomplete
   summary: &summary
+    healthcare:
+      title: Healthcare
+    risk:
+      title: Risk
     section:
       answers:
         risk_to_self:
@@ -553,6 +557,16 @@ en:
         violence_to_general_public: Violent to anyone else
         violence_to_other_detainees: Violent to other prisoners
         violence_to_staff: Violent to staff
+    status:
+      confirmed:
+        label: Complete
+        title: Check all answers, then confirm and save
+      incomplete:
+        label: Incomplete
+        title: Please complete the missing answers
+      needs_review:
+        label: Review
+        title: Check all answers, then confirm and save
   escort: &escort
     alerts:
       acct_status:

--- a/db/migrate/20170607172008_add_cloned_id_to_escorts.rb
+++ b/db/migrate/20170607172008_add_cloned_id_to_escorts.rb
@@ -1,0 +1,5 @@
+class AddClonedIdToEscorts < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :escorts, :cloned, type: :uuid, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170605105913) do
+ActiveRecord::Schema.define(version: 20170607172008) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,8 @@ ActiveRecord::Schema.define(version: 20170605105913) do
     t.datetime "updated_at",    null: false
     t.datetime "deleted_at"
     t.datetime "issued_at"
+    t.uuid     "cloned_id"
+    t.index ["cloned_id"], name: "index_escorts_on_cloned_id", using: :btree
     t.index ["deleted_at"], name: "index_escorts_on_deleted_at", using: :btree
     t.index ["prison_number"], name: "index_escorts_on_prison_number", using: :btree
   end

--- a/lib/time_diff.rb
+++ b/lib/time_diff.rb
@@ -1,0 +1,28 @@
+class TimeDiff
+  include ActionView::Helpers::TextHelper
+
+  attr_reader :start_time, :end_time, :components
+
+  def initialize(start_time, end_time)
+    @start_time = start_time
+    @end_time = end_time
+    @components = calculate_components
+  end
+
+  def to_s
+    non_zero_components = components.reject { |_key, value| value.zero? }
+    non_zero_components.each_with_object([]) do |(key, value), array|
+      array << pluralize(value, key.to_s)
+    end.join(', ')
+  end
+
+  private
+
+  def calculate_components
+    diff = (start_time - end_time).to_i.abs
+    mm, ss = diff.divmod(60)
+    hh, mm = mm.divmod(60)
+    dd, hh = hh.divmod(24)
+    { day: dd, hour: hh, minute: mm, second: ss }
+  end
+end

--- a/spec/features/pages/assessment_summary_page_helpers.rb
+++ b/spec/features/pages/assessment_summary_page_helpers.rb
@@ -6,6 +6,10 @@ module Page
       end
     end
 
+    def confirm_review_warning
+      expect(page).to have_selector('.review-warning')
+    end
+
     def confirm_read_only
       expect(page).not_to have_link('Change')
     end

--- a/spec/features/pages/offences.rb
+++ b/spec/features/pages/offences.rb
@@ -7,7 +7,7 @@ module Page
     end
 
     def confirm_status(expected_status)
-      within('header h3') do
+      within('#offences-status') do
         expect(page).to have_content(expected_status)
       end
     end

--- a/spec/features/reuse_spec.rb
+++ b/spec/features/reuse_spec.rb
@@ -16,12 +16,14 @@ RSpec.feature 'Reuse of previously entered PER data', type: :feature do
     escort_page.confirm_healthcare_status('Review')
     escort_page.click_edit_healthcare
     healthcare_summary.confirm_status('Review')
+    healthcare_summary.confirm_review_warning
     healthcare_summary.confirm_and_save
     escort_page.confirm_healthcare_status('Complete')
 
     escort_page.confirm_risk_status('Review')
     escort_page.click_edit_risk
     risk_summary.confirm_status('Review')
+    risk_summary.confirm_review_warning
     risk_summary.confirm_and_save
     escort_page.confirm_risk_status('Complete')
 

--- a/spec/lib/time_diff_spec.rb
+++ b/spec/lib/time_diff_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+require 'time_diff'
+
+RSpec.describe TimeDiff do
+  subject(:diff) { described_class.new(start_time, end_time) }
+
+  describe '#to_s' do
+    context 'when there is no days difference since the start time' do
+      let(:start_time) { Time.local(2008, 9, 1, 12, 0, 0) }
+      let(:end_time) { Time.local(2008, 9, 1, 14, 25, 46) }
+
+      it 'returns the humanized time difference without days passed' do
+        expect(diff.to_s).to eq('2 hours, 25 minutes, 46 seconds')
+      end
+    end
+
+    context 'when there is no hours difference since the start time' do
+      let(:start_time) { Time.local(2008, 9, 1, 12, 0, 0) }
+      let(:end_time) { Time.local(2008, 9, 11, 12, 23, 46) }
+
+      it 'returns the humanized time difference without hours passed' do
+        expect(diff.to_s).to eq('10 days, 23 minutes, 46 seconds')
+      end
+    end
+
+    context 'when there is no minutes difference since the start time' do
+      let(:start_time) { Time.local(2008, 9, 1, 12, 0, 0) }
+      let(:end_time) { Time.local(2008, 9, 21, 14, 0, 46) }
+
+      it 'returns the humanized time difference without minutes passed' do
+        expect(diff.to_s).to eq('20 days, 2 hours, 46 seconds')
+      end
+    end
+
+    context 'when there is no seconds difference since the start time' do
+      let(:start_time) { Time.local(2008, 9, 1, 12, 0, 0) }
+      let(:end_time) { Time.local(2008, 9, 21, 14, 44, 0) }
+
+      it 'returns the humanized time difference without seconds passed' do
+        expect(diff.to_s).to eq('20 days, 2 hours, 44 minutes')
+      end
+    end
+  end
+end
+

--- a/spec/presenters/summary/escort_section_status_presenter_spec.rb
+++ b/spec/presenters/summary/escort_section_status_presenter_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Summary::EscortSectionStatusPresenter, type: :presenter do
+  let(:status) { 'incomplete' }
   let(:escort) { double(Escort) }
   let(:section) { double(:section, status: status, escort: escort) }
   let(:name) { 'section_name' }
@@ -136,6 +137,23 @@ RSpec.describe Summary::EscortSectionStatusPresenter, type: :presenter do
       let(:status) { 'some_other_status' }
 
       specify { expect(presenter.has_status?).to be_falsey }
+    end
+  end
+
+  describe '#last_updated_info' do
+    it 'returns a string containing the difference from the current time since the last update' do
+      now = Time.local(2008, 9, 1, 12, 0, 0)
+      Timecop.freeze(now) do
+        last_updated_at = 2.days.ago
+        expect(escort).to receive(:updated_at).and_return(last_updated_at)
+        expect(presenter.last_updated_info).to eq('This information was last saved 2 days ago.')
+      end
+    end
+  end
+
+  describe '#up_to_date_warning' do
+    it 'returns the localised wording for the warning' do
+      expect(presenter.up_to_date_warning).to eq('Make sure all answers are up to date and check history and events in the last PER for any relevant updates.')
     end
   end
 end

--- a/spec/presenters/summary/escort_section_status_presenter_spec.rb
+++ b/spec/presenters/summary/escort_section_status_presenter_spec.rb
@@ -1,0 +1,141 @@
+require 'rails_helper'
+
+RSpec.describe Summary::EscortSectionStatusPresenter, type: :presenter do
+  let(:escort) { double(Escort) }
+  let(:section) { double(:section, status: status, escort: escort) }
+  let(:name) { 'section_name' }
+  subject(:presenter) { described_class.new(section, name: name) }
+
+  describe '#title' do
+    before do
+      localize_key("summary.#{name}.title", 'Localised section title')
+      allow(escort).to receive(:issued?).and_return(false)
+    end
+
+    context 'when the section is incomplete' do
+      let(:status) { 'incomplete' }
+
+      it 'returns the localised title for an incomplete section' do
+        expect(presenter.title).to eq('Please complete the missing answers')
+      end
+    end
+
+    context 'when the section needs review' do
+      let(:status) { 'needs_review' }
+
+      it 'returns the localised title for an incomplete section' do
+        expect(presenter.title).to eq('Check all answers, then confirm and save')
+      end
+    end
+
+    context 'when the section is confirmed' do
+      let(:status) { 'confirmed' }
+
+      it 'returns the localised title for a complete section' do
+        expect(presenter.title).to eq('Check all answers, then confirm and save')
+      end
+    end
+
+    context 'when the section is neither incomplete, needs review or confirmed' do
+      let(:status) { 'some_other_status' }
+
+      it 'returns the default title for the section' do
+        expect(presenter.title).to eq('Localised section title')
+      end
+    end
+
+    context 'when the related escort has been issued' do
+      let(:status) { 'confirmed' }
+
+      before do
+        expect(escort).to receive(:issued?).and_return(true)
+      end
+
+      it 'returns the default title for the section' do
+        expect(presenter.title).to eq('Localised section title')
+      end
+    end
+  end
+
+  describe '#label' do
+    before do
+      localize_key("summary.#{name}.label", 'Localised section label')
+    end
+
+    context 'when the section is incomplete' do
+      let(:status) { 'incomplete' }
+
+      it 'returns label for an incomplete section' do
+        expect(presenter.label).to eq('Incomplete')
+      end
+    end
+
+    context 'when the section needs review' do
+      let(:status) { 'needs_review' }
+
+      it 'returns label for an incomplete section' do
+        expect(presenter.label).to eq('Review')
+      end
+    end
+
+    context 'when the section is confirmed' do
+      let(:status) { 'confirmed' }
+
+      it 'returns label for a complete section' do
+        expect(presenter.label).to eq('Complete')
+      end
+    end
+
+    context 'when the section is neither incomplete, needs review or confirmed' do
+      let(:status) { 'some_other_status' }
+
+      specify { expect(presenter.label).to be_nil }
+    end
+  end
+
+  describe '#label_status' do
+    context 'when the section is incomplete' do
+      let(:status) { 'incomplete' }
+      specify { expect(presenter.label_status).to eq('incomplete') }
+    end
+
+    context 'when the section needs review' do
+      let(:status) { 'needs_review' }
+      specify { expect(presenter.label_status).to eq('incomplete') }
+    end
+
+    context 'when the section is confirmed' do
+      let(:status) { 'confirmed' }
+      specify { expect(presenter.label_status).to eq('complete') }
+    end
+
+    context 'when the section is neither incomplete, needs review or confirmed' do
+      let(:status) { 'some_other_status' }
+
+      specify { expect(presenter.label_status).to be_nil }
+    end
+  end
+
+  describe '#has_status?' do
+    context 'when the section is incomplete' do
+      let(:status) { 'incomplete' }
+      specify { expect(presenter.has_status?).to be_truthy }
+    end
+
+    context 'when the section needs review' do
+      let(:status) { 'needs_review' }
+      specify { expect(presenter.has_status?).to be_truthy }
+    end
+
+    context 'when the section is confirmed' do
+      let(:status) { 'confirmed' }
+      specify { expect(presenter.has_status?).to be_truthy }
+    end
+
+    context 'when the section is neither incomplete, needs review or confirmed' do
+      let(:status) { 'some_other_status' }
+
+      specify { expect(presenter.has_status?).to be_falsey }
+    end
+  end
+end

--- a/spec/presenters/summary/escort_section_status_presenter_spec.rb
+++ b/spec/presenters/summary/escort_section_status_presenter_spec.rb
@@ -141,12 +141,34 @@ RSpec.describe Summary::EscortSectionStatusPresenter, type: :presenter do
   end
 
   describe '#last_updated_info' do
-    it 'returns a string containing the difference from the current time since the last update' do
-      now = Time.local(2008, 9, 1, 12, 0, 0)
-      Timecop.freeze(now) do
-        last_updated_at = 2.days.ago
-        expect(escort).to receive(:updated_at).and_return(last_updated_at)
-        expect(presenter.last_updated_info).to eq('This information was last saved 2 days ago.')
+    context 'when the escort is not a clone' do
+      before do
+        expect(escort).to receive(:twig).and_return(nil)
+      end
+
+      it 'returns a string containing the difference from the current time since the last update on the section' do
+        now = Time.local(2008, 9, 1, 12, 0, 0)
+        travel_to(now) do
+          last_updated_at = 2.days.ago
+          expect(section).to receive(:updated_at).and_return(last_updated_at)
+          expect(presenter.last_updated_info).to eq('This information was last saved 2 days ago.')
+        end
+      end
+    end
+    context 'when the escort was cloned from a twig' do
+      let(:reviewed_at) { Time.local(2008, 8, 14, 9, 22, 0) }
+      let(:twig_section) { double(:section, reviewed_at: reviewed_at) }
+      let(:twig) { double(Escort, section_name: twig_section) }
+
+      before do
+        expect(escort).to receive(:twig).and_return(twig)
+      end
+
+      it 'returns a string containing the difference from the current time since the last update on the twig section' do
+        now = Time.local(2008, 9, 1, 12, 0, 0)
+        travel_to(now) do
+          expect(presenter.last_updated_info).to eq('This information was last saved 18 days, 2 hours, 38 minutes ago.')
+        end
       end
     end
   end

--- a/spec/services/create_escort_spec.rb
+++ b/spec/services/create_escort_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe EscortCreator, type: :service do
       expect_healthcare_assessment_to_be_cloned(existent_escort, escort)
       expect_offences_to_be_cloned(existent_escort, escort)
       expect(escort.move).to be_nil
+      expect(escort.twig).to eq(existent_escort)
     end
   end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/mPQFLBEW/195-add-reuse-alert-to-risk-summary-and-health-summary)

Adds an alert section to the assessments summary page (risk/healthcare) when the assessment is in  review mode displaying the information of when was the assessment last updated.

This also adds the notion of a **twig/clone** self-relationship on the `Escort` so that we can keep track of which object the escort was cloned from.

**Note to the use of twig as name:**  

From [Wikipedia](https://en.wikipedia.org/wiki/Cloning)

> The term clone, invented by J. B. S. Haldane, is derived from the Ancient Greek word κλών klōn, "twig", referring to the process whereby a new plant can be created from a twig
