### PR TITLE
Make header signout link white to avoid low contrast

### DIFF
--- a/app/assets/stylesheets/moving_people_safely/_helper_classes.scss
+++ b/app/assets/stylesheets/moving_people_safely/_helper_classes.scss
@@ -39,6 +39,10 @@
   &:hover {
     cursor: pointer;
   }
+
+  .header-wrapper & {
+    color: $white;
+  }
 }
 
 // Javascript helper - makes it slightly easier to include non-JS specific styles


### PR DESCRIPTION
Sign out button uses class `styled-as-link`, which forces blue, and gives low contrast when used in the header.