### PR TITLE
Multiples display improvements

### DIFF
--- a/app/assets/javascripts/multiples.js
+++ b/app/assets/javascripts/multiples.js
@@ -16,7 +16,15 @@ $(function () {
 
       // Hide multiple from when 'delete' radio state changes
       input.on('change', function () {
-        $this.closest('.multiple-wrapper').addClass('mps-hide');
+        var multipleWrapper = $this.closest('.multiple-wrapper');
+        var multiplesParent = multipleWrapper.parent();
+        multipleWrapper.addClass('mps-hide');
+        var removeLinks = multiplesParent.find('.multiple-wrapper:not(.mps-hide) .remove-link');
+        if(removeLinks.length == 1){
+          removeLinks.each(function(){
+            $(this).hide();
+          });
+        }
       })
     })
   };

--- a/app/assets/stylesheets/moving_people_safely/_forms.scss
+++ b/app/assets/stylesheets/moving_people_safely/_forms.scss
@@ -13,6 +13,13 @@ form {
     .panel > .form-group > .form-hint { padding-top: 0; }
   }
 
+  h2 {
+    @extend .heading-medium;
+    margin-bottom: .25em;
+    margin-top: 1.875em;
+    font-size: 24px;
+  }
+
   legend {
     font-weight: bold;
   }
