### PR TITLE
Remove unknown choice from questions

### DIFF
--- a/app/assets/javascripts/optional-sections.js
+++ b/app/assets/javascripts/optional-sections.js
@@ -7,7 +7,7 @@ $(function () {
    * @param {jQuery wrapped input} $input - A radio button.
    */
 
-  var manageStateOfOptionalSection = function ($input, $clear_selection_control) {
+  var manageStateOfOptionalSection = function ($input) {
     var id = $input.attr('id');
     var control = $input.closest($.fn.optional_section.defaults['controls_for_optional_section']);
     var data = control.attr('data-toggle-field');
@@ -15,10 +15,8 @@ $(function () {
 
     if($input.val() != undefined && $input.val() == data){
       show(optionalSection);
-      show($clear_selection_control);
     } else {
       hide(optionalSection);
-      show($clear_selection_control);
     }
   };
 
@@ -37,16 +35,15 @@ $(function () {
     return this.each(function () {
       var $this = $(this),
         $controls = $(settings.controls_for_optional_section, $this),
-        $checked_item_at_load = $controls.find(':checked'),
-        $clear_selection_control = $controls.find('label[for$="_unknown"]');
+        $checked_item_at_load = $controls.find(':checked');
 
       // Initialization
-      manageStateOfOptionalSection($checked_item_at_load, $clear_selection_control);
+      manageStateOfOptionalSection($checked_item_at_load);
 
       // Event management
       $controls.on('change', function (e) {
         var $input = $(e.target);
-        manageStateOfOptionalSection($input, $clear_selection_control);
+        manageStateOfOptionalSection($input);
       });
 
     })

--- a/app/assets/stylesheets/moving_people_safely/_forms.scss
+++ b/app/assets/stylesheets/moving_people_safely/_forms.scss
@@ -21,19 +21,6 @@ form {
     font-weight: bold;
   }
 
-  label[for$=_unknown] {
-    background-color: transparent;
-    border-color: transparent;
-    padding-left: $padding-unit;
-    text-decoration: underline;
-    &:hover {
-      border-color: transparent;
-    }
-    input {
-      @extend .visuallyhidden;
-    }
-  }
-
   .checkbox-list input[type='checkbox'] {
     margin-right: 20px;
   }

--- a/app/models/assessments/question.rb
+++ b/app/models/assessments/question.rb
@@ -26,7 +26,6 @@ module Assessments
     end
 
     def answered?
-      return false if value.nil? || value == 'unknown'
       value.present?
     end
 

--- a/app/models/forms/base.rb
+++ b/app/models/forms/base.rb
@@ -6,9 +6,7 @@ module Forms
 
     TOGGLE_YES = 'yes'
     TOGGLE_NO = 'no'
-    DEFAULT_CHOICE = 'unknown'
-    TOGGLE_STRICT_CHOICES = [TOGGLE_YES, TOGGLE_NO].freeze
-    TOGGLE_CHOICES = [TOGGLE_YES, TOGGLE_NO, DEFAULT_CHOICE].freeze
+    TOGGLE_CHOICES = [TOGGLE_YES, TOGGLE_NO].freeze
 
     StrictString = Forms::StrictString
     TextDate = Forms::TextDate
@@ -187,10 +185,6 @@ module Forms
 
     def toggle_choices
       TOGGLE_CHOICES
-    end
-
-    def toggle_strict_choices
-      TOGGLE_STRICT_CHOICES
     end
 
     def toggle_field

--- a/app/models/forms/move.rb
+++ b/app/models/forms/move.rb
@@ -9,7 +9,7 @@ module Forms
     property :date, type: TextDate
 
     optional_field :not_for_release,
-      options: TOGGLE_STRICT_CHOICES,
+      options: TOGGLE_CHOICES,
       allow_blank: false
     reset attributes: %i[not_for_release_reason not_for_release_reason_details],
           if_falsey: :not_for_release
@@ -17,8 +17,7 @@ module Forms
     optional_field :not_for_release_reason,
       type: StrictString,
       options: NOT_FOR_RELEASE_REASONS,
-      option_with_details: REASON_WITH_DETAILS,
-      default: 'unknown' do
+      option_with_details: REASON_WITH_DETAILS do
       validates :not_for_release_reason,
         inclusion: { in: NOT_FOR_RELEASE_REASONS },
         if: -> { not_for_release == 'yes' }

--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -23,7 +23,7 @@ class QuestionPresenter < SimpleDelegator
   end
 
   def display_inline?
-    answer_options.any? { |a| a.value == 'unknown' }
+    answer_options.size <= 2
   end
 
   def toggle_field

--- a/app/presenters/summary/assessment_question_presenter.rb
+++ b/app/presenters/summary/assessment_question_presenter.rb
@@ -9,7 +9,7 @@ module Summary
     def answer
       return parent_based_answer(parent_group_answer) if belongs_to_group?
       return parent_based_answer(parent.value) if parent&.is_question?
-      default_answer
+      format_answered_value
     end
 
     def details
@@ -27,7 +27,7 @@ module Summary
 
     def parent_based_answer(parent_value)
       case parent_value
-      when 'unknown', nil
+      when nil
         error_content('Missing')
       when 'no', false
         boolean? ? 'No' : 'None'
@@ -38,6 +38,8 @@ module Summary
 
     def format_answered_value
       case value
+      when nil
+        error_content('Missing')
       when 'no', false
         'No'
       when 'yes', true
@@ -45,15 +47,6 @@ module Summary
       else
         answer = answer_value(value)
         relevant_answer? ? highlight(answer) : answer
-      end
-    end
-
-    def default_answer
-      case value
-      when 'unknown', nil
-        error_content('Missing')
-      else
-        format_answered_value
       end
     end
 

--- a/app/views/moves/_form.html.slim
+++ b/app/views/moves/_form.html.slim
@@ -19,7 +19,7 @@
             == 'Tomorrow'
 
     = f.radio_toggle :not_for_release,
-      choices: f.object.toggle_strict_choices do
+      choices: f.object.toggle_choices do
       = f.radio_toggle_with_textarea :not_for_release_reason,
         legend: false,
         choices: f.object.not_for_release_reasons,

--- a/config/assessments_schema.yml
+++ b/config/assessments_schema.yml
@@ -24,8 +24,6 @@ assessment:
                         name: 'Assessments::PresenceValidator'
               -
                 value: 'no'
-              -
-                value: 'unknown'
       mental:
         questions:
           -
@@ -48,8 +46,6 @@ assessment:
                         name: 'Assessments::PresenceValidator'
               -
                 value: 'no'
-              -
-                value: 'unknown'
       transport:
         questions:
           -
@@ -72,8 +68,6 @@ assessment:
                         name: 'Assessments::PresenceValidator'
               -
                 value: 'no'
-              -
-                value: 'unknown'
       needs:
         questions:
           -
@@ -117,8 +111,6 @@ assessment:
                             value: 'detainee'
               -
                 value: 'no'
-              -
-                value: 'unknown'
       dependencies:
         questions:
           -
@@ -141,8 +133,6 @@ assessment:
                         name: 'Assessments::PresenceValidator'
               -
                 value: 'no'
-              -
-                value: 'unknown'
       allergies:
         questions:
           -
@@ -165,8 +155,6 @@ assessment:
                         name: 'Assessments::PresenceValidator'
               -
                 value: 'no'
-              -
-                value: 'unknown'
       social:
         questions:
           -
@@ -189,8 +177,6 @@ assessment:
                         name: 'Assessments::PresenceValidator'
               -
                 value: 'no'
-              -
-                value: 'unknown'
       contact:
         questions:
           -
@@ -253,8 +239,6 @@ assessment:
                 value: 'yes'
               -
                 value: 'no'
-              -
-                value: 'unknown'
           -
             name: high_profile
             type: string
@@ -275,8 +259,6 @@ assessment:
                         name: 'Assessments::PresenceValidator'
               -
                 value: 'no'
-              -
-                value: 'unknown'
       discrimination:
         questions:
           -
@@ -299,8 +281,6 @@ assessment:
                         name: 'Assessments::PresenceValidator'
               -
                 value: 'no'
-              -
-                value: 'unknown'
           -
             name: homophobic
             type: string
@@ -321,8 +301,6 @@ assessment:
                         name: 'Assessments::PresenceValidator'
               -
                 value: 'no'
-              -
-                value: 'unknown'
           -
             name: racist
             type: string
@@ -343,8 +321,6 @@ assessment:
                         name: 'Assessments::PresenceValidator'
               -
                 value: 'no'
-              -
-                value: 'unknown'
           -
             name: discrimination_to_other_religions
             type: string
@@ -365,8 +341,6 @@ assessment:
                         name: 'Assessments::PresenceValidator'
               -
                 value: 'no'
-              -
-                value: 'unknown'
           -
             name: other_violence_due_to_discrimination
             type: string
@@ -387,8 +361,6 @@ assessment:
                         name: 'Assessments::PresenceValidator'
               -
                 value: 'no'
-              -
-                value: 'unknown'
       violence:
         sections:
           csra:
@@ -407,8 +379,6 @@ assessment:
                     relevant: true
                   -
                     value: 'standard'
-                  -
-                    value: 'unknown'
           violence_to_staff:
             questions:
               -
@@ -431,8 +401,6 @@ assessment:
                             name: 'Assessments::PresenceValidator'
                   -
                     value: 'no'
-                  -
-                    value: 'unknown'
           violence_to_other_detainees:
             questions:
               -
@@ -503,8 +471,6 @@ assessment:
                                         name: 'Assessments::PresenceValidator'
                   -
                     value: 'no'
-                  -
-                    value: 'unknown'
           violence_to_general_public:
             questions:
               -
@@ -527,8 +493,6 @@ assessment:
                             name: 'Assessments::PresenceValidator'
                   -
                     value: 'no'
-                  -
-                    value: 'unknown'
           controlled_unlock_required:
             questions:
               -
@@ -566,8 +530,6 @@ assessment:
                             name: 'Assessments::PresenceValidator'
                   -
                     value: 'no'
-                  -
-                    value: 'unknown'
       hostage_taker:
         questions:
           -
@@ -644,8 +606,6 @@ assessment:
                                       not_in_the_future: true
               -
                 value: 'no'
-              -
-                value: 'unknown'
       harassments:
         sections:
           intimidation:
@@ -733,8 +693,6 @@ assessment:
                                         name: 'Assessments::PresenceValidator'
                   -
                     value: 'no'
-                  -
-                    value: 'unknown'
       sex_offences:
         questions:
           -
@@ -777,8 +735,6 @@ assessment:
                           not_in_the_future: true
               -
                 value: 'no'
-              -
-                value: 'unknown'
       security:
         sections:
           escape_status:
@@ -810,8 +766,6 @@ assessment:
                             value: e_list_heightened
                   -
                     value: 'no'
-                  -
-                    value: 'unknown'
           previous_escape_attempts:
             questions:
               -
@@ -897,8 +851,6 @@ assessment:
                                         name: 'Assessments::PresenceValidator'
                   -
                     value: 'no'
-                  -
-                    value: 'unknown'
           category_a:
             questions:
               -
@@ -914,8 +866,6 @@ assessment:
                     value: 'yes'
                   -
                     value: 'no'
-                  -
-                    value: 'unknown'
           escort_details:
             questions:
               -
@@ -940,8 +890,6 @@ assessment:
                               not_in_the_future: true
                   -
                     value: 'no'
-                  -
-                    value: 'unknown'
               -
                 name: escape_pack
                 type: string
@@ -964,8 +912,6 @@ assessment:
                               not_in_the_future: true
                   -
                     value: 'no'
-                  -
-                    value: 'unknown'
       substance_misuse:
         questions:
           -
@@ -981,8 +927,6 @@ assessment:
                 value: 'yes'
               -
                 value: 'no'
-              -
-                value: 'unknown'
       concealed_weapons:
         questions:
           -
@@ -1005,8 +949,6 @@ assessment:
                         name: 'Assessments::PresenceValidator'
               -
                 value: 'no'
-              -
-                value: 'unknown'
           -
             name: conceals_weapons
             type: string
@@ -1027,8 +969,6 @@ assessment:
                         name: 'Assessments::PresenceValidator'
               -
                 value: 'no'
-              -
-                value: 'unknown'
           -
             name: conceals_drugs
             type: string
@@ -1049,8 +989,6 @@ assessment:
                         name: 'Assessments::PresenceValidator'
               -
                 value: 'no'
-              -
-                value: 'unknown'
           -
             name: conceals_mobile_phone_or_other_items
             type: string
@@ -1095,8 +1033,6 @@ assessment:
                                     name: 'Assessments::PresenceValidator'
               -
                 value: 'no'
-              -
-                value: 'unknown'
       arson:
         questions:
           -
@@ -1112,8 +1048,6 @@ assessment:
                 value: 'yes'
               -
                 value: 'no'
-              -
-                value: 'unknown'
       return_instructions:
         questions:
           -
@@ -1142,8 +1076,6 @@ assessment:
                         name: 'Assessments::PresenceValidator'
               -
                 value: 'no'
-              -
-                value: 'unknown'
           -
             name: must_not_return
             type: string
@@ -1174,8 +1106,6 @@ assessment:
                             name: 'Assessments::PresenceValidator'
               -
                 value: 'no'
-              -
-                value: 'unknown'
       other_risk:
         questions:
           -
@@ -1198,5 +1128,3 @@ assessment:
                         name: 'Assessments::PresenceValidator'
               -
                 value: 'no'
-              -
-                value: 'unknown'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,29 +70,13 @@ en:
         violence_to_other_detainees_type: 'Victim of violence (select all that apply):'
         violence_to_staff: 'Are they violent to staff?'
     label:
-      allergies:
-        allergies_choices:
-          unknown: Clear selection
-      arson:
-        arson_choices:
-          unknown: Clear selection
       concealed_weapons:
-        conceals_weapons_choices:
-          unknown: Clear selection
-        conceals_drugs_choices:
-          unknown: Clear selection
         conceals_mobile_phones: Mobile phones
-        conceals_mobile_phone_or_other_items_choices:
-          unknown: Clear selection
         conceals_other_items: Other
         conceals_sim_cards: SIM cards
-        uses_weapons_choices:
-          unknown: Clear selection
       contact:
         contact_number: Medical contact
       dependencies:
-        dependencies_choices:
-          unknown: Clear selection
         dependencies_details: Addictions or dependencies details
       detainee:
         surname: Surname
@@ -105,23 +89,11 @@ en:
       detainee_search:
         prison_number: Enter a prison number. Eg. A1234AB
       discrimination:
-        discrimination_to_other_religions_choices:
-          unknown: Clear selection
         discrimination_to_other_religions_details: Risk to other religions details
-        homophobic_choices:
-          unknown: Clear selection
         homophobic_details: Risk to LGBT people details
-        other_violence_due_to_discrimination_choices:
-          unknown: Clear selection
         other_violence_due_to_discrimination_details: Risk to other groups details
-        racist_choices:
-          unknown: Clear selection
         racist_details: Risk to other races details
-        risk_to_females_choices:
-          unknown: Clear selection
       harassments:
-        intimidation_choices:
-          unknown: Clear selection
         intimidation_to_staff: Staff
         intimidation_to_staff_details: Staff details
         intimidation_to_public: Public
@@ -131,8 +103,6 @@ en:
         intimidation_to_witnesses: Witnesses
         intimidation_to_witnesses_details: Witnesses details
       hostage_taker:
-        hostage_taker_choices:
-          unknown: Clear selection
         staff_hostage_taker: Staff
         public_hostage_taker: Public
         prisoners_hostage_taker: Prisoners
@@ -143,18 +113,12 @@ en:
         from: From
         to: To
         date: Date of travel
-        not_for_release_choices:
-          unknown: Clear selection
       mental:
-        mental_illness_choices:
-          unknown: Clear selection
         mental_illness_details: Mental health issues details
       needs:
         actions:
           medications:
             add_multiple: Add another medicine
-        has_medications_choices:
-          unknown: Clear selection
         medications:
           description: Medicine
           administration: How is it given?
@@ -162,30 +126,16 @@ en:
           carrier_choices:
             escort: Escort
             detainee: Prisoner
-      physical:
-        physical_issues_choices:
-          unknown: Clear selection
-      other_risk:
-        other_risk_choices:
-          unknown: Clear selection
       return_instructions:
         actions:
           must_not_return_details:
             add_multiple: Add another establishment
-        must_not_return_choices:
-          unknown: Clear selection
         must_not_return_details:
           establishment: Establishment name
           establishment_details: 'Give details of why they must not be sent here:'
-        must_return_choices:
-          unknown: Clear selection
         must_return_to: 'Prison name:'
         must_return_to_details: Details for returning to a specific prison
       risk_from_others:
-        rule_45_choices:
-          unknown: Clear selection
-        high_profile_choices:
-          unknown: Clear selection
         high_profile_details: Details of high public interest
       risk_to_self:
         acct_status_choices:
@@ -196,23 +146,13 @@ en:
         acct_status_details: Give details of methods and triggers recorded on NOMIS if entered
         date_of_most_recently_closed_acct: Date of most recently closed ACCT
       security:
-        category_a_choices:
-          unknown: Clear selection
-        current_e_risk_choices:
-          unknown: Clear selection
         current_e_risk_details: E list type
         current_e_risk_details_choices:
           e_list_standard: E-List-Standard
           e_list_escort: E-List-Escort
           e_list_heightened: E-List-Heightened
-        escape_pack_choices:
-          unknown: Clear selection
-        escort_risk_assessment_choices:
-          unknown: Clear selection
         escape_pack_completion_date: 'Escape Pack completed on:'
         escort_risk_assessment_completion_date: 'Escort Risk Assessment completed on:'
-        previous_escape_attempts_choices:
-          unknown: Clear selection
         prison_escape_attempt: Prison
         prison_escape_attempt_details: Last prison escape attempt details
         court_escape_attempt: Court
@@ -222,21 +162,11 @@ en:
         other_type_escape_attempt: Other
         other_type_escape_attempt_details: Last other type of escape attempt details
       sex_offences:
-        sex_offence_choices:
-          unknown: Clear selection
         sex_offence_adult_male_victim: Adult male
         sex_offence_adult_female_victim: Adult female
         sex_offence_under18_victim: Under 18
         date_most_recent_sexual_offence: Date of most recent sexual offence
-      social:
-        personal_care_choices:
-          unknown: Clear selection
-      substance_misuse:
-        substance_supply_choices:
-          unknown: Clear selection
       transport:
-        mpv_choices:
-          unknown: Clear selection
         mpv_details: Details for need of a special vehicle
       violence:
         co_defendant: Co-defendant
@@ -247,22 +177,12 @@ en:
           three_officer_unlock: '3 officer unlock'
           four_officer_unlock: '4 officer unlock'
           more_than_four: 'More than 4 officers'
-        controlled_unlock_required_choices:
-          unknown: Clear selection
-        csra_choices:
-          unknown: Clear selection
         gang_member: Gang member
         gang_member_details: Gang member violence details
         other_violence_to_other_detainees: Other known conflicts
         other_violence_to_other_detainees_details: Other known conflicts details
-        violence_to_general_public_choices:
-          unknown: Clear selection
         violence_to_general_public_details: Violent to the general public details
-        violence_to_staff_choices:
-          unknown: Clear selection
         violence_to_staff_details: Violent to staff details
-        violence_to_other_detainees_choices:
-          unknown: Clear selection
     hint:
       allergies:
         allergies: "For example, dietary, medical or environmental allergies"
@@ -577,12 +497,10 @@ en:
         none: ''
         open: Open
         post_closure: Post closure
-        unknown: ''
       current_e_risk_details:
         e_list_escort: E-List-Escort
         e_list_heightened: E-List-Heightened
         e_list_standard: E-List-Standard
-        unknown: ''
       title:
         acct_status: ACCT
         category_a: Cat A

--- a/db/migrate/20170613132041_remove_default_unknown.rb
+++ b/db/migrate/20170613132041_remove_default_unknown.rb
@@ -1,0 +1,20 @@
+class RemoveDefaultUnknown < ActiveRecord::Migration[5.0]
+  def change
+    change_column_default :healthcare, :physical_issues, nil
+    change_column_default :healthcare, :mental_illness, nil
+    change_column_default :healthcare, :personal_care, nil
+    change_column_default :healthcare, :allergies, nil
+    change_column_default :healthcare, :dependencies, nil
+    change_column_default :healthcare, :has_medications, nil
+    change_column_default :healthcare, :mpv, nil
+
+    change_column_default :risks, :rule_45, nil
+    change_column_default :risks, :csra, nil
+    change_column_default :risks, :sex_offence, nil
+    change_column_default :risks, :current_e_risk, nil
+    change_column_default :risks, :category_a, nil
+    change_column_default :risks, :substance_supply, nil
+    change_column_default :risks, :conceals_weapons, nil
+    change_column_default :risks, :arson, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170607172008) do
+ActiveRecord::Schema.define(version: 20170613132041) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,22 +48,22 @@ ActiveRecord::Schema.define(version: 20170607172008) do
   end
 
   create_table "healthcare", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "physical_issues",         default: "unknown"
+    t.string   "physical_issues"
     t.text     "physical_issues_details"
-    t.string   "mental_illness",          default: "unknown"
+    t.string   "mental_illness"
     t.text     "mental_illness_details"
-    t.string   "personal_care",           default: "unknown"
+    t.string   "personal_care"
     t.text     "personal_care_details"
-    t.string   "allergies",               default: "unknown"
+    t.string   "allergies"
     t.text     "allergies_details"
-    t.string   "dependencies",            default: "unknown"
+    t.string   "dependencies"
     t.text     "dependencies_details"
-    t.string   "has_medications",         default: "unknown"
-    t.string   "mpv",                     default: "unknown"
+    t.string   "has_medications"
+    t.string   "mpv"
     t.text     "mpv_details"
     t.string   "contact_number"
-    t.datetime "created_at",                                  null: false
-    t.datetime "updated_at",                                  null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
     t.uuid     "escort_id"
     t.integer  "status",                  default: 0
     t.integer  "reviewer_id"
@@ -95,24 +95,24 @@ ActiveRecord::Schema.define(version: 20170607172008) do
   end
 
   create_table "risks", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "rule_45",                                           default: "unknown"
-    t.string   "csra",                                              default: "unknown"
+    t.string   "rule_45"
+    t.string   "csra"
     t.string   "risk_to_females"
     t.text     "risk_to_females_details"
     t.string   "homophobic"
     t.text     "homophobic_details"
     t.string   "racist"
     t.text     "racist_details"
-    t.string   "sex_offence",                                       default: "unknown"
-    t.string   "current_e_risk",                                    default: "unknown"
+    t.string   "sex_offence"
+    t.string   "current_e_risk"
     t.text     "current_e_risk_details"
-    t.string   "category_a",                                        default: "unknown"
-    t.string   "substance_supply",                                  default: "unknown"
-    t.string   "conceals_weapons",                                  default: "unknown"
+    t.string   "category_a"
+    t.string   "substance_supply"
+    t.string   "conceals_weapons"
     t.text     "conceals_weapons_details"
-    t.string   "arson",                                             default: "unknown"
-    t.datetime "created_at",                                                            null: false
-    t.datetime "updated_at",                                                            null: false
+    t.string   "arson"
+    t.datetime "created_at",                                                    null: false
+    t.datetime "updated_at",                                                    null: false
     t.string   "acct_status"
     t.text     "acct_status_details"
     t.date     "date_of_most_recently_closed_acct"

--- a/docs/assessments_schema.md
+++ b/docs/assessments_schema.md
@@ -154,8 +154,6 @@ Example of a subset of the assessments schema:
             value: 'yes'
           -
             value: 'no'
-          -
-            value: 'unknown'
   ...
   harassments:
     sections:
@@ -181,6 +179,4 @@ Example of a subset of the assessments schema:
                         name: 'Assessments::PresenceValidator'
               -
                 value: 'no'
-              -
-                value: 'unknown'
 ```

--- a/spec/factories/risk_factory.rb
+++ b/spec/factories/risk_factory.rb
@@ -37,8 +37,8 @@ FactoryGirl.define do
     end
 
     trait :incomplete do
-      rule_45 'unknown'
-      conceals_weapons 'unknown'
+      rule_45 nil
+      conceals_weapons nil
     end
 
     trait :unconfirmed do

--- a/spec/features/per_show_page_spec.rb
+++ b/spec/features/per_show_page_spec.rb
@@ -18,15 +18,6 @@ RSpec.feature 'PER show page', type: :feature do
         let(:options) { {} }
         let(:move) { create(:move, options) }
 
-        context 'when move has not for release set to unknown' do
-          let(:options) { { not_for_release: 'unknown' } }
-
-          scenario 'associated alert is displayed as inactive' do
-            escort_page.confirm_alert_as_inactive(:not_for_release)
-            expect(page.find('#not_for_release_alert .alert-text').text).to be_empty
-          end
-        end
-
         context 'when move has not for release set to no' do
           let(:options) { { not_for_release: 'no' } }
 
@@ -120,15 +111,6 @@ RSpec.feature 'PER show page', type: :feature do
           end
         end
 
-        context 'when detainee has ACCT status as unknown' do
-          let(:risk) { Risk.new(acct_status: 'unknown') }
-
-          scenario 'associated alert is displayed as inactive' do
-            escort_page.confirm_alert_as_inactive(:acct_status)
-            expect(page.find('#acct_status_alert .alert-text').text).to be_empty
-          end
-        end
-
         context 'when detainee has ACCT status as some other value' do
           let(:risk) { Risk.new(acct_status: 'some-other-value') }
 
@@ -162,15 +144,6 @@ RSpec.feature 'PER show page', type: :feature do
 
         context 'when detainee has Rule 45 as no' do
           let(:risk) { Risk.new(rule_45: 'no') }
-
-          scenario 'associated alert is displayed as inactive' do
-            escort_page.confirm_alert_as_inactive(:rule_45)
-            expect(page).not_to have_selector('#rule_45_alert .alert-text')
-          end
-        end
-
-        context 'when detainee has Rule 45 as unknown' do
-          let(:risk) { Risk.new(rule_45: 'unknown') }
 
           scenario 'associated alert is displayed as inactive' do
             escort_page.confirm_alert_as_inactive(:rule_45)
@@ -226,15 +199,6 @@ RSpec.feature 'PER show page', type: :feature do
             expect(page.find('#e_list_alert .alert-text').text).to be_empty
           end
         end
-
-        context 'when detainee has E list as unknown' do
-          let(:risk) { Risk.new(current_e_risk: 'unknown') }
-
-          scenario 'associated alert is displayed as inactive' do
-            escort_page.confirm_alert_as_inactive(:e_list)
-            expect(page.find('#e_list_alert .alert-text').text).to be_empty
-          end
-        end
       end
     end
 
@@ -262,16 +226,6 @@ RSpec.feature 'PER show page', type: :feature do
 
         context 'when detainee has CSRA as standard' do
           let(:risk) { Risk.new(csra: 'standard') }
-
-          scenario 'associated alert is displayed as inactive' do
-            escort_page.confirm_alert_as_inactive(:csra)
-            expect(page).not_to have_selector('#csra_alert .alert-text')
-            expect(page.find('#csra_alert .alert-toggle-text').text).to match(/^Standard$/i)
-          end
-        end
-
-        context 'when detainee has CSRA as unknown' do
-          let(:risk) { Risk.new(csra: 'unknown') }
 
           scenario 'associated alert is displayed as inactive' do
             escort_page.confirm_alert_as_inactive(:csra)
@@ -310,15 +264,6 @@ RSpec.feature 'PER show page', type: :feature do
             expect(page).not_to have_selector('#category_a_alert .alert-text')
           end
         end
-
-        context 'when detainee has Category A as unknown' do
-          let(:risk) { Risk.new(category_a: 'unknown') }
-
-          scenario 'associated alert is displayed as inactive' do
-            escort_page.confirm_alert_as_inactive(:category_a)
-            expect(page).not_to have_selector('#category_a_alert .alert-text')
-          end
-        end
       end
     end
 
@@ -344,15 +289,6 @@ RSpec.feature 'PER show page', type: :feature do
 
         context 'when detainee has MPV as no' do
           let(:healthcare) { Healthcare.new(mpv: 'no') }
-
-          scenario 'associated alert is displayed as inactive' do
-            escort_page.confirm_alert_as_inactive(:mpv)
-            expect(page).not_to have_selector('#mpv_alert .alert-text')
-          end
-        end
-
-        context 'when detainee has MPV as unknown' do
-          let(:healthcare) { Healthcare.new(mpv: 'unknown') }
 
           scenario 'associated alert is displayed as inactive' do
             escort_page.confirm_alert_as_inactive(:mpv)

--- a/spec/features/reuse_spec.rb
+++ b/spec/features/reuse_spec.rb
@@ -48,8 +48,10 @@ RSpec.feature 'Reuse of previously entered PER data', type: :feature do
     escort_page.click_edit_healthcare
 
     find("a", :text => /\AChange\z/, match: :first).click
-    choose 'Clear selection'
+    choose 'Yes'
+    fill_in 'physical[physical_issues_details]', with: 'Some details'
     click_button 'Save and view summary'
-    healthcare_summary.confirm_status 'Incomplete'
+    healthcare_summary.confirm_and_save
+    escort_page.confirm_healthcare_status('Complete')
   end
 end

--- a/spec/forms/move_spec.rb
+++ b/spec/forms/move_spec.rb
@@ -53,26 +53,6 @@ RSpec.describe Forms::Move, type: :form do
         end
       end
 
-      context 'when not for release is set to unknown' do
-        before do
-          form.not_for_release = 'unknown'
-          form.not_for_release_reason = nil
-          form.not_for_release_reason_details = nil
-        end
-
-        include_examples 'validation error on not for release value'
-        include_examples 'no validation on not for release reason'
-
-        context 'and not for release reason is set to other' do
-          before do
-            form.not_for_release_reason = 'other'
-          end
-
-          include_examples 'validation error on not for release value'
-          include_examples 'no validation on not for release reason'
-        end
-      end
-
       context 'when not for release is set to no' do
         before do
           form.not_for_release = 'no'

--- a/spec/models/assessments/question_spec.rb
+++ b/spec/models/assessments/question_spec.rb
@@ -12,11 +12,6 @@ RSpec.describe Assessments::Question do
       specify { expect(question.answered?).to be_falsey }
     end
 
-    context 'when answer is "unknown"' do
-      let(:answer) { 'unknown' }
-      specify { expect(question.answered?).to be_falsey }
-    end
-
     context 'when answer is not present' do
       let(:answer) { '' }
       specify { expect(question.answered?).to be_falsey }

--- a/spec/presenters/question_presenter_spec.rb
+++ b/spec/presenters/question_presenter_spec.rb
@@ -54,30 +54,25 @@ RSpec.describe QuestionPresenter do
   end
 
   describe '#display_inline?' do
-    context 'when the question has no answer options' do
-      let(:answer_options) { [] }
-      specify { expect(presenter.display_inline?).to be_falsey }
-    end
-
-    context 'when none of the answer options are the value unknown' do
+    context 'when the question has two answer options' do
       let(:answer_options) {
         [
           double(Schemas::Answer, value: 'bla'),
           double(Schemas::Answer, value: 'foo')
         ]
       }
-      specify { expect(presenter.display_inline?).to be_falsey }
+      specify { expect(presenter.display_inline?).to be_truthy }
     end
 
-    context 'when one of the answer options has the value unknown' do
+    context 'when the question has three answer options' do
       let(:answer_options) {
         [
           double(Schemas::Answer, value: 'bla'),
-          double(Schemas::Answer, value: 'foo'),
-          double(Schemas::Answer, value: 'unknown')
+          double(Schemas::Answer, value: 'bar'),
+          double(Schemas::Answer, value: 'foo')
         ]
       }
-      specify { expect(presenter.display_inline?).to be_truthy }
+      specify { expect(presenter.display_inline?).to be_falsey }
     end
   end
 

--- a/spec/presenters/summary/assessment_question_presenter_spec.rb
+++ b/spec/presenters/summary/assessment_question_presenter_spec.rb
@@ -136,16 +136,6 @@ RSpec.describe Summary::AssessmentQuestionPresenter do
         expect(question).to receive(:belongs_to_group?).and_return(true)
       end
 
-      context 'and group parent answer is "unknown"' do
-        before do
-          expect(question).to receive(:parent_group_answer).and_return('unknown')
-        end
-
-        it 'returns missing content' do
-          expect(presenter.answer).to eq("<span class='text-error'>Missing</span>")
-        end
-      end
-
       context 'and group parent answer is nil' do
         before do
           expect(question).to receive(:parent_group_answer).and_return(nil)
@@ -189,14 +179,6 @@ RSpec.describe Summary::AssessmentQuestionPresenter do
         expect(question).to receive(:belongs_to_group?).and_return(false)
       end
 
-      context 'and parent answer is "unknown"' do
-        let(:parent_value) { 'unknown' }
-
-        it 'returns missing content' do
-          expect(presenter.answer).to eq("<span class='text-error'>Missing</span>")
-        end
-      end
-
       context 'and parent answer is nil' do
         let(:parent_value) { nil }
 
@@ -229,14 +211,6 @@ RSpec.describe Summary::AssessmentQuestionPresenter do
 
       before do
         expect(question).to receive(:belongs_to_group?).and_return(false)
-      end
-
-      context 'when the answer for the question is "unknown"' do
-        let(:value) { 'unknown' }
-
-        it 'returns missing content' do
-          expect(presenter.answer).to eq("<span class='text-error'>Missing</span>")
-        end
       end
 
       context 'when the answer for the question is nil' do

--- a/spec/support/matchers/validate_optional_details_field.rb
+++ b/spec/support/matchers/validate_optional_details_field.rb
@@ -64,17 +64,15 @@ class ValidateOptionalDetailsField
   end
 
   def doesnt_validate_presence_of_details_field_when_option_field_negative
-    %w[ no unknown ].reduce([]) do |acc, option_field_value|
-      reset_subject
+    reset_subject
 
-      result = !perform_presence_validation_on_details_field(option_field_value: option_field_value)
+    result = !perform_presence_validation_on_details_field(option_field_value: option_field_value)
 
-      unless result
-        set_error "Should be acceptable to set #{details_field_method_name} value to nil/empty string when the option field is set to: #{option_field_value}."
-      end
+    unless result
+      set_error "Should be acceptable to set #{details_field_method_name} value to nil/empty string when the option field is set to: #{option_field_value}."
+    end
 
-      acc << result
-    end.all?
+    result
   end
 
   def validates_details_field_as_strict_string

--- a/spec/support/matchers/validate_optional_field.rb
+++ b/spec/support/matchers/validate_optional_field.rb
@@ -21,7 +21,7 @@ class ValidateOptionalField
 
   private
 
-  FIELD_OPTIONS = %w[ yes no unknown ]
+  FIELD_OPTIONS = %w[ yes no ]
 
   def validates_inclusion
     in_values = FIELD_OPTIONS

--- a/spec/support/matchers/validate_prepopulated_collection.rb
+++ b/spec/support/matchers/validate_prepopulated_collection.rb
@@ -34,13 +34,6 @@ class ValidatePrepopulatedCollection
       set_error "Expected that #{subject.class.to_s} would implement has_#{field_name}, but it doesn't."
       return false
     end
-    unless has_defined_at_runtime?
-      result = subject.public_send("has_#{field_name}")
-      unless result == "unknown"
-        set_error "Expected #{subject.class.to_s}#has_#{field_name} to return 'unknown', got '#{result}'."
-        return false
-      end
-    end
     true
   end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/G6128OAE/203-remove-clear-selection-option-from-questions)

In this work we remove the option to reset the value of questions with radio buttons. Before we had a third hidden value 'unknown' on these inline radio button questions.

This work is useful to align with the gems provide common components/tools across the department apps.