### PR TITLE
Add KPI metrics

### DIFF
--- a/app/models/escort.rb
+++ b/app/models/escort.rb
@@ -32,6 +32,9 @@ class Escort < ApplicationRecord
   scope :in_last_days, lambda { |num_days|
     joins(:move).where('moves.date >= ? AND moves.date < ?', num_days.days.ago.to_date, Date.current)
   }
+  scope :in_month, lambda { |month, year|
+    joins(:move).where('extract(month from moves.date) = ? AND extract(year from moves.date) = ? ', month, year)
+  }
   scope :in_court, ->(court_name) { joins(:move).where('moves.to = ?', court_name) if court_name }
   scope :for_today, -> { joins(:move).where('moves.date = ?', Date.current) }
 

--- a/app/services/metrics/calculator.rb
+++ b/app/services/metrics/calculator.rb
@@ -26,6 +26,13 @@ module Metrics
       [{ hours_saved: hours }]
     end
 
+    def percentage_saved
+      minutes_saved_with_eper = total_reused_escorts * 23.minutes + total_unique_detainees_escorted * 2.5.minutes
+      minutes_to_complete_per_manually = total_issued_escorts * 28.minutes
+      percentage = minutes_saved_with_eper / minutes_to_complete_per_manually * 100
+      [{ percentage_saved: percentage }]
+    end
+
     private
 
     attr_reader :logger

--- a/app/services/metrics/calculator.rb
+++ b/app/services/metrics/calculator.rb
@@ -21,18 +21,14 @@ module Metrics
     end
 
     def hours_saved
-      hours = (total_reused_escorts * 23.minutes) / (60 * 60)
-
+      hours = (total_reused_escorts * 23.minutes) / 3600
+      hours += (total_unique_detainees_escorted * 2.5.minutes) / 3600
       [{ hours_saved: hours }]
     end
 
     private
 
     attr_reader :logger
-
-    def at
-      Escort.arel_table
-    end
 
     def total_initiated_escorts
       @tinitiated ||= Escort.unscoped.count
@@ -43,15 +39,15 @@ module Metrics
     end
 
     def total_issued_escorts
-      @tissued ||= Escort.where(at[:issued_at].not_eq(nil)).count
+      @tissued ||= Escort.issued.count
     end
 
     def total_unique_detainees_escorted
-      @tuniq_detainees ||= Escort.select('distinct(prison_number)').where(at[:issued_at].not_eq(nil)).count
+      @tuniq_detainees ||= Escort.issued.select('distinct(prison_number)').count
     end
 
     def total_escorts_auto_deleted
-      @tautodel ||= Escort.unscoped.where(at[:deleted_at].not_eq(nil)).count
+      @tautodel ||= Escort.unscoped.where.not(deleted_at: nil).count
     end
 
     def all_escorts_in_last_number_of_days(num_days = 30)

--- a/app/services/metrics/calculator.rb
+++ b/app/services/metrics/calculator.rb
@@ -1,5 +1,8 @@
 module Metrics
   class Calculator
+    MINUTES_SAVED_WITH_REUSE_OF_PER = 23.minutes
+    MINUTES_SAVED_FILLING_A_PER_FOR_THE_FIRST_TIME = 2.5.minutes
+
     def initialize(options = {})
       @logger = options.fetch(:logger, Rails.logger)
     end
@@ -21,16 +24,26 @@ module Metrics
     end
 
     def hours_saved
-      hours = (total_reused_escorts * 23.minutes) / 3600
-      hours += (total_unique_detainees_escorted * 2.5.minutes) / 3600
-      [{ hours_saved: hours }]
+      # 3600 is the number of seconds in an hour
+      hours = (total_reused_escorts * MINUTES_SAVED_WITH_REUSE_OF_PER) / 3600
+      hours += (total_unique_detainees_escorted * MINUTES_SAVED_FILLING_A_PER_FOR_THE_FIRST_TIME) / 3600
+      [{ hours_saved: hours.round }]
     end
 
     def percentage_saved
       minutes_saved_with_eper = total_reused_escorts * 23.minutes + total_unique_detainees_escorted * 2.5.minutes
       minutes_to_complete_per_manually = total_issued_escorts * 28.minutes
       percentage = minutes_saved_with_eper / minutes_to_complete_per_manually * 100
-      [{ percentage_saved: percentage }]
+      [{ percentage_saved: percentage.round }]
+    end
+
+    def hours_saved_last_3_months
+      last_three_months.map do |month_year|
+        {
+          month_name: Date::MONTHNAMES[month_year[:month]],
+          hours_saved: hours_saved_in_month(month_year[:month], month_year[:year]).round
+        }
+      end
     end
 
     private
@@ -78,6 +91,18 @@ module Metrics
 
     def not_issued_in_last_number_of_days(num_days)
       Escort.unscoped.active.select('count(*) AS total, moves.date').in_last_days(num_days).group(:date).to_sql
