### PR TITLE
Change Reprint flow to make it harder for users

### DIFF
--- a/app/controllers/escorts/print_controller.rb
+++ b/app/controllers/escorts/print_controller.rb
@@ -1,5 +1,9 @@
 module Escorts
   class PrintController < ApplicationController
+    def new
+      escort
+    end
+
     def show
       error_redirect && return unless printable_escort?
       issue_escort_unless_issued!

--- a/app/views/escorts/_actions.html.slim
+++ b/app/views/escorts/_actions.html.slim
@@ -1,5 +1,8 @@
 ul.actions
-  - if escort.completed?
+  - if escort.issued?
+    li
+      = link_to('Reprint', new_escort_print_path(escort), class: 'button button-print')
+  - elsif escort.completed?
     li
       = link_to_print_in_new_window(escort, styles: 'button button-print')
   li.link-return-home

--- a/app/views/escorts/print/new.html.slim
+++ b/app/views/escorts/print/new.html.slim
@@ -1,0 +1,17 @@
+= content_for :breadcrumbs do
+  - breadcrumbs_for_page root: true
+
+.escort.per-page
+  h1
+    = t('.reprint_per_for')
+    br
+    = "#{@escort.prison_number}: #{@escort.detainee.surname} #{@escort.detainee.forenames}"
+
+  p.font-large
+    = @escort.move.date
+
+  ul.actions
+    li
+      = link_to_print_in_new_window(@escort, text: t('.reprint_this_per'), styles: 'button button-print')
+    li
+      = link_to t('.do_not_reprint_per'), escort_path(@escort), class: 'button button-secondary'

--- a/app/views/homepage/_escorts.html.slim
+++ b/app/views/homepage/_escorts.html.slim
@@ -19,10 +19,8 @@
             |  #{escort.detainee.forenames}
         td = escort.move&.to
         - if escort.issued?
-          td.issued colspan=3
+          td.issued colspan=4
             | Issued
-          td.print
-            = link_to_print_in_new_window(escort, text: 'Reprint')
         - else
           td.completion-status
             span class="#{escort.risk_complete? ? true : false}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -509,6 +509,12 @@ en:
         mpv: MPV
         not_for_release: Not for release
         rule_45: Rule 45
+  escorts:
+    print:
+      new:
+        reprint_per_for: Reprint PER for
+        reprint_this_per: Reprint this PER
+        do_not_reprint_per: Do not reprint this PER
   assessment:
     confirmed_timestamp: "Last confirmed: %{name}, %{time}"
   print:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
       put :confirm, on: :collection
     end
     resource :offences, only: %i[show update]
-    resource :print, only: %i[show], controller: 'escorts/print'
+    resource :print, only: %i[new show], controller: 'escorts/print'
   end
 
   post '/detainees/search', to: 'homepage#detainees'

--- a/spec/features/issued_per_spec.rb
+++ b/spec/features/issued_per_spec.rb
@@ -1,7 +1,7 @@
 require 'feature_helper'
 
 RSpec.feature 'issued PERs', type: :feature do
-  scenario 'Checking issued PER sections are read only' do
+  scenario 'Checking issued PER sections are read only and allows reprint' do
     login
 
     escort = create(:escort, :issued)
@@ -27,5 +27,8 @@ RSpec.feature 'issued PERs', type: :feature do
     escort_page.confirm_offences_action_link('View')
     escort_page.click_edit_offences('View')
     offences.confirm_read_only
+
+    visit escort_path(escort)
+    escort_page.click_reprint
   end
 end

--- a/spec/features/pages/escort.rb
+++ b/spec/features/pages/escort.rb
@@ -147,6 +147,10 @@ module Page
       click_link 'Print'
     end
 
+    def click_reprint
+      click_link 'Reprint'
+    end
+
     def confirm_healthcare_action_link(name)
       confirm_per_section_action_link(:healthcare, name)
     end


### PR DESCRIPTION
[Trello](https://trello.com/c/2NfT5Sp9/207-change-reprint-flow-to-make-it-harder-for-users-to-use-this-by-mistake)

This work hides the Reprint link from the dashboard, and when clicking on Reprint on the escort page, the user will be presented with a confirmation screen before he can see the PDF generated.