### PR TITLE
Fixes a known issue related with to_ary delegation

### DIFF
--- a/app/models/forms/assessments/answer.rb
+++ b/app/models/forms/assessments/answer.rb
@@ -75,6 +75,10 @@ module Forms
 
       attr_reader :assessment, :question, :parent, :validators, :params
 
+      def to_ary
+        nil
+      end
+
       def answer_schema
         question.answer_for(value)
       end

--- a/app/models/forms/assessments/section.rb
+++ b/app/models/forms/assessments/section.rb
@@ -63,6 +63,10 @@ module Forms
       attr_reader :assessment, :section, :parent
       delegate :read_attribute_for_validation, to: :__getobj__
 
+      def to_ary
+        nil
+      end
+
       def valid_subsections?
         subsections.inject(true) do |valid, subsection|
           (subsection.valid? && valid).tap do


### PR DESCRIPTION
When the method `to_ary` was called on the assessment forms was being delegated to the the Delegated class but producing a warning that the delegation was being done on a private method.