### PR TITLE
compare_auto_alerts: avoid writing to STDERR from within tests

### DIFF
--- a/app/services/compare_auto_alerts/compare.rb
+++ b/app/services/compare_auto_alerts/compare.rb
@@ -16,10 +16,10 @@ module CompareAutoAlerts
     RISK_CACHE = 'risk_cache.json'.freeze
     PAUSE_BETWEEN_API_CALLS = 3
 
-    def self.as_hash(ids, pause: PAUSE_BETWEEN_API_CALLS)
+    def self.as_hash(ids, pause: PAUSE_BETWEEN_API_CALLS, quiet: false)
       cached_risks = File.exist?(RISK_CACHE) ? JSON.parse(File.read(RISK_CACHE)) : {}
 
-      compare_escorts(ids, cached_risks, pause).tap do
+      compare_escorts(ids, cached_risks, pause, quiet: quiet).tap do
         File.open(RISK_CACHE, 'w') { |f| f.write(cached_risks.to_json) }
       end
     end
@@ -32,9 +32,9 @@ module CompareAutoAlerts
       Escort.find(ids)
     end
 
-    def self.compare_escorts(ids, cached_risks, pause)
+    def self.compare_escorts(ids, cached_risks, pause, quiet: false)
       escorts(ids).each_with_object({}).with_index do |(escort, comparisons), i|
-        report(escort, i + 1, ids.size)
+        report(escort, i + 1, ids.size) unless quiet
         cached_risks[escort.prison_number] ||= fetch_mapped_risks(escort)
 
         comparisons[escort.prison_number] = escort_details(

--- a/spec/services/compare_auto_alerts/compare_spec.rb
+++ b/spec/services/compare_auto_alerts/compare_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CompareAutoAlerts::Compare do
-  subject { described_class.as_hash([escort.id], pause: 0) }
+  subject { described_class.as_hash([escort.id], pause: 0, quiet: true) }
 
   let!(:escort) do
     create(:escort, :issued, :with_move, :with_complete_risk_assessment)


### PR DESCRIPTION
There are a few ways to solve this,
but to avoid changing the api,
I just added a new parameter `quiet: true`