### PR TITLE
Increase font-size of date of move in print

### DIFF
--- a/app/views/escorts/print/cover.html.slim
+++ b/app/views/escorts/print/cover.html.slim
@@ -74,7 +74,7 @@ html
         div.grid-row.padded.padded-bottom
           div.grid-column.column-one-third
             div.title Date of travel
-            div.strong-text = move.date
+            div.strong-text.font-medium = move.date
           div.grid-column.column-one-third
             div.title From
             div.strong-text = move.from

--- a/spec/support/fixtures/pdf-text-all-yes-answers.txt
+++ b/spec/support/fixtures/pdf-text-all-yes-answers.txt
@@ -1,32 +1,32 @@
 Outbound vehicle
-Registration                   Cell number                      PECS Barcode
+Registration                    Cell number                     PECS Barcode
 
 
 
 
 Return vehicle
-Registration                   Cell number
+Registration                    Cell number
 
 
 
 
 W1234BY: McTest Testy
- NOT FOR RELEASE                     E LIST                             MPV
+ NOT FOR RELEASE                      E LIST                            MPV
 
-                                   E-List-Escort
+                                    E-List-Escort
 
-Prison number    CRO number        PNC number        Aliases
-W1234BY          56TYY/UU          YI896668TT        Terry Tibbs
+Prison number     CRO number        PNC number       Aliases
+W1234BY           56TYY/UU          YI896668TT       Terry Tibbs
                                                      Mr T
-Date of birth    Age      Gender Nationality
-10 Dec 1970      46       M      British
+Date of birth     Age      Gender Nationality
+10 Dec 1970       46       M      British
 
 
 
 
 Move details
-Date of travel                     From                                To
-22 Apr 2099                        HMP Bedford                         Luton Crown Court
+Date of travel                      From                               To
+22 Apr 2099                         HMP Bedford                        Luton Crown Court
 
 
 


### PR DESCRIPTION
[Trello](https://trello.com/c/xFhsG8Jt/208-review-making-it-easier-to-distinguish-between-days-on-print-out)

This change will render the date of move more visible in the print.