### PR TITLE
Keep consistent flow when creating or initiating PERs

### DIFF
--- a/app/controllers/detainees_controller.rb
+++ b/app/controllers/detainees_controller.rb
@@ -60,7 +60,7 @@ class DetaineesController < ApplicationController
   end
 
   def set_extra_attrs
-    options = { pull: :none }
+    options = { pull: :all }
     options = params.slice(:pull) if params[:pull]
     status, remote_attrs = fetch_response_for(detainee.prison_number, options)
     flash_fetcher_errors(status.errors) if status.error?

--- a/app/controllers/escorts_controller.rb
+++ b/app/controllers/escorts_controller.rb
@@ -1,16 +1,14 @@
 class EscortsController < ApplicationController
   helper_method :escort
+  before_action :redirect_if_missing_data, only: :show
   before_action :authorize_user_to_access_prisoner!, only: :create
   before_action :authorize_user_to_access_escort!, except: :create
-  before_action :redirect_if_missing_data, only: :show
   before_action :redirect_if_not_cancellable, only: [:confirm_cancel, :cancel]
 
   def create
     escort = EscortCreator.call(escort_params)
-    if escort.move
-      redirect_to edit_escort_move_path(escort.id)
-    elsif escort.detainee
-      redirect_to new_escort_move_path(escort)
+    if escort.detainee
+      redirect_to edit_escort_detainee_path(escort.id)
     else
       redirect_to new_escort_detainee_path(escort.id, escort_params)
     end

--- a/spec/features/detainee_update_spec.rb
+++ b/spec/features/detainee_update_spec.rb
@@ -5,64 +5,71 @@ RSpec.feature 'Detainee updates', type: :feature do
   let(:detainee) { create(:detainee, prison_number: prison_number) }
   let(:escort) { create(:escort, prison_number: prison_number, detainee: detainee) }
 
-  context 'when detainee does not have an image set' do
-    scenario 'displays an image placeholder' do
-      login
-
-      visit edit_escort_detainee_path(escort)
-      new_detainee_page.assert_form_with_image_placeholder
+  context 'when pull option is not provided' do
+    before do
+      expect(Nomis::Api.instance).to receive(:get).with("/offenders/#{prison_number}")
+      expect(Nomis::Api.instance).to receive(:get).with("/offenders/#{prison_number}/image")
     end
 
-    context 'and pull option is provided' do
-      context 'and image is retrieved successfully' do
-        before do
-          stub_nomis_api_request(:get, "/offenders/#{prison_number}/image", body: { image: 'base-64-encoded-image' }.to_json)
-        end
+    context 'when detainee does not have an image set' do
+      scenario 'displays an image' do
+        login
 
-        scenario 'displays the retrieved image' do
-          login
-
-          visit edit_escort_detainee_path(escort, pull: :image)
-          new_detainee_page.assert_form_with_detainee_image
-        end
+        visit edit_escort_detainee_path(escort)
+        new_detainee_page.assert_form_with_image_placeholder
       end
+    end
 
-      context 'and image is cannot be retrieved' do
-        before do
-          stub_nomis_api_request(:get, "/offenders/#{prison_number}/image", status: 500)
-        end
+    context 'when detainee has an image set' do
+      let(:detainee) { create(:detainee, prison_number: prison_number, image: 'encoded-base64-image') }
 
-        scenario 'displays an image placeholder' do
-          login
+      scenario 'displays the detainee image' do
+        login
 
-          visit edit_escort_detainee_path(escort, pull: :image)
-          new_detainee_page.assert_form_with_image_placeholder
-        end
-      end
-
-      context 'and image is not found' do
-        before do
-          stub_nomis_api_request(:get, "/offenders/#{prison_number}/image", body: { image: nil }.to_json)
-        end
-
-        scenario 'displays an image placeholder' do
-          login
-
-          visit edit_escort_detainee_path(escort, pull: :image)
-          new_detainee_page.assert_form_with_image_placeholder
-        end
+        visit edit_escort_detainee_path(escort)
+        new_detainee_page.assert_form_with_detainee_image
       end
     end
   end
 
-  context 'when detainee has an image set' do
-    let(:detainee) { create(:detainee, prison_number: prison_number, image: 'encoded-base64-image') }
+  context 'when pull option is provided' do
+    context 'and image is retrieved successfully' do
+      before do
+        stub_nomis_api_request(:get, "/offenders/#{prison_number}/image", body: { image: 'base-64-encoded-image' }.to_json)
+      end
 
