### PR TITLE
gems: always use github: 'user/repo' in the gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'aws-sdk-s3'
 gem 'bootsnap', require: false
 gem 'cancancan'
 gem 'connection_pool'
-gem 'custom_error_message', git: 'https://github.com/thethanghn/custom-err-msg.git'
+gem 'custom_error_message', github: 'thethanghn/custom-err-msg'
 gem 'deep_cloneable'
 gem 'excon'
 gem 'faraday'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/thethanghn/custom-err-msg.git
+  remote: https://github.com/thethanghn/custom-err-msg
   revision: b913309360995472507ea444c6f1a80315b99d28
   specs:
     custom_error_message (1.2.1)


### PR DESCRIPTION
more succinct than specifying the full git path each time