### PR TITLE
Fix broken legends in IE8

### DIFF
--- a/app/assets/stylesheets/main-ie8.scss
+++ b/app/assets/stylesheets/main-ie8.scss
@@ -10,3 +10,7 @@ $ie-version: 8;
 textarea.form-control {
   width: 50% !important;
 }
+
+legend {
+  max-width: 100%;
+}


### PR DESCRIPTION
[Trello](https://trello.com/c/l5cPxcag/201-bug-issues-with-css-in-ie8-causing-the-hint-text-to-display-as-a-continuous-long-line)

In IE8 we found a problem with legends in forms not breaking
in new line and forcing the browser to scroll horizontally.