### PR TITLE
Fix Cross-site scripting issues reported in the pen test

### DIFF
--- a/app/presenters/offences_presenter.rb
+++ b/app/presenters/offences_presenter.rb
@@ -7,8 +7,10 @@ class OffencesPresenter < SimpleDelegator
   delegate :empty?, :any?, :each, :present?, to: :@offences
 
   class CurrentOffencePresenter < SimpleDelegator
+    include ActionView::Helpers::SanitizeHelper
+
     def full_details
-      info = offence
+      info = sanitize(offence)
       info << " (CR: #{case_reference})" if case_reference.present?
       info
     end

--- a/app/presenters/presenter_helpers.rb
+++ b/app/presenters/presenter_helpers.rb
@@ -1,7 +1,12 @@
 require 'time_diff'
 module PresenterHelpers
+  include ActionView::Helpers::SanitizeHelper
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::TranslationHelper
+
+  def self.included(base)
+    base.extend(ActionView::Helpers::SanitizeHelper::ClassMethods)
+  end
 
   def highlighted_content(content)
     content_tag(:div, content, class: 'strong-text')

--- a/app/presenters/summary/assessment_question_presenter.rb
+++ b/app/presenters/summary/assessment_question_presenter.rb
@@ -72,7 +72,7 @@ module Summary
     end
 
     def answer_value(value)
-      default_value = value.respond_to?(:humanize) ? value.humanize : value
+      default_value = value.respond_to?(:humanize) ? sanitize(value.humanize) : value
       t(value, scope: [:summary, :section, :answers, section_name], default: default_value)
     end
 


### PR DESCRIPTION
- **XSS**

  Most of the issues reported have to do with the fact that, normally, the
rails views sanitize the fields by default, but in these cases the
values were set in presenters where none of them were being sanitized.

  This might required a more broader look at the use of presenters to
ensure any value that requires sanitize does get sanitized.