### PR TITLE
Fix date today bug

### DIFF
--- a/app/models/date_picker.rb
+++ b/app/models/date_picker.rb
@@ -4,12 +4,9 @@ class DatePicker
 
   include Comparable
 
-  def initialize(date_from_session)
-    if date_from_session.present?
-      send(:date=, date_from_session)
-    else
-      today
-    end
+  def initialize(new_date)
+    return today unless new_date.present?
+    send(:date=, new_date)
   end
 
   def date
@@ -46,7 +43,7 @@ class DatePicker
   end
 
   def today
-    @date = Date.today
+    @date = Time.current.to_date
   end
 
   private

--- a/app/presenters/radio_date_picker_presenter.rb
+++ b/app/presenters/radio_date_picker_presenter.rb
@@ -1,0 +1,46 @@
+class RadioDatePickerPresenter
+  DEFAULT_FORMAT = '%d/%m/%Y'.freeze
+  attr_reader :attr, :value
+
+  def initialize(attr, value)
+    @attr = attr
+    @normalized_attr = attr.to_s.gsub(/\[(.*)\]/, '_\1')
+    @value = value
+  end
+
+  def today_label
+    "#{normalized_attr}_#{today_date}"
+  end
+
+  def tomorrow_label
+    "#{normalized_attr}_#{tomorrow_date}"
+  end
+
+  def today(format = DEFAULT_FORMAT)
+    today_date.strftime(format)
+  end
+
+  def tomorrow(format = DEFAULT_FORMAT)
+    tomorrow_date.strftime(format)
+  end
+
+  def today?
+    value == today_date
+  end
+
+  def tomorrow?
+    value == tomorrow_date
+  end
+
+  private
+
+  attr_reader :normalized_attr
+
+  def today_date
+    Time.current.to_date
+  end
+
+  def tomorrow_date
+    Time.current.tomorrow.to_date
+  end
+end

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -30,13 +30,13 @@ class DateValidator < ActiveModel::EachValidator
     required = options[:not_in_the_past]
     message = required[:message] if required.is_a?(Hash)
     message ||= 'is in the past'
-    record.errors[attribute] << message if required.present? && value < Date.today
+    record.errors[attribute] << message if required.present? && value < Time.current.to_date
   end
 
   def validate_not_in_future(record, attribute, value)
     required = options[:not_in_the_future]
     message = required[:message] if required.is_a?(Hash)
     message ||= 'is in the future'
-    record.errors[attribute] << message if required.present? && value > Date.today
+    record.errors[attribute] << message if required.present? && value > Time.current.to_date
   end
 end

--- a/app/views/homepage/show.html.slim
+++ b/app/views/homepage/show.html.slim
@@ -36,11 +36,11 @@
       .no-script
         .form-group.search-date-radios
           fieldset.inline
-            = label_tag "escorts_due_on_#{Date.today}", 'Today', class: 'block-label' do
-              = radio_button_tag 'escorts_due_on', Date.today.strftime('%d/%m/%Y'), (date_picker == Date.today), class: 'radio-date-selector', disabled: true
+            = label_tag "escorts_due_on_#{Time.current.to_date}", 'Today', class: 'block-label' do
+              = radio_button_tag 'escorts_due_on', Time.current.to_date.strftime('%d/%m/%Y'), (date_picker == Time.current.to_date), class: 'radio-date-selector', disabled: true
               == 'Today'
-            = label_tag "escorts_due_on_#{Date.tomorrow}", 'Tomorrow', class: 'block-label' do
-              = radio_button_tag 'escorts_due_on', Date.tomorrow.strftime('%d/%m/%Y'), (date_picker == Date.tomorrow), class: 'radio-date-selector', disabled: true
+            = label_tag "escorts_due_on_#{Time.current.tomorrow.to_date}", 'Tomorrow', class: 'block-label' do
+              = radio_button_tag 'escorts_due_on', Time.current.tomorrow.to_date.strftime('%d/%m/%Y'), (date_picker == Time.current.tomorrow.to_date), class: 'radio-date-selector', disabled: true
               == 'Tomorrow'
 
   - if dashboard.escorts.empty?

--- a/app/views/homepage/show.html.slim
+++ b/app/views/homepage/show.html.slim
@@ -33,15 +33,7 @@
           span.no-script.calendar-icon.input-group-addon
         button.go type='submit' name='commit' Go
 
-      .no-script
-        .form-group.search-date-radios
-          fieldset.inline
-            = label_tag "escorts_due_on_#{Time.current.to_date}", 'Today', class: 'block-label' do
-              = radio_button_tag 'escorts_due_on', Time.current.to_date.strftime('%d/%m/%Y'), (date_picker == Time.current.to_date), class: 'radio-date-selector', disabled: true
-              == 'Today'
-            = label_tag "escorts_due_on_#{Time.current.tomorrow.to_date}", 'Tomorrow', class: 'block-label' do
-              = radio_button_tag 'escorts_due_on', Time.current.tomorrow.to_date.strftime('%d/%m/%Y'), (date_picker == Time.current.tomorrow.to_date), class: 'radio-date-selector', disabled: true
-              == 'Tomorrow'
+      = render partial: 'shared/radio_date_picker', locals: { picker: RadioDatePickerPresenter.new('escorts_due_on', date_picker) }
 
   - if dashboard.escorts.empty?
     #escorts_gauges.escorts-gauges

