### PR TITLE
Trigger GOV.UK details.polyfill for IE

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,7 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require govuk/details.polyfill
 //= require bootstrap-datepicker/dist/js/bootstrap-datepicker.min
 //= require_tree .
 //= require stickyfill.min
@@ -19,3 +20,5 @@
 //= stub 'auto-complete-init'
 //= stub 'flowplayer-3.2.13.min'
 //= stub 'flowplayer-init'
+
+GOVUK.details.init();


### PR DESCRIPTION
[Trello](https://trello.com/c/EvN0hP1Z/345-05-make-details-polyfill-work-for-help-page)

The app wasn't including or triggering the `govuk/details.polyfill` module so the `<details>` elements were always expanded in browsers that don't support the element (IE, in other words).

IE8 before
---
![image](https://user-images.githubusercontent.com/988436/43785280-dcc4dd94-9a5d-11e8-882a-8b38848d2f61.png)

IE8 after
---
![image](https://user-images.githubusercontent.com/988436/43785320-eef66a64-9a5d-11e8-9c25-5e3e0b732ea9.png)
