### PR TITLE
Allow to cancel PERs

### DIFF
--- a/app/assets/stylesheets/moving_people_safely/_home.scss
+++ b/app/assets/stylesheets/moving_people_safely/_home.scss
@@ -360,4 +360,5 @@
   }
 
   .issued { color: green; font-weight: bold; }
+  .cancelled { color: red; font-weight: bold; margin-right: 10px; }
 }

--- a/app/models/forms/escort.rb
+++ b/app/models/forms/escort.rb
@@ -1,0 +1,7 @@
+module Forms
+  class Escort < Forms::Base
+    property :cancelling_reason, type: String
+
+    validates :cancelling_reason, presence: true
+  end
+end

--- a/app/models/forms/search.rb
+++ b/app/models/forms/search.rb
@@ -21,7 +21,7 @@ module Forms
     end
 
     def escort
-      @escort ||= ::Escort.find_by(_at[:prison_number].matches(prison_number)) if valid?
+      @escort ||= ::Escort.uncancelled.find_by(_at[:prison_number].matches(prison_number)) if valid?
     end
 
     def detainee

--- a/app/presenters/dashboard_presenter.rb
+++ b/app/presenters/dashboard_presenter.rb
@@ -12,7 +12,7 @@ class DashboardPresenter
   end
 
   def render_detainees_indicator
-    render_indicator(:detainees, :detainees_due_to_move, escorts.count)
+    render_indicator(:detainees, :detainees_due_to_move, escorts.uncancelled.count)
   end
 
   def render_risk_indicator
@@ -59,14 +59,14 @@ class DashboardPresenter
   end
 
   def count_of_incomplete_risk
-    escorts.with_incomplete_risk.count + escorts.without_risk_assessment.count
+    escorts.uncancelled.with_incomplete_risk.count + escorts.uncancelled.without_risk_assessment.count
   end
 
   def count_of_incomplete_healthcare
-    escorts.with_incomplete_healthcare.count + escorts.without_healthcare_assessment.count
+    escorts.uncancelled.with_incomplete_healthcare.count + escorts.uncancelled.without_healthcare_assessment.count
   end
 
   def count_of_incomplete_offences
-    escorts.with_incomplete_offences.count
+    escorts.uncancelled.with_incomplete_offences.count
   end
 end

--- a/app/services/escort_creator.rb
+++ b/app/services/escort_creator.rb
@@ -35,7 +35,7 @@ class EscortCreator
   ].freeze
 
   def existent_escort
-    @existent_escort ||= Escort.find_by(prison_number: prison_number)
+    @existent_escort ||= Escort.uncancelled.find_by(prison_number: prison_number)
   end
 
   def deep_clone_escort

--- a/app/views/escorts/_actions.html.slim
+++ b/app/views/escorts/_actions.html.slim
@@ -5,5 +5,8 @@ ul.actions
   - elsif escort.completed?
     li
       = link_to_print_in_new_window(escort, styles: 'button button-print')
+  - if escort.cancellable?
+    li
+      = link_to('Cancel PER', confirm_cancel_escort_path(escort), class: 'button')
   li.link-return-home
     = link_to "Return to home", root_path

--- a/app/views/escorts/confirm_cancel.html.slim
+++ b/app/views/escorts/confirm_cancel.html.slim
@@ -1,0 +1,17 @@
+= content_for :breadcrumbs do
+  - breadcrumbs_for_page root: true do
+    - breadcrumb detainee_breadcrumb(escort.detainee), escort_path(escort)
+
+h1
+  = t('.title')
+  br
+  = "#{escort.prison_number}: #{escort.detainee_surname} #{escort.detainee_forenames}"
+
+= form_for @form, url: cancel_escort_path(escort), method: :put do |f|
+  = f.error_messages
+
+  = f.text_area_without_label :cancelling_reason
+
+  .form-actions
+    = f.submit t('.cancel_this_per'), class: 'button'
+    = link_to t('.do_not_cancel_per'), escort_path(escort), class: 'button button-secondary'

--- a/app/views/escorts/print/new.html.slim
+++ b/app/views/escorts/print/new.html.slim
@@ -1,14 +1,15 @@
 = content_for :breadcrumbs do
-  - breadcrumbs_for_page root: true
+  - breadcrumbs_for_page root: true do
+    - breadcrumb detainee_breadcrumb(@escort.detainee), escort_path(@escort)
 
 .escort.per-page
   h1
     = t('.reprint_per_for')
     br
-    = "#{@escort.prison_number}: #{@escort.detainee.surname} #{@escort.detainee.forenames}"
+    = "#{@escort.prison_number}: #{@escort.detainee_surname} #{@escort.detainee_forenames}"
 
   p.font-large
