### PR TITLE
Move OffencesWorkflow from the Detainee to the Escort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 ### Added
 - Added a floating side bar displaying detainee and move details to ePER editing screens. This ensures that detainee and move details are visible at all stages of ePER creation.
+- Moved OffencesWorkflow model from the Detainee to the Escort
 ### Changed
 ### Fixed
 

--- a/app/controllers/offences_controller.rb
+++ b/app/controllers/offences_controller.rb
@@ -2,7 +2,7 @@ class OffencesController < ApplicationController
   before_action :redirect_unless_document_editable, except: :show
   before_action :add_offence, only: [:update]
 
-  helper_method :escort, :offences
+  helper_method :escort, :offences, :offences_workflow
 
   def show
     prepopulate_offences
@@ -14,7 +14,7 @@ class OffencesController < ApplicationController
   def update
     if form.validate form_data
       form.save
-      offences.confirm!(user: current_user)
+      offences_workflow.confirm!(user: current_user)
       redirect_to escort_path(escort)
     else
       flash[:form_data] = form_data
@@ -30,6 +30,10 @@ class OffencesController < ApplicationController
 
   def offences
     escort.offences
+  end
+
+  def offences_workflow
+    escort.offences_workflow || escort.build_offences_workflow
   end
 
   def add_offence

--- a/app/models/detainee.rb
+++ b/app/models/detainee.rb
@@ -1,30 +1,8 @@
 class Detainee < ApplicationRecord
   belongs_to :escort
   has_many :offences, dependent: :destroy
-  has_one :offences_workflow
-
-  before_create :set_defaults
-
-  def set_defaults
-    offences_workflow || build_offences_workflow
-  end
-
-  def offences
-    OffencesCollection.new(workflow: offences_workflow, collection: super)
-  end
 
   def age
     AgeCalculator.age(date_of_birth)
-  end
-
-  class OffencesCollection < SimpleDelegator
-    def initialize(workflow:, collection:)
-      @workflow = workflow
-      super(collection)
-    end
-
-    attr_reader :workflow
-
-    delegate(*OffencesWorkflow::DELEGATED_METHODS, to: :workflow)
   end
 end

--- a/app/models/offences_workflow.rb
+++ b/app/models/offences_workflow.rb
@@ -1,7 +1,5 @@
 class OffencesWorkflow < ApplicationRecord
   include Reviewable
 
-  DELEGATED_METHODS = %i[status needs_review? needs_review! incomplete? unconfirmed? confirmed? confirm!].freeze
-
-  belongs_to :detainee
+  belongs_to :escort
 end

--- a/app/presenters/dashboard_presenter.rb
+++ b/app/presenters/dashboard_presenter.rb
@@ -59,14 +59,14 @@ class DashboardPresenter
   end
 
   def count_of_incomplete_risk
-    escorts.uncancelled.with_incomplete_risk.count + escorts.uncancelled.without_risk_assessment.count
+    escorts.uncancelled.with_unconfirmed_risk.count + escorts.uncancelled.without_risk_assessment.count
   end
 
   def count_of_incomplete_healthcare
-    escorts.uncancelled.with_incomplete_healthcare.count + escorts.uncancelled.without_healthcare_assessment.count
+    escorts.uncancelled.with_unconfirmed_healthcare.count + escorts.uncancelled.without_healthcare_assessment.count
   end
 
   def count_of_incomplete_offences
-    escorts.uncancelled.with_incomplete_offences.count
+    escorts.uncancelled.with_unconfirmed_offences.count + escorts.uncancelled.without_offences_workflow.count
   end
 end

--- a/app/presenters/offences_presenter.rb
+++ b/app/presenters/offences_presenter.rb
@@ -1,10 +1,11 @@
 class OffencesPresenter < SimpleDelegator
-  def initialize(offences)
+  def initialize(offences, workflow)
     @offences = offences.map { |offence| CurrentOffencePresenter.new(offence) }
-    super
+    @workflow = workflow
   end
 
   delegate :empty?, :any?, :each, :present?, to: :@offences
+  delegate :needs_review?, :incomplete?, :unconfirmed?, :confirmed?, to: :@workflow, allow_nil: true
 
   class CurrentOffencePresenter < SimpleDelegator
     include ActionView::Helpers::SanitizeHelper