-    scenario 'displays the detainee image' do
-      login
+      scenario 'displays the retrieved image' do
+        login
 
-      visit edit_escort_detainee_path(escort)
-      new_detainee_page.assert_form_with_detainee_image
+        visit edit_escort_detainee_path(escort, pull: :image)
+        new_detainee_page.assert_form_with_detainee_image
+      end
+    end
+
+    context 'and image is cannot be retrieved' do
+      before do
+        stub_nomis_api_request(:get, "/offenders/#{prison_number}/image", status: 500)
+      end
+
+      scenario 'displays an image placeholder' do
+        login
+
+        visit edit_escort_detainee_path(escort, pull: :image)
+        new_detainee_page.assert_form_with_image_placeholder
+      end
+    end
+
+    context 'and image is not found' do
+      before do
+        stub_nomis_api_request(:get, "/offenders/#{prison_number}/image", body: { image: nil }.to_json)
+      end
+
+      scenario 'displays an image placeholder' do
+        login
+
+        visit edit_escort_detainee_path(escort, pull: :image)
+        new_detainee_page.assert_form_with_image_placeholder
+      end
     end
   end
 end

--- a/spec/features/reuse_spec.rb
+++ b/spec/features/reuse_spec.rb
@@ -6,6 +6,8 @@ RSpec.feature 'Reuse of previously entered PER data', type: :feature do
     establishment_nomis_id = 'BDI'
     valid_body = { establishment: { code: establishment_nomis_id } }.to_json
     stub_nomis_api_request(:get, "/offenders/#{prison_number}/location", body: valid_body)
+    stub_nomis_api_request(:get, "/offenders/#{prison_number}/image")
+    stub_nomis_api_request(:get, "/offenders/#{prison_number}")
     prison = create(:prison, name: 'HMP Bedford', nomis_id: establishment_nomis_id)
 
     login
@@ -15,6 +17,9 @@ RSpec.feature 'Reuse of previously entered PER data', type: :feature do
 
     dashboard.search(detainee.prison_number)
     dashboard.click_add_new_escort
+
+    detainee_details.complete_form(detainee)
+
     move_data = build(:move, date: 1.day.from_now)
     move_details.complete_form(move_data)
 

--- a/spec/requests/create_escort_request_spec.rb
+++ b/spec/requests/create_escort_request_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Create escort request', type: :request do
   context 'when there is a previous escort for given prison number' do
     let!(:existent_escort) { create(:escort, :completed, prison_number: prison_number) }
 
-    it 'creates a new escort record with the data from the existent escort and redirects to the new move form' do
+    it 'creates a new escort record with the data from the existent escort and redirects to the edit detainee form' do
       expect {
         post '/escorts', params: { escort: { prison_number: prison_number } }
       }.to change { Escort.where(prison_number: prison_number).count }.from(1).to(2)
@@ -49,7 +49,7 @@ RSpec.describe 'Create escort request', type: :request do
       expect(escort.detainee).to be_an_instance_of(Detainee)
       expect(escort.move).to be_nil
 
-      expect(response).to redirect_to(new_escort_move_path(escort))
+      expect(response).to redirect_to(edit_escort_detainee_path(escort))
     end
   end
 end

--- a/spec/requests/edit_detainee_request_spec.rb
+++ b/spec/requests/edit_detainee_request_spec.rb
@@ -48,8 +48,9 @@ RSpec.describe 'Edit detainee requests', type: :request do
 
     context 'when the detainee exists' do
       context 'and no pull option is provided' do
-        it 'does not retrieve image from remote API' do
-          expect(Nomis::Api.instance).not_to receive(:get).with("/offenders/#{prison_number}/image")
+        it 'retrieves details and image from remote API' do
+          expect(Nomis::Api.instance).to receive(:get).with("/offenders/#{prison_number}")
+          expect(Nomis::Api.instance).to receive(:get).with("/offenders/#{prison_number}/image")
           get "/escorts/#{escort.id}/detainee/edit"
         end
       end


### PR DESCRIPTION
[Trello](https://trello.com/c/A8I15glk/224-5-review-the-flow-on-initiating-pers)

This alteration would:

Guarantee that whoever initiates the PER views the personal data.

Enable the system to renew the personal data from NOMIS to 
ensures it is up-to-date.