--- a/app/views/moves/_form.html.slim
+++ b/app/views/moves/_form.html.slim
@@ -8,15 +8,7 @@
     = f.text_field :from
     = f.text_field :to
     = f.date_picker_text_field :date
-    .no-script
-      .form-group.date-radios
-        fieldset.inline
-          = label_tag "move_date_#{Time.current.to_date}", 'Today', class: 'block-label' do
-            = radio_button_tag 'move[date]', Time.current.to_date.strftime('%d/%m/%Y'), (form.date == Time.current.to_date), class: 'radio-date-selector', disabled: true
-            == 'Today'
-          = label_tag "move_date_#{Time.current.tomorrow.to_date}", 'Tomorrow', class: 'block-label' do
-            = radio_button_tag 'move[date]', Time.current.tomorrow.to_date.strftime('%d/%m/%Y'), (form.date == Time.current.tomorrow.to_date), class: 'radio-date-selector', disabled: true
-            == 'Tomorrow'
+    = render partial: 'shared/radio_date_picker', locals: { picker: RadioDatePickerPresenter.new('move[date]', form.date) }
 
     = f.radio_toggle :not_for_release,
       choices: f.object.toggle_choices do

--- a/app/views/moves/_form.html.slim
+++ b/app/views/moves/_form.html.slim
@@ -11,11 +11,11 @@
     .no-script
       .form-group.date-radios
         fieldset.inline
-          = label_tag "move_date_#{Date.today}", 'Today', class: 'block-label' do
-            = radio_button_tag 'move[date]', Date.today.strftime('%d/%m/%Y'), (form.date == Date.today), class: 'radio-date-selector', disabled: true
+          = label_tag "move_date_#{Time.current.to_date}", 'Today', class: 'block-label' do
+            = radio_button_tag 'move[date]', Time.current.to_date.strftime('%d/%m/%Y'), (form.date == Time.current.to_date), class: 'radio-date-selector', disabled: true
             == 'Today'
-          = label_tag "move_date_#{Date.tomorrow}", 'Tomorrow', class: 'block-label' do
-            = radio_button_tag 'move[date]', Date.tomorrow.strftime('%d/%m/%Y'), (form.date == Date.tomorrow), class: 'radio-date-selector', disabled: true
+          = label_tag "move_date_#{Time.current.tomorrow.to_date}", 'Tomorrow', class: 'block-label' do
+            = radio_button_tag 'move[date]', Time.current.tomorrow.to_date.strftime('%d/%m/%Y'), (form.date == Time.current.tomorrow.to_date), class: 'radio-date-selector', disabled: true
             == 'Tomorrow'
 
     = f.radio_toggle :not_for_release,

--- a/app/views/shared/_radio_date_picker.html.slim
+++ b/app/views/shared/_radio_date_picker.html.slim
@@ -1,0 +1,9 @@
+.no-script
+  .form-group.date-radios
+    fieldset.inline
+      = label_tag picker.today_label, 'Today', class: 'block-label' do
+        = radio_button_tag picker.attr, picker.today, picker.today?, class: 'radio-date-selector', disabled: true
+        == 'Today'
+      = label_tag picker.tomorrow_label, 'Tomorrow', class: 'block-label' do
+        = radio_button_tag picker.attr, picker.tomorrow, picker.tomorrow? , class: 'radio-date-selector', disabled: true
+        == 'Tomorrow'

--- a/spec/factories/move_factory.rb
+++ b/spec/factories/move_factory.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
   factory :move do
     from { FixtureData.prison }
     to { FixtureData.county_court }
-    date { Date.today }
+    date { Time.current.to_date }
     not_for_release 'no'
 
     trait :active do

--- a/spec/models/date_picker_spec.rb
+++ b/spec/models/date_picker_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe DatePicker do
         before { subject.today }
 
         it "sets the date to today's date" do
-          expect(result).to eql Date.today
+          expect(result).to eq(Time.current.to_date)
         end
       end
     end
@@ -152,7 +152,7 @@ RSpec.describe DatePicker do
       let(:result) { subject.date }
 
       it "returns today's date" do
-        expect(result).to eql Date.today
+        expect(result).to eq(Time.current.to_date)
       end
     end
 
@@ -166,7 +166,7 @@ RSpec.describe DatePicker do
 
     describe "#forward" do
       before { subject.forward }
-      let(:tomorrow) { Date.today + 1.day }
+      let(:tomorrow) { (Time.current + 1.day).to_date }
 
       it "#date returns tomorrows date" do
         expect(subject.date).to eq(tomorrow)

--- a/spec/models/detainee_spec.rb
+++ b/spec/models/detainee_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Detainee do
   describe "#age" do
     it "uses the AgeCalculator" do