--- a/app/services/escort_creator.rb
+++ b/app/services/escort_creator.rb
@@ -25,7 +25,8 @@ class EscortCreator
   INCLUDE_GRAPH = [
     { detainee: [:offences] },
     :risk,
-    :healthcare
+    :healthcare,
+    :offences_workflow
   ].freeze
 
   EXCEPT_GRAPH = [

--- a/app/views/escorts/show.html.slim
+++ b/app/views/escorts/show.html.slim
@@ -9,9 +9,9 @@
 
   = render partial: 'detainee', locals: { detainee: DetaineePresenter.new(escort.detainee) }
 
-  = render partial: 'risk', locals: { risk: escort.risk, detainee: escort.detainee }
-  = render partial: 'healthcare', locals: { healthcare: escort.healthcare, detainee: escort.detainee }
-  = render partial: 'offences', locals: { offences: OffencesPresenter.new(escort.offences), detainee: escort.detainee }
+  = render partial: 'risk', locals: { risk: escort.risk }
+  = render partial: 'healthcare', locals: { healthcare: escort.healthcare }
+  = render partial: 'offences', locals: { offences: OffencesPresenter.new(escort.offences, escort.offences_workflow) }
   = render partial: 'actions'
 
 .column-one-quarter.side-profile

--- a/app/views/offences/show.html.slim
+++ b/app/views/offences/show.html.slim
@@ -5,7 +5,7 @@
 
 .column-three-quarters
   .offences.per-section-page
-    - if offences.needs_review?
+    - if offences_workflow.needs_review?
       header
         h1 Review before you save and continue
         p#offences-status

--- a/db/migrate/20170913110147_offences_workflows_in_escorts.rb
+++ b/db/migrate/20170913110147_offences_workflows_in_escorts.rb
@@ -1,0 +1,15 @@
+class OffencesWorkflowsInEscorts < ActiveRecord::Migration[5.0]
+  def up
+    add_column :offences_workflows, :escort_id, :uuid
+    OffencesWorkflow.all.each { |ow| d = Detainee.find_by_id(ow.detainee_id); ow.update escort_id: d.escort_id if d }
+    remove_column :offences_workflows, :detainee_id, :uuid
+    add_index :offences_workflows, :escort_id
+  end
+
+  def down
+    add_column :offences_workflows, :detainee_id, :uuid
+    OffencesWorkflow.all.each { |ow| e = Escort.find_by_id(ow.escort_id); ow.update detainee_id: e.detainee.id if e&.detainee }
+    remove_column :offences_workflows, :escort_id, :uuid
+    add_index :offences_workflows, :detainee_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170904133620) do
+ActiveRecord::Schema.define(version: 20170913110147) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -114,13 +114,13 @@ ActiveRecord::Schema.define(version: 20170904133620) do
   end
 
   create_table "offences_workflows", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "detainee_id"
     t.integer  "status",      default: 0
     t.datetime "reviewed_at"
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
     t.integer  "reviewer_id"
-    t.index ["detainee_id"], name: "index_offences_workflows_on_detainee_id", using: :btree
+    t.uuid     "escort_id"
+    t.index ["escort_id"], name: "index_offences_workflows_on_escort_id", using: :btree
   end
 
   create_table "risks", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/spec/factories/detainee_factory.rb
+++ b/spec/factories/detainee_factory.rb
@@ -19,17 +19,5 @@ FactoryGirl.define do
     trait :with_no_offences do
       offences { [] }
     end
-
-    trait :with_completed_offences do
-      association :offences_workflow, :confirmed
-    end
-
-    trait :with_incompleted_offences do
-      association :offences_workflow
-    end
-
-    trait :with_needs_review_offences do
-      association :offences_workflow, :needs_review
-    end
   end
 end

--- a/spec/factories/escort_factory.rb
+++ b/spec/factories/escort_factory.rb
@@ -23,7 +23,7 @@ FactoryGirl.define do
     end
 
     trait :with_complete_offences do
-      association :detainee, :with_completed_offences
+      association :offences_workflow, :confirmed
     end
 
     trait :with_incomplete_risk_assessment do
@@ -34,19 +34,18 @@ FactoryGirl.define do
       association :healthcare, :incomplete
     end
 
-    trait :with_incomplete_offences do
-      association :detainee, :with_incompleted_offences
-    end
-
     trait :completed do
-      association :detainee, :with_completed_offences
+      association :detainee
       association :move
       association :risk, :confirmed
       association :healthcare, :confirmed
+      association :offences_workflow, :confirmed
     end
 
     trait :needs_review do
-      association :detainee, :with_needs_review_offences
+      association :detainee
+      association :move
+      association :offences_workflow, :needs_review
       association :risk, :needs_review
       association :healthcare, :needs_review
     end

--- a/spec/factories/offences_workflow_factory.rb
+++ b/spec/factories/offences_workflow_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :workflow do
+  factory :offences_workflow do
     status :incomplete
 
     trait :confirmed do