-    = @escort.move.date
+    = @escort.move_date
 
   ul.actions
     li

--- a/app/views/homepage/_escorts.html.slim
+++ b/app/views/homepage/_escorts.html.slim
@@ -2,25 +2,30 @@
   table
     thead
       tr
-        th.prison_number Prison No.
-        th.name Name
-        th.destination Destination
-        th Risk
-        th Health
-        th Offences
+        th.prison_number= t('.prison_number')
+        th.name= t('.detainee_name')
+        th.destination= t('.destination')
+        th= t('.risk')
+        th= t('.health')
+        th= t('.offences')
         th
     - escorts.each do |escort|
-      tr.move-row id="prison_number_#{escort.detainee.prison_number}"
-        td = link_to escort.detainee.prison_number, escort_path(escort)
+      tr.move-row id="prison_number_#{escort.prison_number}"
+        td = link_to_unless escort.cancelled?, escort.prison_number, escort_path(escort)
         td
           span.strong-text
-            | #{escort.detainee.surname}
+            | #{escort.detainee_surname}
           span
-            |  #{escort.detainee.forenames}
+            |  #{escort.detainee_forenames}
         td = escort.move&.to
         - if escort.issued?
           td.issued colspan=4
-            | Issued
+            = t('.issued')
+        - elsif escort.cancelled?
+          td colspan=4
+            span.cancelled
+              = t('.cancelled')
+            | By: #{escort.canceller_full_name}. #{escort.cancelling_reason}
         - else
           td.completion-status
             span class="#{escort.risk_complete? ? true : false}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -215,6 +215,8 @@ en:
         racist_details: Give details
         risk_to_females: In NOMIS, check the header section of the prisoner’s record for the Risk to Females alert. Check alert comments and case notes for details.
         risk_to_females_details: Give details
+      escort:
+        cancelling_reason: Give details of why this PER is being cancelled
       harassments:
         intimidation_html: 'In NOMIS, check the header section of the prisoner’s record for relevant alerts. Check alert comments and case notes for details and and <i>Security > Non-association</i> for known risks to named prisoners.'
         intimidation_to_staff_details: Give details, including any relevant court orders
@@ -337,6 +339,15 @@ en:
       offences_incomplete: Offences incomplete
       risk_complete: Risk complete
       risk_incomplete: Risk incomplete
+    escorts:
+      cancelled: Cancelled
+      destination: Destination
+      detainee_name: Name
+      health: Health
+      issued: Issued
+      offences: Offences
+      prison_number: Prison No.
+      risk: Risk
   summary: &summary
     alerts:
       last_updated_info: 'This information was last saved %{time_difference} ago.'
@@ -510,6 +521,10 @@ en:
         not_for_release: Not for release
         rule_45: Rule 45
   escorts:
+    confirm_cancel:
+      title: Cancelling PER for
+      cancel_this_per: Cancel this PER
+      do_not_cancel_per: Do not cancel this PER
     print:
       new:
         reprint_per_for: Reprint PER for

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
   get :ping, to: 'ping#show'
 
   resources :escorts, only: %i[new create show] do
+    get :confirm_cancel, on: :member
+    put :cancel, on: :member
     resource :detainee do
       resource :image, only: %i[show], controller: 'detainees/images', constraints: { format: 'jpg' }
     end