-      subject = Detainee.new(date_of_birth: Date.today)
+      subject = Detainee.new(date_of_birth: Time.current.to_date)
       expect(AgeCalculator).to receive(:age).and_return(:two_hundreds)
       expect(subject.age).to eql :two_hundreds
     end

--- a/spec/presenters/radio_date_picker_presenter_spec.rb
+++ b/spec/presenters/radio_date_picker_presenter_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.describe RadioDatePickerPresenter do
+  let(:attr) { 'some_attr' }
+  let(:value) { Date.civil(2007, 7, 23) }
+  let(:travel_date) { Date.civil(2016, 11, 24) }
+  subject(:picker) { described_class.new(attr, value) }
+
+  around do |example|
+    travel_to(travel_date) do
+      example.run
+    end
+  end
+
+  describe '#today_label' do
+    specify { expect(picker.today_label).to eq('some_attr_24/11/2016') }
+
+    context 'for an attribute that needs to be normalised' do
+      let(:attr) { 'context[some_attr]' }
+      specify { expect(picker.today_label).to eq('context_some_attr_24/11/2016') }
+    end
+  end
+
+  describe '#tomorrow_label' do
+    specify { expect(picker.tomorrow_label).to eq('some_attr_25/11/2016') }
+
+    context 'for an attribute that needs to be normalised' do
+      let(:attr) { 'context[some_attr]' }
+      specify { expect(picker.tomorrow_label).to eq('context_some_attr_25/11/2016') }
+    end
+  end
+
+  describe '#today' do
+    context 'when no format is specified' do
+      it 'returns today date using the default format' do
+        expect(picker.today).to eq('24/11/2016')
+      end
+    end
+
+    context 'when a format is specified' do
+      it 'returns today date using the provided format' do
+        expect(picker.today('%Y-%m-%d')).to eq('2016-11-24')
+      end
+    end
+  end
+
+  describe '#tomorrow' do
+    context 'when no format is specified' do
+      it 'returns tomorrow date using the default format' do
+        expect(picker.tomorrow).to eq('25/11/2016')
+      end
+    end
+
+    context 'when a format is specified' do
+      it 'returns tomorrow date using the provided format' do
+        expect(picker.tomorrow('%Y-%m-%d')).to eq('2016-11-25')
+      end
+    end
+  end
+
+  describe '#today?' do
+    context 'when the provided value is not today' do
+      let(:value) { Date.civil(2007, 7, 23) }
+      let(:travel_date) { Date.civil(2016, 11, 24) }
+      specify { expect(picker.today?).to be_falsey }
+    end
+
+    context 'when the provided value is today' do
+      let(:value) { travel_date }
+      let(:travel_date) { Date.civil(2016, 11, 24) }
+      specify { expect(picker.today?).to be_truthy }
+    end
+  end
+
+  describe '#tomorrow?' do
+    context 'when the provided value is not tomorrow' do
+      let(:value) { Date.civil(2007, 7, 23) }
+      let(:travel_date) { Date.civil(2016, 11, 24) }
+      specify { expect(picker.tomorrow?).to be_falsey }
+    end
+
+    context 'when the provided value is tomorrow' do
+      let(:value) { Date.civil(2016, 11, 25) }
+      let(:travel_date) { Date.civil(2016, 11, 24) }
+      specify { expect(picker.tomorrow?).to be_truthy }
+    end
+  end
+end

--- a/spec/validators/date_validator_spec.rb
+++ b/spec/validators/date_validator_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe DateValidator do
     subject { validatable_klass(not_in_the_past: true).new(date: date) }
 
     context 'and it is' do
-      let(:date) { Date.yesterday }
+      let(:date) { Time.current.yesterday.to_date }
       specify {
         is_expected.not_to be_valid
         expect(subject.errors[:date]).to match_array(['is in the past'])
@@ -92,7 +92,7 @@ RSpec.describe DateValidator do
     end
 
     context 'and its not' do
-      let(:date) { Date.today }
+      let(:date) { Time.current.to_date }
       specify { is_expected.to be_valid }
     end
   end
@@ -101,7 +101,7 @@ RSpec.describe DateValidator do
     subject { validatable_klass(not_in_the_future: true).new(date: date) }
 
     context 'and it is' do
-      let(:date) { Date.today + 1.day }
+      let(:date) { Time.current.tomorrow.to_date }
       specify {
         is_expected.not_to be_valid
         expect(subject.errors[:date]).to match_array(['is in the future'])
@@ -119,7 +119,7 @@ RSpec.describe DateValidator do
     end
 
     context 'and its not' do
-      let(:date) { Date.today }
+      let(:date) { Time.current.to_date }
       specify { is_expected.to be_valid }
     end
   end


### PR DESCRIPTION
[Trello](https://trello.com/c/7WfCMM2n/211-bug-from-midnight-until-1am-clicking-today-displays-yesterdays-date)

The issue with the date is explained in more detail [here](https://stackoverflow.com/questions/26952421/whats-wrong-with-railss-date).

I've also taken the opportunity to clean up some code related with the way we present the _radio buttons_ for the date picker default options.