+    end
+
+    def hours_saved_in_month(month, year)
+      hours = (Escort.issued.in_month(month, year).count * 23.minutes) / 3600
+      hours + (Escort.issued.in_month(month, year).select('distinct(prison_number)').count * 2.5.minutes) / 3600
+    end
+
+    def last_three_months
+      2.downto(0).map do |i|
+        date = (Date.current - i.month)
+        { month: date.month, year: date.year }
+      end
     end
   end
 end

--- a/app/services/metrics/exporter.rb
+++ b/app/services/metrics/exporter.rb
@@ -9,14 +9,19 @@ module Metrics
     def call
       log_disabled && return unless api_key
       logger.info 'Sending updated metrics to Geckoboard dataset'
-      send_dataset(total_escorts_dataset, calculator.total_escorts, 'total escorts')
-      send_dataset(escorts_by_date_dataset, calculator.escorts_by_date, 'escorts by date')
-      send_dataset(hours_saved_dataset, calculator.hours_saved, 'hours saved')
+      send_datasets
     end
 
     private
 
     attr_reader :calculator, :api_config, :logger
+
+    def send_datasets
+      send_dataset(total_escorts, calculator.total_escorts, 'total escorts')
+      send_dataset(escorts_by_date, calculator.escorts_by_date, 'escorts by date')
+      send_dataset(hours_saved, calculator.hours_saved, 'hours saved')
+      send_dataset(percentage_saved, calculator.percentage_saved, 'percentage saved')
+    end
 
     def send_dataset(dataset, data, report_name)
       dataset.put(data).tap do |result|
@@ -39,7 +44,7 @@ module Metrics
       @client ||= Geckoboard.client(api_key)
     end
 
-    def total_escorts_dataset
+    def total_escorts
       @escorts_dataset ||= client.datasets.find_or_create("#{dataset_prefix}.escorts_report", fields: [
         Geckoboard::NumberField.new(:total_initiated_escorts, name: 'Total Initiated Escorts'),
         Geckoboard::NumberField.new(:total_issued_escorts, name: 'Total Issued Escorts'),
@@ -49,17 +54,23 @@ module Metrics
       ])
     end
 
-    def escorts_by_date_dataset
-      @escorts_by_date_dataset ||= client.datasets.find_or_create("#{dataset_prefix}.escorts_by_date_report", fields: [
+    def escorts_by_date
+      @escorts_by_date ||= client.datasets.find_or_create("#{dataset_prefix}.escorts_by_date_report", fields: [
         Geckoboard::NumberField.new(:total_issued, name: 'Total Issued Escorts'),
         Geckoboard::NumberField.new(:total_not_issued, name: 'Total Not Issued Escorts'),
         Geckoboard::DateField.new(:date, name: 'PER move date')
       ])
     end
 
-    def hours_saved_dataset
-      @time_saved_dataset ||= client.datasets.find_or_create("#{dataset_prefix}.hours_saved_report", fields: [
+    def hours_saved
+      @hours_saved ||= client.datasets.find_or_create("#{dataset_prefix}.hours_saved_report", fields: [
         Geckoboard::NumberField.new(:hours_saved, name: 'Hours saved')
+      ])
+    end
+
+    def percentage_saved
+      @percentage_saved ||= client.datasets.find_or_create("#{dataset_prefix}.percentage_saved_report", fields: [
+        Geckoboard::NumberField.new(:percentage_saved, name: 'Percentage saved through use of ePer')
       ])
     end
 

--- a/app/services/metrics/exporter.rb
+++ b/app/services/metrics/exporter.rb
@@ -21,6 +21,7 @@ module Metrics
       send_dataset(escorts_by_date, calculator.escorts_by_date, 'escorts by date')
       send_dataset(hours_saved, calculator.hours_saved, 'hours saved')
       send_dataset(percentage_saved, calculator.percentage_saved, 'percentage saved')
+      send_dataset(hours_saved_last_3_months, calculator.hours_saved_last_3_months, 'hours saved in last 3 months')
     end
 
     def send_dataset(dataset, data, report_name)
@@ -71,6 +72,13 @@ module Metrics
     def percentage_saved
       @percentage_saved ||= client.datasets.find_or_create("#{dataset_prefix}.percentage_saved_report", fields: [
         Geckoboard::NumberField.new(:percentage_saved, name: 'Percentage saved through use of ePer')
+      ])
+    end
+
+    def hours_saved_last_3_months
+      @last_3_months ||= client.datasets.find_or_create("#{dataset_prefix}.hours_saved_last_3_months_report", fields: [
+        Geckoboard::StringField.new(:month_name, name: 'Month'),
+        Geckoboard::NumberField.new(:hours_saved, name: 'Hours saved')
       ])
     end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/EcJCo3nJ/654-kpi-amend-total-savings-to-include-25-minutes-for-each-non-reuse-per)
[Trello](https://trello.com/c/IqApFRjK/653-kpi-age-saved-through-use-of-eper)
[Trello](https://trello.com/c/50AtsJRs/655-kpi-as-well-as-total-cumulative-savings-show-savings-for-each-of-the-last-3-calendar-months)