### PR TITLE
Fix variable naming in handling of non-json Nomis response

### DIFF
--- a/lib/nomis/client.rb
+++ b/lib/nomis/client.rb
@@ -27,6 +27,15 @@ module Nomis
       request(:get, route, params, idempotent: true)
     end
 
+    def http_error_body(original_body)
+      # API errors should be returned as JSON, but there are many scenarios
+      # where this may not be the case.
+      JSON.parse(original_body)
+    rescue JSON::ParserError
+      # Present non-JSON bodies truncated (e.g. this could be HTML)
+      "(invalid-JSON) #{original_body[0, 80]}"
+    end
+
     private
 
     attr_reader :host, :client_id, :client_secret, :connection
@@ -82,15 +91,6 @@ module Nomis
     def auth_header
       token = Nomis::OauthService.valid_token
       "Bearer #{token.access_token}"
-    end
-
-    def http_error_body(original_body)
-      # API errors should be returned as JSON, but there are many scenarios
-      # where this may not be the case.
-      JSON.parse(original_body)
-    rescue JSON::ParserError
-      # Present non-JSON bodies truncated (e.g. this could be HTML)
-      "(invalid-JSON) #{body[0, 80]}"
     end
   end
 end

--- a/spec/nomis/client_spec.rb
+++ b/spec/nomis/client_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Nomis::Client do
+  subject(:client) { described_class.new(host, client_id, client_secret, options) }
+
+  let(:host) { 'http://example.com' }
+  let(:client_id) { 'foo' }
+  let(:client_secret) { 'bar' }
+  let(:options) { {} }
+
+  describe '#http_error_body' do
+    context 'when the response body is parseable JSON' do
+      let(:body) { '{}' }
+
+      it 'returns the error body' do
+        expect(client.http_error_body(body)).to eq({})
+      end
+    end
+
+    context 'when the response body is unparseable' do
+      let(:body) { '<h1></h1>' }
+
+      it 'returns a subset of the full html to the caller' do
+        expect(client.http_error_body(body)).to eq('(invalid-JSON) <h1></h1>')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What?

Nomis is returning something that isn't JSON when trying to populate detainee information.

Unfortunately we've made a typo that means we can't see the response that is getting returned by the client. This PR fixes that typo and adds some specs to avoid regressions.

### Why?

So we can get more information back from the Nomis client.

### A/C

Existing tests still pass.
Jason is happy.