### PR TITLE
Fix bug that causes JS errors on other pages than help

### DIFF
--- a/app/assets/javascripts/flowplayer-init.js.erb
+++ b/app/assets/javascripts/flowplayer-init.js.erb
@@ -19,7 +19,7 @@ $(function () {
   ];
 
   for (var id in videoIds) {
-    var $el = 'a#' + videoIds[id];
+    var $el = $('a#' + videoIds[id]);
     if($el.length) {
       $($el).empty();
 


### PR DESCRIPTION
Just a basic syntax typo, causes a JS error on any page other than `/help`.

My bad.