### PR TITLE
Fix shoulda-matchers deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+
 gem 'aws-sdk-s3'
 gem 'bootsnap', require: false
 gem 'cancancan'
@@ -65,7 +67,8 @@ group :test do
   gem 'rspec-its'
   gem 'rspec-rails'
   gem 'selenium-webdriver'
-  gem 'shoulda-matchers'
+  # TODO: update to 4.x once issue resolved https://github.com/thoughtbot/shoulda-matchers/issues/1146
+  gem 'shoulda-matchers', github: 'thoughtbot/shoulda-matchers', ref: '43f4252'
   gem 'simplecov', require: false
   gem 'site_prism'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,14 @@ GIT
   specs:
     custom_error_message (1.2.1)
 
+GIT
+  remote: https://github.com/thoughtbot/shoulda-matchers
+  revision: 43f4252561e8c21fbc3a4f187099717200868fa8
+  ref: 43f4252
+  specs:
+    shoulda-matchers (3.1.2)
+      activesupport (>= 4.2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -359,8 +367,6 @@ GEM
       rubyzip (~> 1.2)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
-    shoulda-matchers (3.1.2)
-      activesupport (>= 4.0.0)
     simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -479,7 +485,7 @@ DEPENDENCIES
   sass-rails
   selenium-webdriver
   sentry-raven
-  shoulda-matchers
+  shoulda-matchers!
   simplecov
   site_prism
   slim-rails
@@ -494,4 +500,4 @@ DEPENDENCIES
   zendesk_api
 
 BUNDLED WITH
-   1.16.1
+   1.16.5

--- a/spec/forms/detainee_spec.rb
+++ b/spec/forms/detainee_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Forms::Detainee, type: :form do
 
     it do
       is_expected.to validate_inclusion_of(:gender).
-        in_array(%w[ male female ])
+        in_array(Forms::Detainee::GENDERS)
     end
 
     context 'date_of_birth' do


### PR DESCRIPTION
Temporarily switching to a specific git sha
but should be able to switch to 4.0 once this issue is resolved:

https://github.com/thoughtbot/shoulda-matchers/issues/1146