### PR TITLE
Security: upgrade loofah

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
       activesupport (>= 4.0)
       logstash-event (~> 1.2.0)
       request_store
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)


### PR DESCRIPTION
upgrade to loofah 2.2.3

<img width="944" alt="screenshot 2018-11-02 17 24 54" src="https://user-images.githubusercontent.com/8659/47930681-89b38500-dec4-11e8-952a-e42882fd694e.png">

CVE-2018-16468 More information
moderate severity
Vulnerable versions: < 2.2.3
Patched version: 2.2.3
In the Loofah gem for Ruby, through version 2.2.2, unsanitized JavaScript may occur in sanitized output when a crafted SVG element is republished. Users are advised to upgrade to version 2.2.3.

See flavorjones/loofah#154 for more details.