### PR TITLE
Add filename to PDF download

### DIFF
--- a/app/controllers/escorts/print_controller.rb
+++ b/app/controllers/escorts/print_controller.rb
@@ -10,7 +10,16 @@ module Escorts
       error_redirect && return unless printable_escort?
       issue_escort_unless_issued!
       data = open(escort.document_path)
-      send_data data.read, type: 'application/pdf', disposition: 'inline'
+
+      filename = escort.document_file_name
+
+      # handle old files that didn't have .pdf extension
+      filename << '.pdf' unless filename.end_with?('.pdf')
+
+      send_data data.read,
+        type: 'application/pdf',
+        disposition: 'inline',
+        filename: filename
     end
 
     private

--- a/app/form_builders/mps_form_builder.rb
+++ b/app/form_builders/mps_form_builder.rb
@@ -334,8 +334,7 @@ class MpsFormBuilder < ActionView::Helpers::FormBuilder
 
     localised_message = location_text(label_text(attribute)).presence || object.class.human_attribute_name(attribute)
     localised_message = nested_error_message(nested_model, nested_index, localised_message) if nested_index
-    message.sub! default_label(attribute), localised_message
-    message
+    message.sub default_label(attribute), localised_message
   end
 
   def nested_error_message(nested_model, nested_index, message)

--- a/app/services/escort_issuer.rb
+++ b/app/services/escort_issuer.rb
@@ -38,7 +38,7 @@ class EscortIssuer
 
   def generate_per_document
     pdf = PdfGenerator.new(escort).call
-    file = Tempfile.new('per')
+    file = Tempfile.new(['per', '.pdf'])
     file.write(pdf.force_encoding('utf-8'))
     file
   end

--- a/app/services/escorts/generate_documents_for_issued_pers.rb
+++ b/app/services/escorts/generate_documents_for_issued_pers.rb
@@ -40,7 +40,7 @@ module Escorts
 
       def generate_per_document
         pdf = PdfGenerator.new(escort).call
-        file = Tempfile.new('per')
+        file = Tempfile.new(['per', '.pdf'])
         file.write(pdf.force_encoding('utf-8'))
         file
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -796,15 +796,6 @@ en:
           attributes:
             not_for_release:
               inclusion: question must be answered
-  errors:
-    summary:
-      title: Please fix the errors on this page to continue
-    messages:
-      minimum_collection_size: At least one item needs to be provided
-    attributes:
-      base:
-        minimum_current_offence: 'Enter at least one current offence'
-        minimum_one_option: 'Enter at least one option (%{options})'
   alerts:
     detainee_already_exists: "Detainee already exists. You've been redirected to the next relevant form"
     detainee:
@@ -842,6 +833,10 @@ en:
     create:
       cannot_sign_in: You cannot be signed in
   errors: &errors
+    attributes:
+      base:
+        minimum_current_offence: 'Enter at least one current offence'
+        minimum_one_option: 'Enter at least one option (%{options})'
     summary:
       title: Please fix the errors on this page to continue
     messages:
@@ -850,6 +845,7 @@ en:
       date_not_valid: "^Enter a valid %{attribute}"
       date_is_in_the_past: "must not be in the past"
       date_is_in_the_future: "must not be in the future"
+      minimum_collection_size: At least one item needs to be provided
     models:
       forms/police_station_selector:
         attributes:

--- a/spec/features/printing_prison_per_spec.rb
+++ b/spec/features/printing_prison_per_spec.rb
@@ -85,6 +85,12 @@ RSpec.feature 'printing a prison PER', type: :feature do
       visit escort_path(escort)
       escort_page.click_print
 
+      escort.reload
+      expected_filename = escort.document_file_name
+      expect(expected_filename).to match(/^per[0-9a-z-]+\.pdf$/i)
+      expect(page.response_headers['Content-Type']).to eq 'application/pdf'
+      expect(page.response_headers['Content-Disposition']).to eq "inline; filename=#{expected_filename.inspect}"
+
       expect(page.body).
         to validate_as_pdf_that_contains_text('prison/pdf-text-all-no-answers.txt')
     end

--- a/spec/services/escort_issuer_spec.rb
+++ b/spec/services/escort_issuer_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe EscortIssuer do
         expect { issuer.call }
           .to change { escort.reload.document.present? }
           .from(false).to(true)
+
+        expect(escort.document_file_name).to end_with '.pdf'
       end
 
       it 'marks the escort as issued' do


### PR DESCRIPTION
Ticket: https://trello.com/c/o5On82Gx/520-at-medway-and-at-salfords-custodies-the-pdf-does-not-appear-in-a-separate-tab

Keep it inline,
but let the browser know what filename to use.

For a modern browser this means:

* when it's open in a tab, if you click to save, it uses the filename
* you can right click "save as", and it will use the filename

Hopefully this will fix the bug seen in Police.

BONUS:

fixed a couple of bugs I found on the way:

* avoid an error when trying to create a per with no offences
* fix some missing translations
* ensure uploaded pdfs have the .pdf extension