### PR TITLE
Apply usual styling to datepicker radios

### DIFF
--- a/app/views/shared/_radio_date_picker.html.slim
+++ b/app/views/shared/_radio_date_picker.html.slim
@@ -1,9 +1,10 @@
 .no-script
   .form-group.date-radios
     fieldset.inline
-      = label_tag picker.today_label, 'Today', class: 'block-label' do
+      legend.visuallyhidden Datepicker shortcuts
+      .multiple-choice
         = radio_button_tag picker.attr, picker.today, picker.today?, class: 'radio-date-selector', disabled: true
-        == 'Today'
-      = label_tag picker.tomorrow_label, 'Tomorrow', class: 'block-label' do
+        = label_tag picker.today_label, 'Today', class: 'block-label'
+      .multiple-choice
         = radio_button_tag picker.attr, picker.tomorrow, picker.tomorrow? , class: 'radio-date-selector', disabled: true
-        == 'Tomorrow'
+        = label_tag picker.tomorrow_label, 'Tomorrow', class: 'block-label'


### PR DESCRIPTION
Applies the more commonplace "huge radio buttons" to the datepicker shortcuts.

Note for @cesidio and/or @doctorpod : the `==` values appear to be just duplicating the text passed to `label_tag`, and removing them produces identical HTML, so I deleted them. Am I missing something there?