### PR TITLE
Show no date available when date fields are blank

### DIFF
--- a/app/presenters/print/assessment_question_presenter.rb
+++ b/app/presenters/print/assessment_question_presenter.rb
@@ -32,18 +32,19 @@ module Print
     def details
       return unless has_dependencies?
       dependency_questions.each_with_object([]) do |subquestion, output|
-        if subquestion.complex?
-          output << complex_detail_context(subquestion)
-        elsif public_send(subquestion.name).present?
-          output << detail_content(subquestion.name)
-        end
+        output << (subquestion.complex? ? complex_detail_context(subquestion) : detail_content(subquestion.name))
       end.join(' | ')
     end
 
     private
 
     def detail_content(attribute)
-      [detail_label(attribute), answer_value(public_send(attribute))].join('')
+      label = detail_label(attribute)
+      value = answer_value(public_send(attribute))
+
+      value = 'No date available' if label == 'Last incident: ' && value.blank?
+
+      [label, value].join('')
     end
 
     def complex_detail_context(question)
@@ -65,6 +66,7 @@ module Print
 
     def answer_value(value)
       default_value = value.respond_to?(:humanize) ? value.humanize : value
+      return nil if default_value.blank?
       t(value, scope: [:print, :section, :answers, section_name], default: default_value)
     end
 

--- a/app/presenters/summary/assessment_question_presenter.rb
+++ b/app/presenters/summary/assessment_question_presenter.rb
@@ -15,11 +15,7 @@ module Summary
     def details
       return unless has_dependencies?
       dependency_questions.each_with_object([]) do |dependency, output|
-        if dependency.complex?
-          output << complex_detail_context(dependency)
-        elsif public_send(dependency.name).present?
-          output << detail_content(dependency.name)
-        end
+        output << (dependency.complex? ? complex_detail_context(dependency) : detail_content(dependency.name))
       end.join(' | ')
     end
 
@@ -40,6 +36,8 @@ module Summary
       case value
       when nil
         error_content('Missing')
+      when ''
+        'No date available'
       when 'no', false
         'No'
       when 'yes', true
@@ -51,7 +49,12 @@ module Summary
     end
 
     def detail_content(attribute)
-      [detail_label(attribute), answer_value(public_send(attribute))].join('')
+      label = detail_label(attribute)
+      value = answer_value(public_send(attribute))
+
+      value = 'No date available' if label == 'Last incident: ' && value.blank?
+
+      [label, value].join('')
     end
 
     def complex_detail_context(question)

--- a/spec/presenters/print/assessment_question_presenter_spec.rb
+++ b/spec/presenters/print/assessment_question_presenter_spec.rb
@@ -157,14 +157,6 @@ RSpec.describe Print::AssessmentQuestionPresenter do
         expect(presenter.details).to eq('Foo | Bar')
       end
 
-      context 'when one of the details is empty' do
-        let(:answer_detail_1) { nil }
-
-        it 'returns a string only with the details that are present' do
-          expect(presenter.details).to eq('Bar')
-        end
-      end
-
       context 'when one of the details has a locale for its label in the print page' do
         let(:answer_dependant_questions) {
           [


### PR DESCRIPTION
On the risk summary and print pages we allow some date fields
to be blank and before we where showing an empty test. Now we 
show no date available instead.