### PR TITLE
Override NTA font throughout with Arial... ugh

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -50,3 +50,4 @@
 @import "moving_people_safely/text";
 @import "moving_people_safely/court_dashboard";
 @import "moving_people_safely/global_header";
+@import "moving_people_safely/font_override";

--- a/app/assets/stylesheets/moving_people_safely/_font_override.scss
+++ b/app/assets/stylesheets/moving_people_safely/_font_override.scss
@@ -1,0 +1,89 @@
+html,
+body,
+button,
+input,
+table,
+td,
+th,
+main,
+#global-header .header-proposition #proposition-name,
+#global-header .header-proposition a.menu,
+#global-header .header-proposition #proposition-link a,
+#global-header .header-proposition #proposition-links a,
+#global-cookie-message p,
+#footer h2,
+#footer .footer-meta .footer-meta-inner ul,
+#footer .footer-meta .footer-meta-inner .open-government-licence p,
+#footer .footer-meta .copyright,
+.button-start,
+.button-get-started,
+#signed-in-box,
+.font-xxlarge,
+.font-xlarge,
+.font-large,
+.font-medium,
+.font-small,
+.font-xsmall,
+.bold-xxlarge,
+.bold-xlarge,
+.bold-large,
+.bold-medium,
+.bold-small,
+.bold-xsmall,
+.heading-xlarge,
+.heading-xlarge .heading-secondary,
+.heading-large,
+h1,
+.summary header h1,
+.heading-large .heading-secondary,
+h1 .heading-secondary,
+.summary header h1 .heading-secondary,
+.heading-medium,
+form h2,
+.search_block h2,
+.heading-secondary,
+.heading-small,
+.summary h3,
+.lede,
+.link-back,
+.form-label,
+.form-label-bold,
+.form-hint,
+.form-control,
+.error-message,
+.circle,
+table th,
+table td,
+table td.numeric,
+.table-font-xsmall th,
+.table-font-xsmall td,
+.breadcrumbs li,
+.phase-banner p,
+.phase-banner .phase-tag,
+.phase-banner-alpha p,
+.phase-banner-beta p,
+.phase-banner-alpha .phase-tag,
+.phase-banner-beta .phase-tag,
+.phase-tag,
+.summary header p,
+.alpha-banner p,
+.alpha-banner .phase-tag {
+  font-family: Arial, arial, sans-serif;
+}
+
+@media (min-width: 769px) {
+ #global-header .header-proposition #proposition-link a, #global-header .header-proposition #proposition-links a {
+   font-family: Arial, arial, sans-serif;
+ }
+}
+
+
+// Width adjustments because using Arial in the footer makes the license statement have a linebreak...
+@media (min-width: 641px) {
+  #footer .footer-meta .footer-meta-inner {
+    width: 77%;
+  }
+  #footer .footer-meta .copyright {
+    width: 23%;
+  }
+}


### PR DESCRIPTION
Because the service is [not on GOV.UK](https://www.gov.uk/service-manual/design/making-your-service-look-like-govuk#if-your-service-isnt-on-govuk) we need to change the font to Arial throughout.

😢 

Before
---
![image](https://user-images.githubusercontent.com/988436/42567700-7e91f952-8502-11e8-9198-b212796ec743.png)

After
---
![image](https://user-images.githubusercontent.com/988436/42567725-8fab50f8-8502-11e8-8637-3b0792da5728.png)