@@ -48,6 +55,7 @@ form {
     float: left;
     clear: left;
     width: 100%;
+    padding-top: 30px;
 
     .remove-link {
       label {
@@ -132,6 +140,8 @@ form {
   }
 
   .multiple-add {
+    padding-top: 30px;
+
     input {
       @extend .styled-as-link;
     }
@@ -148,5 +158,31 @@ form {
 
     h2 { font-weight: bold; }
     p { margin: 0; }
+  }
+
+  .button-add-another-vertical,
+  .button-add-another {
+    background-color: #eee;
+    color: #000;
+    box-shadow: 0 2px 0 #666;
+  }
+
+  .button-add-another-vertical:hover,
+  .button-add-another:hover {
+    background-color: #ccc;
+    color: #000;
+    box-shadow: 0 2px 0 #666;
+  }
+
+  .button-add-another-vertical:focus,
+  .button-add-another:focus {
+    background-color: #ccc;
+    color: #000;
+    box-shadow: 0 2px 0 #666;
+  }
+
+  .remove-list-item-vertical {
+    margin-top: 4.4em !important;
+    display: block;
   }
 }

--- a/app/form_builders/mps_form_builder.rb
+++ b/app/form_builders/mps_form_builder.rb
@@ -28,12 +28,13 @@ class MpsFormBuilder < GovukElementsFormBuilder::FormBuilder
 
   def fieldset_legend(attribute, options = {})
     tags = []
+    legend_options = options.fetch(:legend_options, {})
     legend = content_tag(:legend) do
       if options.fetch(:legend, true)
         tags << content_tag(
           :span,
           fieldset_text(attribute),
-          class: 'form-label-bold'
+          class: legend_options.fetch(:class, 'form-label-bold')
         )
       end
 

--- a/app/form_builders/mps_form_builder.rb
+++ b/app/form_builders/mps_form_builder.rb
@@ -1,4 +1,12 @@
 class MpsFormBuilder < GovukElementsFormBuilder::FormBuilder
+  class << GovukElementsFormBuilder::FormBuilder
+    def localized(scope, attribute, default, object_name)
+      @object_name = object_name.gsub(/\[(.*)_attributes\]\[\d+\]/, '.\1')
+      key = "#{@object_name}.#{attribute}"
+      translate(key, default, scope)
+    end
+  end
+
   def error_messages(options = {})
     title = options.fetch(:title, I18n.t('.errors.summary.title'))
     description = options.fetch(:description, '')

--- a/app/models/forms/assessments/complex_answer.rb
+++ b/app/models/forms/assessments/complex_answer.rb
@@ -13,6 +13,7 @@ module Forms
         @parent = options[:parent]
         @answer = answer || dummy_answer
         super(@answer)
+        define_complex_attr_methods
       end
 
       def complex_attributes
@@ -37,6 +38,13 @@ module Forms
           subquestion.validators.each do |validator|
             validator.call(self, subquestion.name, in: subquestion.answer_options_values)
           end
+        end
+      end
+
+      def define_complex_attr_methods
+        complex_attributes.each do |attr|
+          attr_name = attr.name.to_sym
+          define_singleton_method(attr_name) { __getobj__.send(attr_name) }
         end
       end
     end

--- a/app/views/shared/_fields_for.html.slim
+++ b/app/views/shared/_fields_for.html.slim
@@ -15,9 +15,10 @@ div
               - if subquestion.answer_options_values.empty?
                 = mf.text_field subquestion.name.to_sym
               - else
-                .form-group
-                  = mf.label subquestion.name.to_sym, class: 'form-label'
-                  = mf.select subquestion.name.to_sym, select_values_for("#{f.object.name}.#{question.name}.#{subquestion.name}"), include_blank: true
+                = mf.radio_button_fieldset subquestion.name.to_sym,
+                  choices: subquestion.answer_options_values,
+                  legend_options: { class: 'form-label' },
+                  inline: true
         .column-one-third
           - if question.complex_answers.size > 1
             .multiple-field.remove-link

--- a/app/views/shared/_fields_for.html.slim
+++ b/app/views/shared/_fields_for.html.slim
@@ -4,30 +4,30 @@ div
 
   = f.fields_for question.name, question.complex_answers do |mf|
     .multiple-wrapper
-      - unless mf.index == 0
-        hr
-
       .grid-row
         .column-two-thirds
-          = mf.hidden_field :id
-          - mf.object.complex_attributes.each do |subquestion|
-            .multiple-field
-              - if subquestion.answer_options_values.empty?
-                = mf.text_field subquestion.name.to_sym
-              - else
-                = mf.radio_button_fieldset subquestion.name.to_sym,
-                  choices: subquestion.answer_options_values,
-                  legend_options: { class: 'form-label' },
-                  inline: true
+          .form-group-compound
+            h2 = "Item #{mf.index + 1}"
+            = mf.hidden_field :id
+            - mf.object.complex_attributes.each do |subquestion|
+              .multiple-field
+                - if subquestion.answer_options_values.empty?
+                  = mf.text_field subquestion.name.to_sym
+                - else
+                  = mf.radio_button_fieldset subquestion.name.to_sym,
+                    choices: subquestion.answer_options_values,
+                    legend_options: { class: 'form-label' },
+                    inline: true
         .column-one-third
           - if question.complex_answers.size > 1
-            .multiple-field.remove-link
+            .remove-link.remove-list-item-vertical
               .form-group
                 = mf.label :_delete, 'Remove'
                 = mf.check_box :_delete
+      hr
 
-  .multiple-field.multiple-add
-    = f.submit t("helpers.label.#{f.object.name}.actions.#{question.name}.add_multiple"),
-      class: 'js-anchor-focus',
+  .multiple-field.multiple-add.form-group
+    = f.button t("helpers.label.#{f.object.name}.actions.#{question.name}.add_multiple"),
+      class: 'js-anchor-focus button button-add-another-vertical',
       data: { 'anchor-focus' => question.name },
       name: "#{f.object.name}_add_multiple_#{question.name}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,10 @@ en:
         mental_illness: Are there any mental health issues that may affect this journey?
       needs:
         has_medications: Will they need to be given medication during this journey?
+        medications:
+          description: Medicine
+          administration: How is it given?
+          carrier: Who will carry the medicine?
       other_risk:
         other_risk: Is there any other information related to risk on this journey you would like to include?
       physical:

--- a/spec/features/managing_healthcare_medications_spec.rb
+++ b/spec/features/managing_healthcare_medications_spec.rb
@@ -40,7 +40,9 @@ RSpec.describe 'managing healthcare medications', type: :feature do
       within_medication(position) do
         expect(find_field('Medicine').value).to eq text_for(:description, position)
         expect(find_field('How is it given').value).to eq text_for(:administration, position)
-        expect(has_select?('Who will carry the medicine?', selected: 'Escort')).to be true
+        within_fieldset('Who will carry the medicine?') do
+          expect(find(:radio_button, checked: true).value).to eq('escort')
+        end
       end
     end
   end
@@ -73,7 +75,9 @@ RSpec.describe 'managing healthcare medications', type: :feature do
     within_medication(position) do
       fill_in 'Medicine', with: text_for(:description, position)
       fill_in 'How is it given', with: text_for(:administration, position)
-      select 'Escort', from: 'Who will carry the medicine?'
+      within_fieldset('Who will carry the medicine?') do
+        choose 'Escort'
+      end
     end
   end
 

--- a/spec/features/pages/healthcare.rb
+++ b/spec/features/pages/healthcare.rb
@@ -70,7 +70,9 @@ module Page
       within(el) do
         fill_in 'Medicine', with: med.description
         fill_in 'How is it given', with: med.administration
-        select med.carrier.titlecase, from: 'Who will carry the medicine?'
+        within_fieldset('Who will carry the medicine?') do
+          choose med.carrier.titlecase
+        end
       end
     end
 


### PR DESCRIPTION
Trello: https://trello.com/c/xJnE5Hq6/107-3-redesign-multiples-interaction

* Adds support for localised error messages for nested fields
* CSS changes to bring the display of the multiples section in line with the [DWP](https://dwp-patterns.herokuapp.com/additemstoalist)
* Ensure the remove link is not shown when only one item is left on the multiples section