### PR TITLE
Fix display of about section message.

### DIFF
--- a/app/views/escorts/print/cover.html.slim
+++ b/app/views/escorts/print/cover.html.slim
@@ -87,6 +87,4 @@ html
         tr
           td.panel
             .feedback-text
-              | This PER was produced by the the Moving People Safely digital PER service, currently being piloted
-              | at HMP Bedford. If you have feedback or questions about the service, contact the Moving People Safely
-              | team at: moving-people-safely@digital.justice.gov.uk
+              | This PER was produced by the the Moving People Safely digital PER service, currently being piloted at HMP Bedford. If you have feedback or questions about the service, contact the Moving People Safely team at: moving-people-safely@digital.justice.gov.uk

--- a/spec/support/fixtures/pdf-text-all-no-answers.txt
+++ b/spec/support/fixtures/pdf-text-all-no-answers.txt
@@ -32,9 +32,9 @@ Date of travel                     From                                 To
 
 About this Person Escort Record
 
-   This PER was produced by the the Moving People Safely digital PER service, currently being pilotedat HMP
-   Bedford. If you have feedback or questions about the service, contact the Moving People Safelyteam at:
-   moving-people-safely@digital.justice.gov.uk
+   This PER was produced by the the Moving People Safely digital PER service, currently being piloted at
+   HMP Bedford. If you have feedback or questions about the service, contact the Moving People Safely team
+   at: moving-people-safely@digital.justice.gov.uk
 W1234BY: McTest Testy                                                                         Page 1 of 1
 
  NOT FOR RELEASE               NO        ACCT     NO                          RULE 45    NO

--- a/spec/support/fixtures/pdf-text-all-yes-answers.txt
+++ b/spec/support/fixtures/pdf-text-all-yes-answers.txt
@@ -33,9 +33,9 @@ Date of travel                      From                               To
 
 About this Person Escort Record
 
-   This PER was produced by the the Moving People Safely digital PER service, currently being pilotedat HMP
-   Bedford. If you have feedback or questions about the service, contact the Moving People Safelyteam at:
-   moving-people-safely@digital.justice.gov.uk
+   This PER was produced by the the Moving People Safely digital PER service, currently being piloted at
+   HMP Bedford. If you have feedback or questions about the service, contact the Moving People Safely team
+   at: moving-people-safely@digital.justice.gov.uk
 W1234BY: McTest Testy                                                                                Page 1 of 3
 
  NOT FOR RELEASE             NO         ACCT                                    RULE 45


### PR DESCRIPTION
https://trello.com/c/yiNMsB7J/251-bug-about-this-per-wording-display

The existent display of the about wording was overlaying the text.