### PR TITLE
Change check on prisoner location

### DIFF
--- a/app/services/authorize_user_to_access_prisoner.rb
+++ b/app/services/authorize_user_to_access_prisoner.rb
@@ -20,6 +20,7 @@ class AuthorizeUserToAccessPrisoner
 
   def prisoner_location
     response = Detainees::LocationFetcher.new(prison_number).call
+    return false unless response.to_h[:code]
     Establishment.find_by(nomis_id: response.to_h[:code])
   end
 end

--- a/spec/services/authorize_user_to_access_prisoner_spec.rb
+++ b/spec/services/authorize_user_to_access_prisoner_spec.rb
@@ -11,16 +11,27 @@ RSpec.describe AuthorizeUserToAccessPrisoner do
     specify { is_expected.to be_truthy }
   end
 
-  context 'when the prisoner_location is nil' do
+  context 'when the prisoner_location is not present' do
     let(:user) { create(:user, permissions: []) }
     let(:location_service) { double(Detainees::LocationFetcher) }
 
-    before do
-      allow(Detainees::LocationFetcher).to receive(:new).with(prison_number).and_return(location_service)
-      allow(location_service).to receive(:call).and_return(nil)
+    context 'prisoner location is nil' do
+      before do
+        allow(Detainees::LocationFetcher).to receive(:new).with(prison_number).and_return(location_service)
+        allow(location_service).to receive(:call).and_return(nil)
+      end
+
+      specify { is_expected.to be_truthy }
     end
 
-    specify { is_expected.to be_truthy }
+    context 'prisoner location is empty hash' do
+      before do
+        allow(Detainees::LocationFetcher).to receive(:new).with(prison_number).and_return(location_service)
+        allow(location_service).to receive(:call).and_return({})
+      end
+
+      specify { is_expected.to be_truthy }
+    end
   end
 
   context 'when the user is not an admin' do


### PR DESCRIPTION
The reason to introduce this check is that when NOMIS API
is down, we have an empty hash and now that we have courts
which do not have a nomis_id field set, find_by returns
the first establishment that finds, which is a court.