### PR TITLE
This fixes a minor migration deprecation warning

### DIFF
--- a/db/migrate/20170622120222_add_attachment_file_to_escorts.rb
+++ b/db/migrate/20170622120222_add_attachment_file_to_escorts.rb
@@ -1,4 +1,4 @@
-class AddAttachmentFileToEscorts < ActiveRecord::Migration
+class AddAttachmentFileToEscorts < ActiveRecord::Migration[5.0]
   def self.up
     change_table :escorts do |t|
       t.attachment :document


### PR DESCRIPTION
In the new versions of Rails when a new migration is created the version
of the Rails version that is being used at the time is attached to the
migration. The generator used by the paperclip gem is still not using
that approach which causes the app to show a deprecation warning.