### PR TITLE
Authorise users to access relevant escorts

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,9 +21,16 @@ class ApplicationController < ActionController::Base
     redirect_to new_session_path unless sso_identity
   end
 
-  def authorize_user!
+  def authorize_user_to_access_prisoner!
     unless AuthorizeUserToAccessPrisoner.call(current_user, prison_number)
       flash[:error] = t('alerts.detainee.access.unauthorized', prison_number: prison_number)
+      redirect_to(root_path)
+    end
+  end
+
+  def authorize_user_to_access_escort!
+    unless AuthorizeUserToAccessEscort.call(current_user, escort)
+      flash[:error] = t('alerts.detainee.access.unauthorized', prison_number: escort.prison_number)
       redirect_to(root_path)
     end
   end

--- a/app/controllers/escorts_controller.rb
+++ b/app/controllers/escorts_controller.rb
@@ -1,6 +1,7 @@
 class EscortsController < ApplicationController
   helper_method :escort
-  before_action :authorize_user!, only: :create
+  before_action :authorize_user_to_access_prisoner!, only: :create
+  before_action :authorize_user_to_access_escort!, except: :create
   before_action :redirect_if_missing_data, only: :show
   before_action :redirect_if_not_cancellable, only: [:confirm_cancel, :cancel]
 

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -1,9 +1,9 @@
 class HomepageController < ApplicationController
   before_action :validate_search, only: :show
-  before_action :authorize_user!, only: :show, if: :valid_search?
+  before_action :authorize_user_to_access_prisoner!, only: :show, if: :valid_search?
 
   def show
-    @escorts = Escort.for_date(date_picker.date)
+    @escorts = Escort.for_date(date_picker.date).for_user(current_user)
     render :show, locals: locals
   end
 

--- a/app/controllers/moves_controller.rb
+++ b/app/controllers/moves_controller.rb
@@ -1,7 +1,7 @@
 class MovesController < ApplicationController
   before_action :redirect_unless_document_editable
   before_action :redirect_if_move_already_exists, only: %i[new create]
-  helper_method :escort, :move
+  helper_method :escort, :from_establishment
 
   def new
     form = Forms::Move.new(escort.build_move)
@@ -13,6 +13,7 @@ class MovesController < ApplicationController
 
     if form.validate(params[:move])
       form.save
+      set_establishment
       redirect_to escort_path(escort)
     else
       render :new, locals: { form: form }
@@ -43,6 +44,20 @@ class MovesController < ApplicationController
 
   def move
     escort.move || raise(ActiveRecord::RecordNotFound)
+  end
+
+  def set_establishment
+    move.update from_establishment: user_or_prisoner_establishment
+  end
+
+  def from_establishment
+    move.from_establishment || user_or_prisoner_establishment
+  end
+
+  def user_or_prisoner_establishment
+    return current_user.authorized_establishments.first if current_user.authorized_establishments.one?
+    response = Detainees::LocationFetcher.new(escort.prison_number).call
+    Establishment.find_by!(nomis_id: response.to_h[:code])
   end
 
   def redirect_if_move_already_exists

--- a/app/models/escort.rb
+++ b/app/models/escort.rb
@@ -16,6 +16,9 @@ class Escort < ApplicationRecord
   validates_attachment_content_type :document, content_type: ['application/pdf']
 
   scope :for_date, ->(date) { eager_load(:move).where(moves: { date: date }) }
+  scope :for_user, lambda { |user|
+    joins(:move).where('moves.from_establishment_id IN (?)', user.authorized_establishments) unless user.is_admin?
+  }
   scope :with_incomplete_risk, -> { joins(:risk).merge(Risk.not_confirmed) }
   scope :with_incomplete_healthcare, -> { joins(:healthcare).merge(Healthcare.not_confirmed) }
   scope :without_risk_assessment, -> { includes(:risk).where(risks: { escort_id: nil }) }

--- a/app/models/forms/move.rb
+++ b/app/models/forms/move.rb
@@ -4,7 +4,6 @@ module Forms
     NOT_FOR_RELEASE_REASONS = %w[serving_sentence further_charges licence_revoke
                                  held_for_immigration other].freeze
 
-    property :from, type: StrictString, default: 'HMP Bedford', validates: { presence: true }
     property :to,   type: StrictString, validates: { presence: true }
     property :date, type: TextDate
 

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -1,3 +1,4 @@
 class Move < ApplicationRecord
   belongs_to :escort
+  belongs_to :from_establishment, class_name: 'Establishment'
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  ADMIN_ORGANISATION = 'digital.noms.moj'.freeze
+
   serialize :permissions
 
   class << self
@@ -32,5 +34,16 @@ class User < ApplicationRecord
 
   def full_name
     "#{first_name} #{last_name}".strip
