### PR TITLE
Fix datepicker radio label alignment

### DIFF
--- a/app/assets/stylesheets/moving_people_safely/_home.scss
+++ b/app/assets/stylesheets/moving_people_safely/_home.scss
@@ -146,13 +146,12 @@
         position: relative;
         float: left;
         display: table-cell;
-        font-family: "Helvetica Neue";
         height: 45px;
         width: 100%;
         z-index: 2;
         font-size: 30px;
         font-weight: bold;
-        padding-top: 0px;
+        padding-top: 7px;
         vertical-align: middle;
         display: inline-block;
         margin-bottom: 0;
@@ -204,8 +203,7 @@
       cursor: pointer;
     }
   }
-  label {
-    font-family: "Helvetica Neue";
+  label.date-picker-label {
     font-size: 24px;
     font-weight: bold;
     margin-right: 10px;

--- a/app/views/homepage/show.html.slim
+++ b/app/views/homepage/show.html.slim
@@ -7,7 +7,7 @@
 .search-header
   .date-picker
     = form_tag(escorts_search_path) do
-      label for='escorts_due_on' Scheduled moves
+      label.date-picker-label for='escorts_due_on' Scheduled moves
       .date-picker-wrapper
         span.date-picker-field.input-group.date data-provide='datepicker'
           = text_field_tag 'escorts_due_on', @date_picker, class: 'no-script form-control date-field'


### PR DESCRIPTION
I broke the alignment of the datepicker shortcut labels when fixing the textbox label. This fixes that, and removes Helvetica Neue from the CSS.

![image](https://user-images.githubusercontent.com/988436/42514764-11be4264-8452-11e8-99b7-4d71822bece1.png)
