### PR TITLE
omniauth: set logger to Rails.logger

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -16,6 +16,7 @@ def initialize_omniauth
     )
   end
   OmniAuth.config.on_failure = SessionsController.action(:new)
+  OmniAuth.config.logger = Rails.logger
 end
 
 initialize_omniauth unless ENV.fetch('SKIP_OPTIONAL_INITIALIZERS', false)


### PR DESCRIPTION
Will ensure omniauth errors get logged properly
also avoids omniauth making the spec output noisy