+  end
+
+  def authorized_establishments
+    permissions.each_with_object([]) do |permission, locations|
+      location = Establishment.find_by(sso_id: permission['organisation'])
+      locations << location if location
+    end
+  end
+
+  def is_admin?
+    permissions.any? { |permission| permission['organisation'] == ADMIN_ORGANISATION }
   end
 end

--- a/app/presenters/move_presenter.rb
+++ b/app/presenters/move_presenter.rb
@@ -4,4 +4,8 @@ class MovePresenter < SimpleDelegator
   def humanized_date
     date && date.to_s(:humanized)
   end
+
+  def from
+    from_establishment&.name
+  end
 end

--- a/app/presenters/print/move_presenter.rb
+++ b/app/presenters/print/move_presenter.rb
@@ -6,6 +6,10 @@ module Print
       model.date.to_s(:humanized)
     end
 
+    def from
+      model.from_establishment&.name
+    end
+
     private
 
     def model

--- a/app/services/authorize_user_to_access_escort.rb
+++ b/app/services/authorize_user_to_access_escort.rb
@@ -1,0 +1,19 @@
+class AuthorizeUserToAccessEscort
+  def self.call(user, escort)
+    new(user, escort).call
+  end
+
+  def initialize(user, escort)
+    @user = user
+    @escort = escort
+  end
+
+  def call
+    return true if user.is_admin?
+    user.authorized_establishments.any? { |e| e.sso_id == escort.move&.from_establishment&.sso_id }
+  end
+
+  private
+
+  attr_reader :user, :escort
+end

--- a/app/services/authorize_user_to_access_prisoner.rb
+++ b/app/services/authorize_user_to_access_prisoner.rb
@@ -1,6 +1,4 @@
 class AuthorizeUserToAccessPrisoner
-  ADMIN_ORGANISATION = 'digital.noms.moj'.freeze
-
   def self.call(user, prison_number)
     new(user, prison_number).call
   end
@@ -11,8 +9,8 @@ class AuthorizeUserToAccessPrisoner
   end
 
   def call
-    return true if user_is_admin?
-    user_authorized_locations.include?(prisoner_location)
+    return true if user.is_admin?
+    user.authorized_establishments.include?(prisoner_location)
   end
 
   private
@@ -22,16 +20,5 @@ class AuthorizeUserToAccessPrisoner
   def prisoner_location
     response = Detainees::LocationFetcher.new(prison_number).call
     Establishment.find_by(nomis_id: response.to_h[:code])
-  end
-
-  def user_authorized_locations
-    user.permissions.each_with_object([]) do |permission, locations|
-      location = Establishment.find_by(sso_id: permission['organisation'])
-      locations << location if location
-    end
-  end
-
-  def user_is_admin?
-    user.permissions.any? { |permission| permission['organisation'] == ADMIN_ORGANISATION }
   end
 end

--- a/app/views/moves/_form.html.slim
+++ b/app/views/moves/_form.html.slim
@@ -5,7 +5,9 @@
   = form_for form, url: submit_path, method: method do |f|
     = f.error_messages
 
-    = f.text_field :from
+    .form-group
+      label.form-label From
+      = from_establishment&.name
     = f.text_field :to
     = f.date_picker_text_field :date
     = render partial: 'shared/radio_date_picker', locals: { picker: RadioDatePickerPresenter.new('move[date]', form.date) }

--- a/db/migrate/20170802160521_add_establishment_to_moves.rb
+++ b/db/migrate/20170802160521_add_establishment_to_moves.rb
@@ -1,0 +1,8 @@
+class AddEstablishmentToMoves < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :moves, :from, :string
+    add_column :moves, :from_establishment_id, :uuid
+    bedford = Establishment.where(name: 'HMP/YOI Bedford').first
+    Move.update_all(from_establishment_id: bedford.id) if bedford
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170721132806) do
+ActiveRecord::Schema.define(version: 20170802160521) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,7 +90,6 @@ ActiveRecord::Schema.define(version: 20170721132806) do
   end
 
   create_table "moves", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "from"
     t.string   "to"
     t.date     "date"
     t.datetime "created_at",                     null: false
@@ -99,6 +98,7 @@ ActiveRecord::Schema.define(version: 20170721132806) do
     t.string   "not_for_release_reason"
     t.text     "not_for_release_reason_details"
     t.uuid     "escort_id"
+    t.uuid     "from_establishment_id"
     t.index ["escort_id"], name: "index_moves_on_escort_id", using: :btree
   end
 

--- a/spec/factories/move_factory.rb
+++ b/spec/factories/move_factory.rb
@@ -2,7 +2,7 @@ require_relative '../support/fixture_data'
 
 FactoryGirl.define do
   factory :move do
