### PR TITLE
Allow chunking of compare analysis

### DIFF
--- a/app/services/compare_auto_alerts/compare.rb
+++ b/app/services/compare_auto_alerts/compare.rb
@@ -1,10 +1,10 @@
 module CompareAutoAlerts
   class Compare
     RISK_CACHE = 'risk_cache.json'.freeze
-    PAUSE_BETWEEN_API_CALLS = 5
 
-    def initialize(limit, pause = PAUSE_BETWEEN_API_CALLS)
+    def initialize(limit: ENV.fetch('LIMIT', 200), offset: ENV.fetch('OFFSET', 0), pause: ENV.fetch('PAUSE', 3))
       @limit = limit
+      @offset = offset
       @pause = pause
     end
 
@@ -18,10 +18,10 @@ module CompareAutoAlerts
 
     private
 
-    attr_reader :limit, :pause
+    attr_reader :limit, :offset, :pause
 
     def escorts
-      @_escorts ||= Escort.issued.limit(limit)
+      @_escorts ||= Escort.issued.offset(offset).limit(limit).order(:id)
     end
 
     def compare_escorts(cached_risks)

--- a/lib/tasks/compare_auto_alerts.rake
+++ b/lib/tasks/compare_auto_alerts.rake
@@ -1,15 +1,11 @@
 # In Google sheets use this formula:
 #   =query(A1:G53,"select D, count(D) group by D pivot G")
 
-def limit
-  ENV.fetch('LIMIT', 200).to_i
-end
-
 namespace :analysis do
   desc 'Compare the last LIMIT of issued PER alerts with what would have ' \
        'been generated automatically. Output as CSV.'
   task compare_auto_alerts: :environment do
-    comparisons = CompareAutoAlerts::Compare.new(limit).call
+    comparisons = CompareAutoAlerts::Compare.new.call
     STDOUT.puts CompareAutoAlerts::CsvWriter.write(comparisons)
   end
 end

--- a/spec/lib/tasks/compare_spec.rb
+++ b/spec/lib/tasks/compare_spec.rb
@@ -1,9 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe CompareAutoAlerts::Compare do
-  subject { described_class.new(limit, 0).call }
+  subject { described_class.new(limit: 1, pause: 0).call }
 
-  let(:limit) { 1 }
   let!(:escort) do
     create(:escort, :issued, :with_move, :with_complete_risk_assessment)
   end


### PR DESCRIPTION
When running the report on production, the terminal session was timing out after about an hour.
This chunking lets us perform the analysis in batches over multiple sessions if required.