### PR TITLE
CSS hackery to get the search button inline with the search field

### DIFF
--- a/app/assets/stylesheets/moving_people_safely/_forms.scss
+++ b/app/assets/stylesheets/moving_people_safely/_forms.scss
@@ -193,3 +193,18 @@ form {
     display: block;
   }
 }
+
+.search-wrapper {
+  .form-group {
+    margin-bottom: 0;
+    display: inline;
+
+    .form-control {
+      margin-right: 5px;
+    }
+
+    &:after {
+      display: inline;
+    }
+  }
+}

--- a/app/views/search/_form.html.slim
+++ b/app/views/search/_form.html.slim
@@ -1,8 +1,9 @@
 .form-wrapper
   = form_for @form, url: search_path, method: :post do |f|
     -# f.error_messages
-    - if current_user.police?
-      = f.text_field :pnc_number
-    - else
-      = f.text_field :prison_number
-    = f.submit class: 'button', value: 'Search'
+    .search-wrapper.form-group
+      - if current_user.police?
+        = f.text_field :pnc_number
+      - else
+        = f.text_field :prison_number
+      = f.submit class: 'button', value: 'Search'


### PR DESCRIPTION
[Trello](https://trello.com/c/X8FcK4ak/283-05-new-search-screen-search-button-should-be-inline-rather-than-below)

before
---
![image](https://user-images.githubusercontent.com/988436/43895736-3a6e5d6e-9bce-11e8-88a8-86503e2164eb.png)

after
---
![image](https://user-images.githubusercontent.com/988436/43895769-53a7af9c-9bce-11e8-9104-9aaea61c05c7.png)