@@ -9,8 +9,5 @@ FactoryGirl.define do
     trait :needs_review do
       status :needs_review
     end
-  end
-
-  factory :offences_workflow, parent: :workflow, class: 'OffencesWorkflow' do
   end
 end

--- a/spec/features/printing_spec.rb
+++ b/spec/features/printing_spec.rb
@@ -14,6 +14,7 @@ RSpec.feature 'printing a PER', type: :feature do
       move: move,
       risk: risk,
       healthcare: healthcare,
+      offences_workflow: offences_workflow
     )
   }
   let(:move) {
@@ -25,12 +26,13 @@ RSpec.feature 'printing a PER', type: :feature do
     )
   }
 
+  let(:offences_workflow) { create(:offences_workflow, :confirmed) }
+
   let(:offences) { [] }
 
   let(:detainee) {
     create(
       :detainee,
-      :with_completed_offences,
       prison_number: 'W1234BY',
       forenames: 'Testy',
       surname: 'McTest',

--- a/spec/models/escort_spec.rb
+++ b/spec/models/escort_spec.rb
@@ -25,9 +25,10 @@ RSpec.describe Escort do
   describe '#completed?' do
     let(:risk) { create(:risk) }
     let(:healthcare) { create(:healthcare) }
+    let(:offences_workflow) { create(:offences_workflow) }
     let(:detainee) { create(:detainee) }
     let(:move) { create(:move) }
-    let(:escort) { create(:escort, detainee: detainee, move: move, risk: risk, healthcare: healthcare) }
+    let(:escort) { create(:escort, detainee: detainee, move: move, risk: risk, healthcare: healthcare, offences_workflow: offences_workflow) }
 
     specify {
       escort = create(:escort, :completed)
@@ -55,7 +56,7 @@ RSpec.describe Escort do
     end
 
     context 'when offences info is not complete' do
-      let(:detainee) { create(:detainee, :with_incompleted_offences) }
+      let(:offences_workflow) { create(:offences_workflow) }
       specify { expect(escort).not_to be_completed }
     end
   end
@@ -206,7 +207,8 @@ RSpec.describe Escort do
     let(:detainee) { create(:detainee) }
     let(:risk) { create(:risk) }
     let(:healthcare) { create(:healthcare) }
-    let(:escort) { create(:escort, detainee: detainee, risk: risk, healthcare: healthcare) }
+    let(:offences_workflow) { create(:offences_workflow) }
+    let(:escort) { create(:escort, detainee: detainee, risk: risk, healthcare: healthcare, offences_workflow: offences_workflow) }
 
     specify { expect(escort.needs_review?).to be_falsey }
 
@@ -223,7 +225,7 @@ RSpec.describe Escort do
     end
 
     context 'when offences needs reviewing' do
-      let(:detainee) { create(:detainee, :with_needs_review_offences) }
+      let(:offences_workflow) { create(:offences_workflow, :needs_review) }
 
       specify { expect(escort.needs_review?).to be_truthy }
     end

--- a/spec/models/offences_workflow_spec.rb
+++ b/spec/models/offences_workflow_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe OffencesWorkflow, type: :model do
   it { is_expected.to be_a(Reviewable) }
 
-  it { is_expected.to belong_to(:detainee) }
+  it { is_expected.to belong_to(:escort) }
 
   subject { described_class.new }
 

--- a/spec/presenters/offences_presenter_spec.rb
+++ b/spec/presenters/offences_presenter_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe OffencesPresenter, type: :presenter do
   let(:detainee) { create(:detainee, offences: offences) }
-  subject { described_class.new(detainee.offences) }
+  let(:workflow) { create(:offences_workflow) }
+  subject { described_class.new(detainee.offences, workflow) }
 
   describe '#empty?' do
     context 'when there are no offences' do

--- a/spec/services/create_escort_spec.rb
+++ b/spec/services/create_escort_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe EscortCreator, type: :service do
   end
 
   def expect_offences_to_be_cloned(existent_escort, new_escort)
-    expect(new_escort.offences.status).to eq('needs_review')
+    expect(new_escort.offences_workflow.status).to eq('needs_review')
 
     expected_offences_attributes = existent_escort.offences.map { |o| o.attributes.except(*except_current_offences_attributes) }
     offences_attributes = new_escort.offences.map { |o| o.attributes.except(*except_current_offences_attributes) }


### PR DESCRIPTION
Before this work we had the detainee model having to deal with the offences_workflow data, which is created and modified by the user when the data is not available from the NOMIS API

This work will move the offences_workflow into the escort. 

It will also remove the need to create the offences_workflow before saving the container object (before it was the detainee, now it is the escort).