### PR TITLE
Fix detainee ages at 47

### DIFF
--- a/spec/features/printing_female_prison_per_spec.rb
+++ b/spec/features/printing_female_prison_per_spec.rb
@@ -66,6 +66,10 @@ RSpec.feature 'printing a prison PER', type: :feature do
     )
   }
 
+  before do
+    allow(AgeCalculator).to receive(:age).and_return(47)
+  end
+
   context 'when a PER has detailed answers' do
     let(:offences) {
       [

--- a/spec/features/printing_male_prison_per_spec.rb
+++ b/spec/features/printing_male_prison_per_spec.rb
@@ -63,6 +63,10 @@ RSpec.feature 'printing a prison PER', type: :feature do
     )
   }
 
+  before do
+    allow(AgeCalculator).to receive(:age).and_return(47)
+  end
+
   context 'when a PER is completed with all answers as no' do
     let(:risk) {
       create(:risk, :confirmed,

--- a/spec/features/printing_police_per_spec.rb
+++ b/spec/features/printing_police_per_spec.rb
@@ -69,6 +69,10 @@ RSpec.feature 'printing a police PER', type: :feature do
     )
   }
 
+  before do
+    allow(AgeCalculator).to receive(:age).and_return(47)
+  end
+  
   context 'when a PER is completed with all answers as no' do
     let(:risk) {
       create(:risk, :confirmed,


### PR DESCRIPTION
Some feature specs were failing because the detainee DoBs where fixed and the current date has now caused their ages to advance.