### PR TITLE
Use real label tag for datepicker

### DIFF
--- a/app/assets/stylesheets/moving_people_safely/_home.scss
+++ b/app/assets/stylesheets/moving_people_safely/_home.scss
@@ -204,7 +204,7 @@
       cursor: pointer;
     }
   }
-  span.label {
+  label {
     font-family: "Helvetica Neue";
     font-size: 24px;
     font-weight: bold;

--- a/app/views/homepage/show.html.slim
+++ b/app/views/homepage/show.html.slim
@@ -7,7 +7,7 @@
 .search-header
   .date-picker
     = form_tag(escorts_search_path) do
-      span.label Scheduled moves
+      label for='escorts_due_on' Scheduled moves
       .date-picker-wrapper
         span.date-picker-field.input-group.date data-provide='datepicker'
           = text_field_tag 'escorts_due_on', @date_picker, class: 'no-script form-control date-field'


### PR DESCRIPTION
First thing Wave picked up was the datepicker field on the start page has no associated `<label>`, as it's a `<span>`. 