-    from { FixtureData.prison }
+    association :from_establishment, factory: :prison
     to { FixtureData.county_court }
     date { Time.current.to_date }
     not_for_release 'no'

--- a/spec/features/detainees_due_to_move_spec.rb
+++ b/spec/features/detainees_due_to_move_spec.rb
@@ -36,5 +36,31 @@ RSpec.feature 'detainees due to move', type: :feature do
       dashboard.assert_incomplete_gauge(:offences, 2)
       dashboard.assert_escorts_due(5)
     end
+
+    scenario 'shows escorts scoped in the establishment of the user' do
+      bedford_sso_id = 'bedford.prisons.noms.moj'
+      bedford_nomis_id = 'BDI'
+      bedford = create(:prison, name: 'HMP Bedford', sso_id: bedford_sso_id, nomis_id: bedford_nomis_id)
+
+      brixton_sso_id = 'brixton.prisons.noms.moj'
+      brixton_nomis_id = 'BXI'
+      brixton = create(:prison, name: 'HMP Brixton', sso_id: brixton_sso_id, nomis_id: brixton_nomis_id)
+
+      move = create(:move, date: '11/08/2016', from_establishment: bedford)
+      create(:escort, :completed, move: move)
+
+      move = create(:move, date: '11/08/2016', from_establishment: bedford)
+      create(:escort, :completed, move: move)
+
+      move = create(:move, date: '11/08/2016', from_establishment: brixton)
+      create(:escort, :completed, move: move)
+
+      login_options = { sso: { info: { permissions: [{'organisation' => bedford_sso_id}]}} }
+
+      login(nil, login_options)
+
+      dashboard.search_escorts_due_on('11/08/2016')
+      dashboard.assert_escorts_due(2)
+    end
   end
 end

--- a/spec/features/pages/escort.rb
+++ b/spec/features/pages/escort.rb
@@ -31,7 +31,7 @@ module Page
 
     def confirm_move_info(move, options = {})
       within('.move-information') do
-        expect(page).to have_content move.from
+        expect(page).to have_content move.from_establishment.name
         expect(page).to have_content move.to
         expect(page).to have_content move.date.strftime('%d %b %Y')
       end

--- a/spec/features/pages/move_details.rb
+++ b/spec/features/pages/move_details.rb
@@ -1,7 +1,6 @@
 module Page
   class MoveDetails < Base
     def complete_form(move, options = {})
-      fill_in 'From', with: move.from
       fill_in 'To', with: move.to
       fill_in 'Date', with: move.date
       fill_in_not_for_release_details(move)

--- a/spec/features/per_show_page_spec.rb
+++ b/spec/features/per_show_page_spec.rb
@@ -269,29 +269,25 @@ RSpec.feature 'PER show page', type: :feature do
   end
 
   context 'move information' do
-    let(:detainee) { create(:detainee) }
-    let(:move) { create(:move) }
-    let(:escort) { create(:escort, detainee: detainee, move: move) }
-
     context 'issued PER' do
-      let(:escort) { create(:escort, :issued, detainee: detainee, move: move) }
+      let(:escort) { create(:escort, :issued) }
 
       scenario 'displays all the mandatory move information' do
         login
 
         visit escort_path(escort)
-        escort_page.confirm_move_info(move)
+        escort_page.confirm_move_info(escort.move)
       end
     end
 
     context 'unissued PER' do
-      let(:move) { create(:move) }
+      let(:escort) { create(:escort, :completed) }
 
       scenario 'displays all the mandatory move information' do
         login
 
         visit escort_path(escort)
-        escort_page.confirm_move_info(move)
+        escort_page.confirm_move_info(escort.move)
       end
     end
   end

--- a/spec/features/printing_spec.rb
+++ b/spec/features/printing_spec.rb
@@ -4,6 +4,9 @@ RSpec.feature 'printing a PER', type: :feature do
   let(:reviewer) {
     create(:user, first_name: 'Nelle', last_name: 'Bailey')
   }
