### PR TITLE
Make sticky js class generic and add it to help menu

### DIFF
--- a/app/assets/javascripts/stickyfill-init.js
+++ b/app/assets/javascripts/stickyfill-init.js
@@ -8,6 +8,6 @@ $(function () {
    */
 
   if (typeof Stickyfill !== 'undefined') {
-    Stickyfill.add($('.side-profile'));
+    Stickyfill.add($('.sticky'));
   }
 });

--- a/app/views/escorts/show.html.slim
+++ b/app/views/escorts/show.html.slim
@@ -25,5 +25,5 @@
 
   = render 'actions'
 
-.column-one-quarter.side-profile
+.column-one-quarter.side-profile.sticky
   = render 'shared/detainee_sidebar'

--- a/app/views/healthcare/edit.html.slim
+++ b/app/views/healthcare/edit.html.slim
@@ -10,5 +10,5 @@
   .healthcare
     = render 'shared/wizard_step_form', scope: 'healthcare', method: :put
 
-.column-one-quarter.side-profile
+.column-one-quarter.side-profile.sticky
   = render 'shared/detainee_sidebar'

--- a/app/views/healthcare/new.html.slim
+++ b/app/views/healthcare/new.html.slim
@@ -10,5 +10,5 @@
   .healthcare
     = render 'shared/wizard_step_form', scope: 'healthcare', method: :post
 
-.column-one-quarter.side-profile
+.column-one-quarter.side-profile.sticky
   = render 'shared/detainee_sidebar'

--- a/app/views/healthcare/show.html.slim
+++ b/app/views/healthcare/show.html.slim
@@ -18,5 +18,5 @@
 
     = render 'summary/call_to_action', workflow: assessment, confirm_path: confirm_escort_healthcare_path(escort)
 
-.column-one-quarter.side-profile
+.column-one-quarter.side-profile.sticky
   = render 'shared/detainee_sidebar'

--- a/app/views/homepage/help.html.slim
+++ b/app/views/homepage/help.html.slim
@@ -8,7 +8,7 @@
         | These short video guides show you how to complete different sections of the ePER.
 
   .grid-row data-module="highlight-active-section-heading"
-    .column-third.page_contents_list
+    .column-third.page_contents_list.sticky
       h2 Page contents:
 
       ul.page_contents_list__items

--- a/app/views/offences/show.html.slim
+++ b/app/views/offences/show.html.slim
@@ -20,5 +20,5 @@
     - else
       = render 'table'
 
-.column-one-quarter.side-profile
+.column-one-quarter.side-profile.sticky
   = render 'shared/detainee_sidebar'

--- a/app/views/risks/edit.html.slim
+++ b/app/views/risks/edit.html.slim
@@ -10,5 +10,5 @@
   .risk
     = render 'shared/wizard_step_form', scope: 'risks', method: :put
 
-.column-one-quarter.side-profile
+.column-one-quarter.side-profile.sticky
   = render 'shared/detainee_sidebar'

--- a/app/views/risks/new.html.slim
+++ b/app/views/risks/new.html.slim
@@ -10,5 +10,5 @@
   .risk
     = render 'shared/wizard_step_form', scope: 'risks', method: :post
 
-.column-one-quarter.side-profile
+.column-one-quarter.side-profile.sticky
   = render 'shared/detainee_sidebar'

--- a/app/views/risks/show.html.slim
+++ b/app/views/risks/show.html.slim
@@ -18,5 +18,5 @@
 
     = render 'summary/call_to_action', workflow: assessment, confirm_path: confirm_escort_risks_path(escort)
 
-.column-one-quarter.side-profile
+.column-one-quarter.side-profile.sticky
   = render 'shared/detainee_sidebar'


### PR DESCRIPTION
Does what it says on the tin - instead of applying the Stickyfill polyfill to just `.side-profile` it's best to use a generic class such as `.sticky` which can then be applied where needed, such as on the new improved help menu.

Of course, this is moot for IE8 users since the polyfill only works for IE9+, but there's nothing we can do about that. This helps out for all other versions of IE below Edge and any other browsers that may not support `position: sticky;`.