--- a/db/migrate/20170629152622_add_canceller_to_escort.rb
+++ b/db/migrate/20170629152622_add_canceller_to_escort.rb
@@ -1,0 +1,7 @@
+class AddCancellerToEscort < ActiveRecord::Migration[5.0]
+  def change
+    add_column :escorts, :canceller_id, :integer
+    add_column :escorts, :cancelled_at, :datetime
+    add_column :escorts, :cancelling_reason, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170622120222) do
+ActiveRecord::Schema.define(version: 20170629152622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,9 @@ ActiveRecord::Schema.define(version: 20170622120222) do
     t.string   "document_content_type"
     t.integer  "document_file_size"
     t.datetime "document_updated_at"
+    t.integer  "canceller_id"
+    t.datetime "cancelled_at"
+    t.text     "cancelling_reason"
     t.index ["cloned_id"], name: "index_escorts_on_cloned_id", using: :btree
     t.index ["deleted_at"], name: "index_escorts_on_deleted_at", using: :btree
     t.index ["prison_number"], name: "index_escorts_on_prison_number", using: :btree

--- a/spec/factories/escort_factory.rb
+++ b/spec/factories/escort_factory.rb
@@ -53,8 +53,13 @@ FactoryGirl.define do
 
     trait :issued do
       completed
-      issued_at 1.day.ago
+      issued_at 1.day.ago.utc
       document { File.new("#{Rails.root}/spec/support/fixtures/pdf-per-document.pdf") }
+    end
+
+    trait :cancelled do
+      completed
+      cancelled_at 1.day.ago.utc
     end
   end
 end

--- a/spec/features/cancelling_a_per_spec.rb
+++ b/spec/features/cancelling_a_per_spec.rb
@@ -1,0 +1,22 @@
+require 'feature_helper'
+
+RSpec.feature 'cancelling a PER', type: :feature do
+  scenario 'Cancelling a non issued PER' do
+    escort = create(:escort, :completed)
+
+    login
+
+    dashboard.assert_escorts_due(1)
+    dashboard.assert_total_detainees_due_to_move_gauge(1)
+
+    visit escort_path(escort)
+
+    escort_page.click_cancel
+
+    fill_in 'escort[cancelling_reason]', with: 'Started by mistake'
+    click_button 'Cancel this PER'
+
+    dashboard.assert_escorts_due(1)
+    dashboard.assert_total_detainees_due_to_move_gauge(0)
+  end
+end

--- a/spec/features/pages/escort.rb
+++ b/spec/features/pages/escort.rb
@@ -151,6 +151,10 @@ module Page
       click_link 'Reprint'
     end
 
+    def click_cancel
+      click_link 'Cancel PER'
+    end
+
     def confirm_healthcare_action_link(name)
       confirm_per_section_action_link(:healthcare, name)
     end

--- a/spec/forms/escort_spec.rb
+++ b/spec/forms/escort_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Forms::Escort, type: :form do
+  let(:model) { Escort.new }
+  subject(:form) { described_class.new(model) }
+
+  it { is_expected.to validate_presence_of(:cancelling_reason) }
+end

--- a/spec/forms/search_spec.rb
+++ b/spec/forms/search_spec.rb
@@ -44,6 +44,17 @@ RSpec.describe Forms::Search, type: :form do
         end
       end
 
+      context 'when an escort has been cancelled for a given prison number' do
+        let(:prison_number) { 'A1234BC' }
+        let(:detainee) { create(:detainee, prison_number: prison_number) }
+        let!(:escort) { create(:escort, :cancelled, prison_number: prison_number, detainee: detainee) }
+
+        it 'returns nothing' do
+          subject.validate(prison_number: 'A1234BC')
+          expect(subject.detainee).to be_nil
+        end
+      end
+
       context 'when the provided prison name is in a different format than the one recorded for the detainee' do
         let(:prison_number) { 'A1234BC' }
         let(:detainee) { create(:detainee, prison_number: prison_number) }

--- a/spec/requests/escort_cancel_request_spec.rb
+++ b/spec/requests/escort_cancel_request_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe 'PER page requests', type: :request do
+  let(:prison_number) { 'A45345HG' }
+  let(:escort) { create(:escort, prison_number: prison_number) }
+  let(:params) { { escort: { cancelling_reason: 'initiated by mistake' } } }
+
+  describe "#cancel" do
+    context 'when user is not authorized' do
+      it 'redirects user to login page' do
+        get "/escorts/#{escort.id}"
+        expect(response).to have_http_status(302)
+        expect(response).to redirect_to new_session_path
+      end
+    end
+
+    context 'when user is authorized' do
+      before { sign_in(create(:user)) }
+
+      context 'when the escort for the provided id does not exist' do
+        it 'raises a record not found error' do
+          expect {
+            put "/escorts/#{SecureRandom.uuid}/cancel", params: params
+          }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      context "when the escort has already been cancelled" do
+        let(:escort) { create(:escort, :cancelled, prison_number: prison_number) }
+
+        it 'redirects to the escort page' do
+          put "/escorts/#{escort.id}/cancel", params: params
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to escort_path(escort)
+        end
+      end
+
+      context "when the escort has already been issued" do
+        let(:escort) { create(:escort, :issued, prison_number: prison_number) }
+
+        it 'redirects to the escort page' do
+          put "/escorts/#{escort.id}/cancel", params: params
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to escort_path(escort)
+        end
+      end
+
+      context "with a valid escort ID" do
+        it "redirects to the dashboard page" do
+          put "/escorts/#{escort.id}/cancel", params: params
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to root_path
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/MkXUijC8/26-3-as-someone-adding-and-or-completing-a-per-i-want-to-be-able-to-cancel-an-unisssed-move-and-remove-any-associated-data-from-the)

This work will allow users to cancel PERs that have been initiated by my stake

In this work we also delegate methods from escort to associated models in order to comply with Law of Demeter.