+  let(:bedford) {
+    create(:prison, name: 'HMP Bedford')
+  }
   let(:escort) {
     create(
       :escort,
@@ -16,7 +19,7 @@ RSpec.feature 'printing a PER', type: :feature do
   let(:move) {
     create(
       :move,
-      from: 'HMP Bedford',
+      from_establishment: bedford,
       to: 'Luton Crown Court',
       date: Date.civil(2099, 4, 22)
     )

--- a/spec/features/reuse_spec.rb
+++ b/spec/features/reuse_spec.rb
@@ -2,9 +2,14 @@ require 'feature_helper'
 
 RSpec.feature 'Reuse of previously entered PER data', type: :feature do
   scenario 'Reviewing the data of a reused PER' do
+    prison_number = 'A4321FD'
+    establishment_nomis_id = 'BDI'
+    valid_body = { establishment: { code: establishment_nomis_id } }.to_json
+    stub_nomis_api_request(:get, "/offenders/#{prison_number}/location", body: valid_body)
+    prison = create(:prison, name: 'HMP Bedford', nomis_id: establishment_nomis_id)
+
     login
 
-    prison_number = 'A4321FD'
     detainee = create(:detainee, prison_number: prison_number)
     create(:escort, :issued, prison_number: prison_number, detainee: detainee)
 

--- a/spec/forms/move_spec.rb
+++ b/spec/forms/move_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Forms::Move, type: :form do
 
   let(:params) {
     {
-      from: 'Bedford',
       to: 'Albany',
       date: '1/2/2017',
       not_for_release: 'yes',
@@ -14,13 +13,9 @@ RSpec.describe Forms::Move, type: :form do
     }.with_indifferent_access
   }
 
-  describe 'defaults' do
-    its(:from) { is_expected.to eq 'HMP Bedford' }
-  end
-
   describe '#validate' do
     describe 'nilifies empty strings' do
-      %w[from to].each do |attribute|
+      %w[to].each do |attribute|
         it { is_expected.to validate_strict_string(attribute) }
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -107,4 +107,32 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#is_admin?' do
+    context 'when is admin' do
+      subject { described_class.new(permissions: [{"organisation"=>User::ADMIN_ORGANISATION}])}
+      its(:is_admin?) { is_expected.to be_truthy }
+    end
+
+    context 'when is not admin' do
+      subject { described_class.new(permissions: []) }
+      its(:is_admin?) { is_expected.to be_falsey }
+    end
+  end
+
+  describe '#authorized_establishments' do
+    let!(:bedford) { create(:establishment, sso_id: 'bedford.prisons.noms.moj')}
+    let!(:pentonville) { create(:establishment, sso_id: 'pentonville.prisons.noms.moj')}
+    let(:permissions) {
+      [
+        { 'organisation' => 'bedford.prisons.noms.moj' },
+        { 'organisation' => 'pentonville.prisons.noms.moj' }
+      ]
+    }
+    subject { described_class.new(permissions: permissions)}
+
+    it 'returns the establishments' do
+      expect(subject.authorized_establishments).to eq [bedford, pentonville]
+    end
+  end
 end

--- a/spec/requests/new_move_request_spec.rb
+++ b/spec/requests/new_move_request_spec.rb
@@ -5,6 +5,13 @@ RSpec.describe 'New Move requests', type: :request do
   let(:detainee) { create(:detainee, prison_number: prison_number) }
   let(:escort) { create(:escort, prison_number: prison_number, detainee: detainee) }
 
+  before do
+    establishment_nomis_id = 'BDI'
+    valid_body = { establishment: { code: establishment_nomis_id } }.to_json
+    stub_nomis_api_request(:get, "/offenders/#{prison_number}/location", body: valid_body)
+    prison = create(:prison, name: 'HMP Bedford', nomis_id: establishment_nomis_id)
+  end
+
   describe "#new" do
     context "when the user is not authorized" do
       it "user is redirected to the login page" do

--- a/spec/services/authorize_user_to_access_escort_spec.rb
+++ b/spec/services/authorize_user_to_access_escort_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe AuthorizeUserToAccessEscort do
+  let(:establishment_sso_id) { 'bedford.prisons.noms.moj' }
+  let(:prison) { create(:prison, sso_id: establishment_sso_id) }
+  let(:move) { create(:move, from_establishment: prison) }
+  let(:escort) { create(:escort, move: move)}
+
+  subject(:service) { described_class.call(user, escort) }
+
+  context 'when the user is an admin' do
+    let(:user) { create(:user, :admin) }
+
+    specify { is_expected.to be_truthy }
+  end
+
+  context 'when the user is not an admin' do
+    context 'when the user tries to access an escort of the same prison' do
+      let(:establishment_sso_id) { 'bedford.prisons.noms.moj' }
+      let(:permissions) {
+        [
+          { 'organisation' => 'bedford.prisons.noms.moj' }
+        ]
+      }
+      let(:user) { create(:user, permissions: permissions) }
+
+      specify { is_expected.to be_truthy }
+    end
+
+    context 'when the user tries to access an escort of another prison' do
+      let(:establishment_sso_id) { 'bedford.prisons.noms.moj' }
+
+      let(:permissions) {
+        [
+          { 'organisation' => 'pentonville.prisons.noms.moj' }
+        ]
+      }
+      let(:user) { create(:user, permissions: permissions) }
+
+      specify { is_expected.to be_falsey }
+    end
+  end
+end


### PR DESCRIPTION
With this work we limit what users can see in the app. If user is admin, he can access all escorts created by all prisons. If user is not admin, he will see only the  escorts for the prison he/she belongs to.