### PR TITLE
When printing a PER use a more useful pdf name

### DIFF
--- a/app/controllers/escorts/print_controller.rb
+++ b/app/controllers/escorts/print_controller.rb
@@ -11,18 +11,22 @@ module Escorts
       issue_escort_unless_issued!
       data = open(escort.document_path)
 
-      filename = escort.document_file_name
-
-      # handle old files that didn't have .pdf extension
-      filename << '.pdf' unless filename.end_with?('.pdf')
-
       send_data data.read,
         type: 'application/pdf',
         disposition: 'inline',
-        filename: filename
+        filename: pdf_filename(escort)
     end
 
     private
+
+    def pdf_filename(escort)
+      [
+        'per',
+        escort.detainee_surname&.dasherize,
+        escort.detainee_forenames&.dasherize,
+        escort.issued_at&.to_date&.to_s(:db)
+      ].join('-') + '.pdf'
+    end
 
     def escort
       @escort ||= Escort.find(params[:escort_id])

--- a/spec/features/printing_male_prison_per_spec.rb
+++ b/spec/features/printing_male_prison_per_spec.rb
@@ -85,9 +85,7 @@ RSpec.feature 'printing a prison PER', type: :feature do
       visit escort_path(escort)
       escort_page.click_print
 
-      escort.reload
-      expected_filename = escort.document_file_name
-      expect(expected_filename).to match(/^per[0-9a-z-]+\.pdf$/i)
+      expected_filename = "per-McTest-Testy-#{Date.current.to_s(:db)}.pdf"
       expect(page.response_headers['Content-Type']).to eq 'application/pdf'
       expect(page.response_headers['Content-Disposition']).to eq "inline; filename=#{expected_filename.inspect}"
 


### PR DESCRIPTION
Ticket: https://trello.com/c/o5On82Gx/520-at-medway-and-at-salfords-custodies-the-pdf-does-not-appear-in-a-separate-tab

eg:
A PER for a person named "Testy McTest"
When the PER has been issued on 14th November 2018 (today)

Has the filename:

```
per-McTest-Testy-2018-11-14.pdf
```

This is not necessarily unique,
but good enough