### PR TITLE
Add banner for current phase of the project

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,6 +25,7 @@
 @import "elements/panels";
 @import "elements/tables";
 @import "elements/breadcrumbs";
+@import "elements/phase-banner";
 
 // Application
 @import "variables";
@@ -42,3 +43,4 @@
 @import "moving_people_safely/errors";
 @import "moving_people_safely/images";
 @import "moving_people_safely/login";
+@import "moving_people_safely/phase_banner";

--- a/app/assets/stylesheets/moving_people_safely/_phase_banner.scss
+++ b/app/assets/stylesheets/moving_people_safely/_phase_banner.scss
@@ -1,0 +1,3 @@
+.alpha-banner  {
+  @include phase-banner(alpha);
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,8 @@
 module ApplicationHelper
+  def current_phase
+    Rails.application.config.phase
+  end
+
   def flash_message_for(messages)
     return messages unless messages.is_a?(Array)
     content_tag(:ul) do

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -31,6 +31,12 @@
   main id="wrapper" role="main"
     .container
       section class="content inner cf" id="content" role="main"
+        .phase-banner class=("#{current_phase}-banner")
+          .phase-banner-inner
+            p
+              strong.phase-tag = current_phase.upcase
+              span = t('.current_phase_text')
+
         = render_breadcrumbs
         - %i[notice success alert warning error].each do |severity|
             - if flash[severity].present?

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ module MovingPeopleSafely
     # -- all .rb files in that directory are automatically loaded.
     config.app_title = 'Moving people safely'
     config.proposition_title = 'Moving people safely'
-    config.phase = 'beta'
+    config.phase = 'alpha'
     config.product_type = 'service'
     config.feedback_url = ''
     config.assets.paths << Rails.root.join('vendor', 'bower')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -700,3 +700,6 @@ en:
   activemodel:
     errors:
       <<: *errors
+  layouts:
+    application:
+      current_phase_text: This is a new service


### PR DESCRIPTION
This changes make the default phase banner to be displayed in the application as per the MOJ/GOV standards.

At the moment, there's no link to a support form (which is also something that is present by default).