### PR TITLE
Change headers in complex attributes

### DIFF
--- a/app/views/shared/_fields_for.html.slim
+++ b/app/views/shared/_fields_for.html.slim
@@ -7,7 +7,7 @@ div
       .grid-row
         .column-two-thirds
           .form-group-compound
-            h2 = "Item #{mf.index + 1}"
+            h2= t("helpers.complex_attributes.#{f.object.name}")
             = mf.hidden_field :id
             - mf.object.complex_attributes.each do |subquestion|
               .multiple-field

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,8 @@
 en:
   helpers:
+    complex_attributes:
+      needs: Medication
+      return_instructions: Establishment
     fieldset:
       default_title: 'Select all that apply:'
       allergies:
@@ -32,7 +35,7 @@ en:
       needs:
         has_medications: Will they need to be given medication during this journey?
         medications:
-          description: Medicine
+          description: Medicine name
           administration: How is it given?
           carrier: Who will carry the medicine?
       other_risk:
@@ -149,7 +152,7 @@ en:
             add_multiple: Add another medicine
         has_medications: "Will they need to be given medication during this journey?"
         medications:
-          description: Medicine
+          description: Medicine name
           administration: How is it given?
           carrier: Who will carry the medicine?
           carrier_choices:


### PR DESCRIPTION
[Trello](https://trello.com/c/6q2TxtcV/308-2-multiples-unit-titling)

This change will remove the index, and use a specific title for the complex attribute, instead of the generic word 'Item'